### PR TITLE
CredentialData: Fix misnamed variable confusing time units.

### DIFF
--- a/identity/src/main/java/com/android/identity/AccessControlProfile.java
+++ b/identity/src/main/java/com/android/identity/AccessControlProfile.java
@@ -28,7 +28,7 @@ public class AccessControlProfile {
     @NonNull AccessControlProfileId mAccessControlProfileId = new AccessControlProfileId(0);
     @Nullable X509Certificate mReaderCertificate = null;
     boolean mUserAuthenticationRequired = true;
-    long mUserAuthenticationTimeout = 0;
+    long mUserAuthenticationTimeoutMillis = 0;
 
     AccessControlProfile() {
     }
@@ -38,8 +38,11 @@ public class AccessControlProfile {
         return mAccessControlProfileId;
     }
 
+    /**
+     * Returns the authentication timeout, in milliseconds.
+     */
     long getUserAuthenticationTimeout() {
-        return mUserAuthenticationTimeout;
+        return mUserAuthenticationTimeoutMillis;
     }
 
     boolean isUserAuthenticationRequired() {
@@ -109,7 +112,7 @@ public class AccessControlProfile {
          * @return The builder.
          */
         public @NonNull Builder setUserAuthenticationTimeout(long userAuthenticationTimeoutMillis) {
-            mProfile.mUserAuthenticationTimeout = userAuthenticationTimeoutMillis;
+            mProfile.mUserAuthenticationTimeoutMillis = userAuthenticationTimeoutMillis;
             return this;
         }
 

--- a/identity/src/main/java/com/android/identity/CredentialData.java
+++ b/identity/src/main/java/com/android/identity/CredentialData.java
@@ -387,14 +387,14 @@ class CredentialData {
         data.mAcpTimeoutKeyAliases = new HashMap<>();
         for (AccessControlProfile profile : personalizationData.getAccessControlProfiles()) {
             boolean isAuthRequired = profile.isUserAuthenticationRequired();
-            long timeoutSeconds = profile.getUserAuthenticationTimeout();
+            long timeoutMillis = profile.getUserAuthenticationTimeout();
             if (isAuthRequired) {
                 // Always make sure the per-reader-session key exists since this is what we're
                 // going to be handing out a Cipher for when returning a CryptoObject at
                 // presentation time.
                 ensurePerReaderSessionKey(credentialName, data);
 
-                ensureAcpTimoutKeyForProfile(credentialName, data, profile, timeoutSeconds);
+                ensureAcpTimoutKeyForProfile(credentialName, data, profile, timeoutMillis);
             }
         }
 


### PR DESCRIPTION
Before this CL, CredentialData.createCredentialData() called ensureAcpTimoutKeyForProfile(..., timeoutSeconds) but that method expects a timeout in milliseconds.

Upon further inspection, timeoutSeconds came from profile.getUserAuthenticationTimeout(); that method did not document its time unit, but the corresponding Builder method is clear about it being milliseconds. Therefore it appears that the logic is correct but the name 'timeoutSeconds' was wrong.

This commit renames the misnamed variable and adds documentation to AccessControlProfile.getUserAuthenticationTimeout() noting that the returned time value is in milliseconds.

This commit is a pure refactoring with no behavior change.
