### PR TITLE
Preserve order when replacing NULL in IssuerSignedItemBytes CBOR.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         material_version = "1.0.0"
         anko_version = '0.10.8'
         qrcode_version = '2.1.0'
-        cbor_version = '0.8'
+        cbor_version = '0.9'
         constraint_layout_version = '2.1.0-beta01'
         bouncy_castle_bcprov_version = '1.65'
         bouncy_castle_bcpkix_version = '1.56'

--- a/identity/src/main/java/com/android/identity/Utility.java
+++ b/identity/src/main/java/com/android/identity/Utility.java
@@ -90,7 +90,7 @@ public class Utility {
      *       "digestID" : uint,                           ; Digest ID for issuer data auth
      *       "random" : bstr,                             ; Random value for issuer data auth
      *       "elementIdentifier" : DataElementIdentifier, ; Data element identifier
-     *       "elementValue" : DataElementValue            ; Data element value
+     *       "elementValue" : NULL                        ; Placeholder for Data element value
      *     }
      * </pre>
      *


### PR DESCRIPTION
The helper Util.issuerSignedItemBytesSetValue() takes a the bytes of
|IssuerSignedItemBytes| and replaces the value (usually NULL) for the
"elementValue" key with a given value. It then returns the bytes of
|IssuerSignedItemBytes|.

Because |IssuerSignedItemBytes| originates from the issuer (as part of
|staticAuthData|, see Utility.encodeStaticAuthData() for the CDDL) and
|IssuerSignedItem| is a map, it's not well-defined what the encoding
is. The issuer could choose whatever order they want.

This change fixes Util.issuerSignedItemBytesSetValue() so the order is
preserved. This is done by upgrade cbor-java to 0.9 and using the
non-canonical encoder. Also add unit test for this.

Test: All unit tests pass.
Test: Manually tested holder and verifier.
