### PR TITLE
Map Android platform ResultData.Status codes to our own.

### DIFF
--- a/identity/src/androidTest/java/com/android/identity/HardwareIdentityCredentialTest.java
+++ b/identity/src/androidTest/java/com/android/identity/HardwareIdentityCredentialTest.java
@@ -1,0 +1,27 @@
+package com.android.identity;
+import static org.junit.Assert.assertEquals;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@SmallTest
+@RunWith(AndroidJUnit4.class)
+public class HardwareIdentityCredentialTest {
+
+  @Test
+  public void convertFromAndroidResultDataStatus() {
+    checkConvertStatus(ResultData.STATUS_NOT_IN_REQUEST_MESSAGE, android.security.identity.ResultData.STATUS_NOT_IN_REQUEST_MESSAGE);
+    checkConvertStatus(ResultData.STATUS_NOT_REQUESTED, android.security.identity.ResultData.STATUS_NOT_REQUESTED);
+    checkConvertStatus(ResultData.STATUS_NO_ACCESS_CONTROL_PROFILES, android.security.identity.ResultData.STATUS_NO_ACCESS_CONTROL_PROFILES);
+    checkConvertStatus(ResultData.STATUS_NO_SUCH_ENTRY, android.security.identity.ResultData.STATUS_NO_SUCH_ENTRY);
+    checkConvertStatus(ResultData.STATUS_OK, android.security.identity.ResultData.STATUS_OK);
+    checkConvertStatus(ResultData.STATUS_READER_AUTHENTICATION_FAILED, android.security.identity.ResultData.STATUS_READER_AUTHENTICATION_FAILED);
+    checkConvertStatus(ResultData.STATUS_USER_AUTHENTICATION_FAILED, android.security.identity.ResultData.STATUS_USER_AUTHENTICATION_FAILED);
+  }
+
+  private static void checkConvertStatus(@ResultData.Status int expected, int androidStatus) {
+    assertEquals(expected, HardwareIdentityCredential.convertFromAndroidStatus(androidStatus));
+  }
+}

--- a/identity/src/main/java/com/android/identity/HardwareIdentityCredential.java
+++ b/identity/src/main/java/com/android/identity/HardwareIdentityCredential.java
@@ -16,6 +16,7 @@
 
 package com.android.identity;
 
+import android.annotation.SuppressLint;
 import android.icu.util.Calendar;
 import android.os.Build;
 
@@ -23,6 +24,7 @@ import androidx.annotation.DoNotInline;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import androidx.annotation.VisibleForTesting;
 import androidx.biometric.BiometricPrompt;
 
 import java.nio.ByteBuffer;
@@ -239,7 +241,8 @@ class HardwareIdentityCredential extends IdentityCredential {
 
         for (String namespaceName : rd.getNamespaces()) {
             for (String entryName : rd.getEntryNames(namespaceName)) {
-                int status = rd.getStatus(namespaceName, entryName);
+                @ResultData.Status int status = convertFromAndroidStatus(
+                    rd.getStatus(namespaceName, entryName));
                 if (status == ResultData.STATUS_OK) {
                     byte[] value = rd.getEntry(namespaceName, entryName);
                     builder.addEntry(namespaceName, entryName, value);
@@ -250,6 +253,19 @@ class HardwareIdentityCredential extends IdentityCredential {
         }
 
         return builder.build();
+    }
+
+    /**
+     * Returns the {@link ResultData} status code corresponding to
+     * the given one from {@link android.security.identity.ResultData}.
+     */
+    @SuppressLint("WrongConstant")
+    @VisibleForTesting
+    static @ResultData.Status
+    int convertFromAndroidStatus(int status) {
+        // Because our status codes are defined consistently with the ones in the Android platform,
+        // no conversion is needed.
+        return status;
     }
 
     @Override


### PR DESCRIPTION
This silences a lint warning which can break compilation in some environments.

Since our status codes are defined consistently (same values) with those in the Android platform, no actual conversion is necessary. To check that this assumption holds, I've added a test case covering the constant values currently defined in the Android platform.

Tested: Unit tests still pass.