### PR TITLE
Util.java: Specify a Locale for SimpleDateFormat instances.

### DIFF
--- a/identity/src/main/java/com/android/identity/Util.java
+++ b/identity/src/main/java/com/android/identity/Util.java
@@ -246,9 +246,9 @@ class Util {
      */
     static @NonNull
     DataItem cborBuildDateTime(@NonNull Calendar calendar) {
-        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.US);
         if (calendar.isSet(Calendar.MILLISECOND) && calendar.get(Calendar.MILLISECOND) != 0) {
-            df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+            df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US);
         }
         df.setTimeZone(calendar.getTimeZone());
         Date val = calendar.getTime();
@@ -268,7 +268,7 @@ class Util {
      */
     static @NonNull
     DataItem cborBuildDateTimeFor18013_5(@NonNull Calendar calendar) {
-        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.US);
         df.setTimeZone(TimeZone.GMT_ZONE);
         Date val = calendar.getTime();
         String dateString = df.format(val);


### PR DESCRIPTION
Some but not all SimpleDateFormat invocations in Util.java specified a Locale; these particular formats probably don't contain Locale-dependent fields, but this is more definitely correct if we specify a Locale.

I chose Locale.US for consistency with existing use in the file. Locale.ROOT would probably also have worked.

This will fix compilation in setups that enforce Locale-aware code.

I've checked that the code still compiles in Android Studio.