### PR TITLE
Limit log TAGs to 23chars.

### DIFF
--- a/identity/src/main/java/com/android/identity/DataTransportBleCentralClientMode.java
+++ b/identity/src/main/java/com/android/identity/DataTransportBleCentralClientMode.java
@@ -44,7 +44,7 @@ import java.util.UUID;
  * central client mode.
  */
 class DataTransportBleCentralClientMode extends DataTransportBle {
-    private static final String TAG = "DataTransportBleCentralClientMode";
+    private static final String TAG = "DataTransportBleCCM"; // limit to <= 23 chars
     final Util.Logger mLog;
 
     UUID mCharacteristicStateUuid = UUID.fromString("00000005-a123-48ce-896b-4c76973373e6");

--- a/identity/src/main/java/com/android/identity/DataTransportBlePeripheralServerMode.java
+++ b/identity/src/main/java/com/android/identity/DataTransportBlePeripheralServerMode.java
@@ -44,7 +44,7 @@ import java.util.UUID;
  * peripheral server mode.
  */
 class DataTransportBlePeripheralServerMode extends DataTransportBle {
-    private static final String TAG = "DataTransportBlePeripheralServerMode";
+    private static final String TAG = "DataTransportBlePSM"; // limit to <= 23 chars
     final Util.Logger mLog;
 
     UUID mCharacteristicStateUuid = UUID.fromString("00000001-a123-48ce-896b-4c76973373e6");

--- a/identity/src/main/java/com/android/identity/SoftwarePresentationSession.java
+++ b/identity/src/main/java/com/android/identity/SoftwarePresentationSession.java
@@ -51,7 +51,7 @@ import javax.crypto.SecretKey;
 
 class SoftwarePresentationSession extends PresentationSession {
 
-    private static final String TAG = "SoftwarePresentationSession";
+    private static final String TAG = "SoftwarePresentSession"; // limit to <= 23 chars
     private @IdentityCredentialStore.Ciphersuite
     final int mCipherSuite;
     private final Context mContext;


### PR DESCRIPTION
Lint rules at compile time enforce log TAGs <= 23chars in some environments. I suspect that the Lint rule's existence means that log tags are truncated or similar to 23chars anyway, so having longer TAGs gives the wrong impression that the whole TAG is used.

This commit shortens the overlong TAGs to <= 23chars by removing some suffixes from camelCased words; this way, copy&pasting the TAG into IntelliJ will still find the right class.
