### PR TITLE
Add docker-compose files

### DIFF
--- a/mdl-ref-server/Dockerfile
+++ b/mdl-ref-server/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.8.13-alpine
+ADD . /code
+WORKDIR /code
+RUN apk add --update \
+  cargo \
+  gcc \
+  lcms2-dev \
+  libffi-dev \
+  musl-dev \
+  openssl-dev \
+  py-cffi \
+  rust
+RUN pip install -r requirements.txt
+CMD ["python3", "mdl-ref-server.py", "--reset-with-testdata"]

--- a/mdl-ref-server/README.md
+++ b/mdl-ref-server/README.md
@@ -15,6 +15,9 @@ to a separate repo at some point. This is all currently a work in progress, use
 at your own risk etc. etc.
 
 # How to run the reference server
+It is possible to run the server directly and via Docker
+
+## Directly
 
 Simply run `./mdl-ref-server.py` to get started. The first time you run, you
 also want to pass the `--reset-with-testdata` option to create some test
@@ -23,6 +26,14 @@ support will be added later).
 
 The server comes with an admin interface at the `/admin` URI and the
 provisioning protocol itself is rooted under the `/mdlServer` URI.
+
+## Via Docker
+
+Make sure that Docker and Docker-compose have been installed. Simply open a terminal window in this folder and run:
+
+```
+docker-compose up
+```
 
 # Data Model
 

--- a/mdl-ref-server/docker-compose.yml
+++ b/mdl-ref-server/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  mdl-ref-server:
+    build: .
+    ports:
+      - "18013:18013"


### PR DESCRIPTION
I was struggling a bit with setting up the test server because some of the Python dependency versions between projects. So I have added a Docker file for easier deployment. Just run `docker-compose up` to run the test server. No dependency mess-ups.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR