### PR TITLE
static import StandardCharsets.UTF_8.

### DIFF
--- a/identity/src/androidTest/java/com/android/identity/DeviceResponseGeneratorTest.java
+++ b/identity/src/androidTest/java/com/android/identity/DeviceResponseGeneratorTest.java
@@ -16,6 +16,7 @@
 
 package com.android.identity;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assume.assumeTrue;
 
 import android.content.Context;
@@ -100,7 +101,7 @@ public class DeviceResponseGeneratorTest {
         store.deleteCredentialByName("test");
         WritableIdentityCredential wc = store.createCredential("test", MDL_DOCTYPE);
         Collection<X509Certificate> certificateChain =
-                wc.getCredentialKeyCertificateChain("myChallenge".getBytes(StandardCharsets.UTF_8));
+                wc.getCredentialKeyCertificateChain("myChallenge".getBytes(UTF_8));
 
         // Profile 0 (no authentication)
         AccessControlProfile noAuthProfile =

--- a/identity/src/main/java/com/android/identity/DataTransport.java
+++ b/identity/src/main/java/com/android/identity/DataTransport.java
@@ -16,6 +16,8 @@
 
 package com.android.identity;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import android.content.Context;
 import android.nfc.NdefRecord;
 import android.os.Build;
@@ -126,8 +128,8 @@ abstract class DataTransport {
         //
         if (record.getTnf() == 0x02
                 && Arrays.equals(record.getType(),
-                "application/vnd.bluetooth.le.oob".getBytes(StandardCharsets.UTF_8))
-                && Arrays.equals(record.getId(), "0".getBytes(StandardCharsets.UTF_8))) {
+                "application/vnd.bluetooth.le.oob".getBytes(UTF_8))
+                && Arrays.equals(record.getId(), "0".getBytes(UTF_8))) {
             return DataTransportBle.parseNdefRecord(record);
         }
 
@@ -135,8 +137,8 @@ abstract class DataTransport {
         //
         if (record.getTnf() == 0x02
                 && Arrays.equals(record.getType(),
-                "application/vnd.wfa.nan".getBytes(StandardCharsets.UTF_8))
-                && Arrays.equals(record.getId(), "W".getBytes(StandardCharsets.UTF_8))) {
+                "application/vnd.wfa.nan".getBytes(UTF_8))
+                && Arrays.equals(record.getId(), "W".getBytes(UTF_8))) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 return DataTransportWifiAware.parseNdefRecord(record);
             } else {
@@ -150,8 +152,8 @@ abstract class DataTransport {
         //
         if (record.getTnf() == 0x02
                 && Arrays.equals(record.getType(),
-                "iso.org:18013:nfc".getBytes(StandardCharsets.UTF_8))
-                && Arrays.equals(record.getId(), "nfc".getBytes(StandardCharsets.UTF_8))) {
+                "iso.org:18013:nfc".getBytes(UTF_8))
+                && Arrays.equals(record.getId(), "nfc".getBytes(UTF_8))) {
             return DataTransportNfc.parseNdefRecord(record);
         }
 
@@ -159,7 +161,7 @@ abstract class DataTransport {
         //
         if (record.getTnf() == 0x02
                 && Arrays.equals(record.getType(),
-                "application/vnd.android.ic.dmr".getBytes(StandardCharsets.UTF_8))) {
+                "application/vnd.android.ic.dmr".getBytes(UTF_8))) {
             byte[] deviceRetrievalMethod = record.getPayload();
             return parseDeviceRetrievalMethod(deviceRetrievalMethod);
         }

--- a/identity/src/main/java/com/android/identity/DataTransportBle.java
+++ b/identity/src/main/java/com/android/identity/DataTransportBle.java
@@ -16,6 +16,8 @@
 
 package com.android.identity;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import android.content.Context;
 import android.nfc.NdefRecord;
 import android.util.Log;
@@ -237,8 +239,8 @@ abstract class DataTransportBle extends DataTransport {
         Log.d(TAG, "Encoding UUID " + serviceUuid + " in NDEF");
 
         NdefRecord record = new NdefRecord((short) 0x02, // type = RFC 2046 (MIME)
-                "application/vnd.bluetooth.le.oob".getBytes(StandardCharsets.UTF_8),
-                "0".getBytes(StandardCharsets.UTF_8),
+                "application/vnd.bluetooth.le.oob".getBytes(UTF_8),
+                "0".getBytes(UTF_8),
                 oobData);
 
         // From 7.1 Alternative Carrier Record
@@ -250,7 +252,7 @@ abstract class DataTransportBle extends DataTransport {
         baos.write(0x01); // Number of auxiliary references
         // Each auxiliary reference consists of a single byte for the length and then as
         // many bytes for the reference itself.
-        byte[] auxReference = "mdoc".getBytes(StandardCharsets.UTF_8);
+        byte[] auxReference = "mdoc".getBytes(UTF_8);
         baos.write(auxReference.length);
         baos.write(auxReference, 0, auxReference.length);
         byte[] acRecordPayload = baos.toByteArray();
@@ -358,8 +360,8 @@ abstract class DataTransportBle extends DataTransport {
             Log.d(TAG, "Encoding UUID " + uuid + " in NDEF");
 
             NdefRecord record = new NdefRecord((short) 0x02, // type = RFC 2046 (MIME)
-                    "application/vnd.bluetooth.le.oob".getBytes(StandardCharsets.UTF_8),
-                    "0".getBytes(StandardCharsets.UTF_8),
+                    "application/vnd.bluetooth.le.oob".getBytes(UTF_8),
+                    "0".getBytes(UTF_8),
                     oobData);
 
             // From 7.1 Alternative Carrier Record
@@ -371,7 +373,7 @@ abstract class DataTransportBle extends DataTransport {
             baos.write(0x01); // Number of auxiliary references
             // Each auxiliary reference consists of a single byte for the length and then as
             // many bytes for the reference itself.
-            byte[] auxReference = "mdoc".getBytes(StandardCharsets.UTF_8);
+            byte[] auxReference = "mdoc".getBytes(UTF_8);
             baos.write(auxReference.length);
             baos.write(auxReference, 0, auxReference.length);
             byte[] acRecordPayload = baos.toByteArray();

--- a/identity/src/main/java/com/android/identity/DataTransportNfc.java
+++ b/identity/src/main/java/com/android/identity/DataTransportNfc.java
@@ -16,6 +16,8 @@
 
 package com.android.identity;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import android.content.Context;
 import android.nfc.NdefRecord;
 import android.nfc.tech.IsoDep;
@@ -939,7 +941,7 @@ class DataTransportNfc extends DataTransport {
 
         @Override
         Pair<NdefRecord, byte[]> createNdefRecords(List<DataRetrievalAddress> listeningAddresses) {
-            byte[] carrierDataReference = "nfc".getBytes(StandardCharsets.UTF_8);
+            byte[] carrierDataReference = "nfc".getBytes(UTF_8);
 
             // This is defined by ISO 18013-5 8.2.2.2 Alternative Carrier Record for device
             // retrieval using NFC.
@@ -951,7 +953,7 @@ class DataTransportNfc extends DataTransport {
             byte[] oobData = baos.toByteArray();
 
             NdefRecord record = new NdefRecord((short) 0x02, // type = RFC 2046 (MIME)
-                    "iso.org:18013:nfc".getBytes(StandardCharsets.UTF_8),
+                    "iso.org:18013:nfc".getBytes(UTF_8),
                     carrierDataReference,
                     oobData);
 
@@ -966,7 +968,7 @@ class DataTransportNfc extends DataTransport {
                 throw new IllegalStateException(e);
             }
             baos.write(0x01); // Number of auxiliary references
-            byte[] auxReference = "mdoc".getBytes(StandardCharsets.UTF_8);
+            byte[] auxReference = "mdoc".getBytes(UTF_8);
             baos.write(auxReference.length);  // Length of auxiliary reference 0 data
             baos.write(auxReference, 0, auxReference.length);
             byte[] acRecordPayload = baos.toByteArray();

--- a/identity/src/main/java/com/android/identity/DataTransportTcp.java
+++ b/identity/src/main/java/com/android/identity/DataTransportTcp.java
@@ -16,6 +16,8 @@
 
 package com.android.identity;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import android.content.Context;
 import android.net.wifi.WifiManager;
 import android.nfc.NdefRecord;
@@ -314,7 +316,7 @@ class DataTransportTcp extends DataTransport {
     @Override
     void sendMessage(@NonNull byte[] data) {
         ByteBuffer bb = ByteBuffer.allocate(8 + data.length);
-        bb.put("GmDL".getBytes(StandardCharsets.UTF_8));
+        bb.put("GmDL".getBytes(UTF_8))
         bb.putInt(data.length);
         bb.put(data);
         mWriterQueue.add(bb.array());
@@ -348,9 +350,9 @@ class DataTransportTcp extends DataTransport {
         @Override
         Pair<NdefRecord, byte[]> createNdefRecords(List<DataRetrievalAddress> listeningAddresses) {
             byte[] reference = String.format("%d", DEVICE_RETRIEVAL_METHOD_TYPE)
-                    .getBytes(StandardCharsets.UTF_8);
+                    .getBytes(UTF_8);
             NdefRecord record = new NdefRecord((short) 0x02, // type = RFC 2046 (MIME)
-                    "application/vnd.android.ic.dmr".getBytes(StandardCharsets.UTF_8),
+                    "application/vnd.android.ic.dmr".getBytes(UTF_8),
                     reference,
                     buildDeviceRetrievalMethod(host, port));
 
@@ -365,7 +367,7 @@ class DataTransportTcp extends DataTransport {
                 throw new IllegalStateException(e);
             }
             baos.write(0x01); // Number of auxiliary references
-            byte[] auxReference = "mdoc".getBytes(StandardCharsets.UTF_8);
+            byte[] auxReference = "mdoc".getBytes(UTF_8);
             baos.write(auxReference.length);
             baos.write(auxReference, 0, auxReference.length);
             byte[] acRecordPayload = baos.toByteArray();

--- a/identity/src/main/java/com/android/identity/DataTransportWifiAware.java
+++ b/identity/src/main/java/com/android/identity/DataTransportWifiAware.java
@@ -16,6 +16,8 @@
 
 package com.android.identity;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.net.ConnectivityManager;
@@ -130,7 +132,7 @@ class DataTransportWifiAware extends DataTransport {
                 // passphrase
                 byte[] encodedPassphrase = new byte[len - 1];
                 payload.get(encodedPassphrase, 0, len - 1);
-                passphraseInfoPassphrase = new String(encodedPassphrase, StandardCharsets.UTF_8);
+                passphraseInfoPassphrase = new String(encodedPassphrase, UTF_8);
             } else if (type == 0x04 && len > 1) {
                 bandInfoSupportedBands = new byte[len - 1];
                 payload.get(bandInfoSupportedBands, 0, len - 1);
@@ -186,13 +188,13 @@ class DataTransportWifiAware extends DataTransport {
         mEncodedEDeviceKeyBytes = encodedEDeviceKeyBytes;
 
         byte[] ikm = mEncodedEDeviceKeyBytes;
-        byte[] info = "NANService".getBytes(StandardCharsets.UTF_8);
+        byte[] info = "NANService".getBytes(UTF_8);
         byte[] salt = new byte[]{};
         mServiceName = Util.base16(Util.computeHkdf("HmacSha256", ikm, salt, info, 16));
         Log.d(TAG, String.format("Using service name '%s'", mServiceName));
 
         ikm = mEncodedEDeviceKeyBytes;
-        info = "NANPassphrase".getBytes(StandardCharsets.UTF_8);
+        info = "NANPassphrase".getBytes(UTF_8);
         salt = new byte[]{};
         mDerivedPassphrase = Base64.encodeToString(
                 Util.computeHkdf("HmacSha256", ikm, salt, info, 32),
@@ -333,7 +335,7 @@ class DataTransportWifiAware extends DataTransport {
 
         session.sendMessage(peerHandle,
                 0,
-                "helloSub".getBytes(StandardCharsets.UTF_8));
+                "helloSub".getBytes(UTF_8));
 
     }
 
@@ -418,7 +420,7 @@ class DataTransportWifiAware extends DataTransport {
 
                                 mSubscribeDiscoverySession.sendMessage(peerHandle,
                                         0,
-                                        "helloPub".getBytes(StandardCharsets.UTF_8));
+                                        "helloPub".getBytes(UTF_8));
                             }
 
                             @Override
@@ -495,7 +497,7 @@ class DataTransportWifiAware extends DataTransport {
 
         //session.sendMessage(peerHandle,
         //        0,
-        //        "helloSub".getBytes(StandardCharsets.UTF_8));
+        //        "helloSub".getBytes(UTF_8));
 
     }
 
@@ -621,13 +623,13 @@ class DataTransportWifiAware extends DataTransport {
                     os.write(("HTTP/1.1 200 OK\r\n"
                             + "Content-Length: " + messageToSend.length + "\r\n"
                             + "Content-Type: application/CBOR\r\n"
-                            + "\r\n").getBytes(StandardCharsets.UTF_8));
+                            + "\r\n").getBytes(UTF_8));
                 } else {
                     os.write(("POST /mdoc HTTP/1.1\r\n"
                             + "Host: " + mInitiatorIPv6HostString + "\r\n"
                             + "Content-Length: " + messageToSend.length + "\r\n"
                             + "Content-Type: application/CBOR\r\n"
-                            + "\r\n").getBytes(StandardCharsets.UTF_8));
+                            + "\r\n").getBytes(UTF_8));
                 }
                 os.write(messageToSend);
                 os.flush();
@@ -783,7 +785,7 @@ class DataTransportWifiAware extends DataTransport {
                 // So we have to make up a passphrase.
                 //
                 byte[] encodedPassphrase = passphraseInfoPassphrase.getBytes(
-                        StandardCharsets.UTF_8);
+                        UTF_8);
                 baos.write(1 + encodedPassphrase.length);
                 baos.write(0x03); // Data Type 0x03 - Pass-phrase Info
                 baos.write(encodedPassphrase);
@@ -809,8 +811,8 @@ class DataTransportWifiAware extends DataTransport {
             byte[] oobData = baos.toByteArray();
 
             NdefRecord record = new NdefRecord((short) 0x02, // type = RFC 2046 (MIME)
-                    "application/vnd.wfa.nan".getBytes(StandardCharsets.UTF_8),
-                    "W".getBytes(StandardCharsets.UTF_8),
+                    "application/vnd.wfa.nan".getBytes(UTF_8),
+                    "W".getBytes(UTF_8),
                     oobData);
 
             // From 7.1 Alternative Carrier Record
@@ -820,7 +822,7 @@ class DataTransportWifiAware extends DataTransport {
             baos.write(0x01); // Length of carrier data reference ("0")
             baos.write('W');  // Carrier data reference
             baos.write(0x01); // Number of auxiliary references
-            byte[] auxReference = "mdoc".getBytes(StandardCharsets.UTF_8);
+            byte[] auxReference = "mdoc".getBytes(UTF_8);
             baos.write(auxReference.length);
             baos.write(auxReference, 0, auxReference.length);
             byte[] acRecordPayload = baos.toByteArray();

--- a/identity/src/main/java/com/android/identity/SessionEncryptionDevice.java
+++ b/identity/src/main/java/com/android/identity/SessionEncryptionDevice.java
@@ -16,6 +16,8 @@
 
 package com.android.identity;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import android.util.Pair;
 
 import androidx.annotation.NonNull;
@@ -263,12 +265,12 @@ final class SessionEncryptionDevice {
                     Util.cborBuildTaggedByteString(mEncodedSessionTranscript));
             byte[] salt = MessageDigest.getInstance("SHA-256").digest(sessionTranscriptBytes);
 
-            byte[] info = "SKDevice".getBytes(StandardCharsets.UTF_8);
+            byte[] info = "SKDevice".getBytes(UTF_8);
             byte[] derivedKey = Util.computeHkdf("HmacSha256", sharedSecret, salt, info, 32);
 
             mSKDevice = new SecretKeySpec(derivedKey, "AES");
 
-            info = "SKReader".getBytes(StandardCharsets.UTF_8);
+            info = "SKReader".getBytes(UTF_8);
             derivedKey = Util.computeHkdf("HmacSha256", sharedSecret, salt, info, 32);
             mSKReader = new SecretKeySpec(derivedKey, "AES");
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {

--- a/identity/src/main/java/com/android/identity/SessionEncryptionReader.java
+++ b/identity/src/main/java/com/android/identity/SessionEncryptionReader.java
@@ -16,6 +16,8 @@
 
 package com.android.identity;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import android.util.Pair;
 
 import androidx.annotation.NonNull;
@@ -172,12 +174,12 @@ final class SessionEncryptionReader {
                     Util.cborBuildTaggedByteString(mEncodedSessionTranscript));
             byte[] salt = MessageDigest.getInstance("SHA-256").digest(sessionTranscriptBytes);
 
-            byte[] info = "SKDevice".getBytes(StandardCharsets.UTF_8);
+            byte[] info = "SKDevice".getBytes(UTF_8);
             byte[] derivedKey = Util.computeHkdf("HmacSha256", sharedSecret, salt, info, 32);
 
             mSKDevice = new SecretKeySpec(derivedKey, "AES");
 
-            info = "SKReader".getBytes(StandardCharsets.UTF_8);
+            info = "SKReader".getBytes(UTF_8);
             derivedKey = Util.computeHkdf("HmacSha256", sharedSecret, salt, info, 32);
             mSKReader = new SecretKeySpec(derivedKey, "AES");
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {

--- a/identity/src/main/java/com/android/identity/Utility.java
+++ b/identity/src/main/java/com/android/identity/Utility.java
@@ -16,6 +16,8 @@
 
 package com.android.identity;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import android.icu.util.Calendar;
 import android.util.Log;
 import android.util.Pair;
@@ -253,7 +255,7 @@ public class Utility {
             int numAuthKeys,
             int maxUsesPerKey) throws IdentityCredentialException {
 
-        final byte[] provisioningChallenge = "dummyChallenge".getBytes(StandardCharsets.UTF_8);
+        final byte[] provisioningChallenge = "dummyChallenge".getBytes(UTF_8);
 
         store.deleteCredentialByName(credentialName);
         WritableIdentityCredential wc = store.createCredential(credentialName, docType);

--- a/identity/src/main/java/com/android/identity/VerificationHelper.java
+++ b/identity/src/main/java/com/android/identity/VerificationHelper.java
@@ -16,6 +16,8 @@
 
 package com.android.identity;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import android.app.Activity;
 import android.content.Context;
 import android.net.Uri;
@@ -270,7 +272,7 @@ public class VerificationHelper {
             // version 1.5 (encoded as 0x15 below).
             //
             if (r.getTnf() == NdefRecord.TNF_WELL_KNOWN
-                    && Arrays.equals(r.getType(), "Hs".getBytes(StandardCharsets.UTF_8))) {
+                    && Arrays.equals(r.getType(), "Hs".getBytes(UTF_8))) {
                 byte[] payload = r.getPayload();
                 if (payload.length >= 1 && payload[0] == 0x15) {
                     // The NDEF payload of the Handover Select Record SHALL consist of a single
@@ -294,8 +296,8 @@ public class VerificationHelper {
             //
             if (r.getTnf() == NdefRecord.TNF_EXTERNAL_TYPE
                     && Arrays.equals(r.getType(),
-                    "iso.org:18013:deviceengagement".getBytes(StandardCharsets.UTF_8))
-                    && Arrays.equals(r.getId(), "mdoc".getBytes(StandardCharsets.UTF_8))) {
+                    "iso.org:18013:deviceengagement".getBytes(UTF_8))
+                    && Arrays.equals(r.getId(), "mdoc".getBytes(UTF_8))) {
                 encodedDeviceEngagement = r.getPayload();
                 if (mLog.isEngagementEnabled()) {
                     mLog.engagement(


### PR DESCRIPTION
This is shorter but just as clear, thus more readable, and addresses a family of lint warnings.

This commit is a pure refactoring. I've added static imports via IntelliJ's corresponding refactoring feature.