### PR TITLE
Refactor occurrences of new Thread(new Runnable() { ...

### DIFF
--- a/identity/src/main/java/com/android/identity/DataTransportNfc.java
+++ b/identity/src/main/java/com/android/identity/DataTransportNfc.java
@@ -214,7 +214,7 @@ class DataTransportNfc extends DataTransport {
     }
 
     void setupListenerWritingThread() {
-        Thread transceiverThread = new Thread(new Runnable() {
+        Thread transceiverThread = new Thread() {
             @Override
             public void run() {
                 while (mListenerStillActive) {
@@ -266,7 +266,7 @@ class DataTransportNfc extends DataTransport {
                     sendNextChunk(false);
                 }
             }
-        });
+        };
         transceiverThread.start();
     }
 
@@ -656,7 +656,7 @@ class DataTransportNfc extends DataTransport {
         Log.d(TAG, "maxTransceiveLength: " + maxTransceiveLength);
         Log.d(TAG, "isExtendedLengthApduSupported: " + mIsoDep.isExtendedLengthApduSupported());
 
-        Thread transceiverThread = new Thread(new Runnable() {
+        Thread transceiverThread = new Thread() {
             @Override
             public void run() {
                 try {
@@ -885,7 +885,7 @@ class DataTransportNfc extends DataTransport {
                 Log.d(TAG, "Ending transceiver thread");
                 mIsoDep = null;
             }
-        });
+        };
         transceiverThread.start();
 
     }

--- a/identity/src/main/java/com/android/identity/DataTransportTcp.java
+++ b/identity/src/main/java/com/android/identity/DataTransportTcp.java
@@ -134,7 +134,7 @@ class DataTransportTcp extends DataTransport {
             return;
         }
         int port = mServerSocket.getLocalPort();
-        Thread socketServerThread = new Thread(new Runnable() {
+        Thread socketServerThread = new Thread() {
             @Override
             public void run() {
                 try {
@@ -159,7 +159,7 @@ class DataTransportTcp extends DataTransport {
                     reportError(e);
                 }
             }
-        });
+        };
         socketServerThread.start();
 
         mListeningAddress = new DataRetrievalAddressTcp(address, port);
@@ -225,7 +225,7 @@ class DataTransportTcp extends DataTransport {
         int port = address.port;
 
         mSocket = new Socket();
-        Thread socketReaderThread = new Thread(new Runnable() {
+        Thread socketReaderThread = new Thread() {
             @Override
             public void run() {
                 SocketAddress endpoint = new InetSocketAddress(ipAddress, port);
@@ -247,12 +247,12 @@ class DataTransportTcp extends DataTransport {
                     reportConnectionDisconnected();
                 }
             }
-        });
+        };
         socketReaderThread.start();
     }
 
     void setupWritingThread() {
-        mSocketWriterThread = new Thread(new Runnable() {
+        mSocketWriterThread = new Thread() {
             @Override
             public void run() {
                 while (mSocket.isConnected()) {
@@ -280,7 +280,7 @@ class DataTransportTcp extends DataTransport {
                     }
                 }
             }
-        });
+        };
         mSocketWriterThread.start();
     }
 

--- a/identity/src/main/java/com/android/identity/DataTransportWifiAware.java
+++ b/identity/src/main/java/com/android/identity/DataTransportWifiAware.java
@@ -338,7 +338,7 @@ class DataTransportWifiAware extends DataTransport {
     }
 
     private void listenOnServerSocket() {
-        Thread socketServerThread = new Thread(new Runnable() {
+        Thread socketServerThread = new Thread() {
             @Override
             public void run() {
                 try {
@@ -346,12 +346,12 @@ class DataTransportWifiAware extends DataTransport {
                     //
                     mListenerSocket = mListenerServerSocket.accept();
 
-                    Thread writingThread = new Thread(new Runnable() {
+                    Thread writingThread = new Thread() {
                         @Override
                         public void run() {
                             writeToSocket(true, mListenerSocket);
                         }
-                    });
+                    };
                     writingThread.start();
 
                     reportListeningPeerConnected();
@@ -362,7 +362,7 @@ class DataTransportWifiAware extends DataTransport {
                     reportError(e);
                 }
             }
-        });
+        };
         socketServerThread.start();
     }
 
@@ -524,20 +524,20 @@ class DataTransportWifiAware extends DataTransport {
         try {
             mInitiatorSocket = network.getSocketFactory().createSocket(peerIpv6, peerPort);
 
-            Thread writingThread = new Thread(new Runnable() {
+            Thread writingThread = new Thread() {
                 @Override
                 public void run() {
                     writeToSocket(false, mInitiatorSocket);
                 }
-            });
+            };
             writingThread.start();
 
-            Thread listenerThread = new Thread(new Runnable() {
+            Thread listenerThread = new Thread() {
                 @Override
                 public void run() {
                     readFromSocket(false, mInitiatorSocket);
                 }
-            });
+            };
             listenerThread.start();
             reportConnectionResult(null);
         } catch (IOException e) {


### PR DESCRIPTION
Instead of constructing an instance of an anonymous subclass of Runnable, constructing an anonymous subclass of Thread and overriding its run() method has the same effect, is more concise, and saves one Object. I'm not aware of any advantage of using the other variant. Therefore this commit refactors such occurrences.
