### PR TITLE
Avoid default Locale for String.format("%d", ...).

### DIFF
--- a/identity/src/main/java/com/android/identity/CredentialData.java
+++ b/identity/src/main/java/com/android/identity/CredentialData.java
@@ -26,6 +26,7 @@ import android.util.Pair;
 
 import androidx.annotation.NonNull;
 
+import java.util.Locale;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.cert.CertIOException;
@@ -1159,7 +1160,8 @@ class CredentialData {
                 try {
                     // Calculate name to use and be careful to avoid collisions when
                     // re-certifying an already populated slot.
-                    String aliasForAuthKey = mCredentialKeyAlias + String.format("_auth_%d", n);
+                    String aliasForAuthKey = mCredentialKeyAlias + String.format(Locale.US,
+                            "_auth_%d", n);
                     if (aliasForAuthKey.equals(data.mAlias)) {
                         aliasForAuthKey = aliasForAuthKey + "_";
                     }

--- a/identity/src/main/java/com/android/identity/DataTransportBle.java
+++ b/identity/src/main/java/com/android/identity/DataTransportBle.java
@@ -33,6 +33,7 @@ import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 import co.nstant.in.cbor.CborBuilder;
@@ -95,7 +96,7 @@ abstract class DataTransportBle extends DataTransport {
             Log.d(TAG, "hasR: " + payload.hasRemaining() + " rem: " + payload.remaining());
             int len = payload.get();
             int type = payload.get();
-            Log.d(TAG, String.format("type %d len %d", type, len));
+            Log.d(TAG, String.format(Locale.US, "type %d len %d", type, len));
             if (type == 0x1c && len == 2) {
                 gotLeRole = true;
                 int value = payload.get();

--- a/identity/src/main/java/com/android/identity/DataTransportTcp.java
+++ b/identity/src/main/java/com/android/identity/DataTransportTcp.java
@@ -41,6 +41,7 @@ import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
@@ -349,7 +350,7 @@ class DataTransportTcp extends DataTransport {
 
         @Override
         Pair<NdefRecord, byte[]> createNdefRecords(List<DataRetrievalAddress> listeningAddresses) {
-            byte[] reference = String.format("%d", DEVICE_RETRIEVAL_METHOD_TYPE)
+            byte[] reference = String.format(Locale.US, "%d", DEVICE_RETRIEVAL_METHOD_TYPE)
                     .getBytes(UTF_8);
             NdefRecord record = new NdefRecord((short) 0x02, // type = RFC 2046 (MIME)
                     "application/vnd.android.ic.dmr".getBytes(UTF_8),

--- a/identity/src/main/java/com/android/identity/DataTransportWifiAware.java
+++ b/identity/src/main/java/com/android/identity/DataTransportWifiAware.java
@@ -66,6 +66,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.OptionalInt;
 import java.util.Random;
 import java.util.concurrent.BlockingQueue;
@@ -519,8 +520,8 @@ class DataTransportWifiAware extends DataTransport {
 
         // TODO: it's not clear whether port should be included here, we include it for now...
         //
-        mInitiatorIPv6HostString = String.format("[%s]:%d", strippedAddress.getHostAddress(),
-                peerPort);
+        mInitiatorIPv6HostString = String.format(Locale.US,
+                "[%s]:%d", strippedAddress.getHostAddress(), peerPort);
         Log.d(TAG, "Connecting to " + mInitiatorIPv6HostString);
 
         try {
@@ -672,7 +673,7 @@ class DataTransportWifiAware extends DataTransport {
                     return;
                 }
                 Log.d(TAG, "read line '" + line + "'");
-                if (line.toLowerCase().startsWith("content-length:")) {
+                if (line.toLowerCase(Locale.US).startsWith("content-length:")) {
                     try {
                         contentLength = Integer.parseInt(line.substring(15).trim());
                     } catch (NumberFormatException e) {

--- a/identity/src/main/java/com/android/identity/Util.java
+++ b/identity/src/main/java/com/android/identity/Util.java
@@ -1343,7 +1343,7 @@ class Util {
         String indentString = indentBuilder.toString();
 
         if (dataItem.hasTag()) {
-            sb.append(String.format("tag %d ", dataItem.getTag().getValue()));
+            sb.append(String.format(Locale.US, "tag %d ", dataItem.getTag().getValue()));
         }
 
         switch (dataItem.getMajorType()) {


### PR DESCRIPTION
Formatting of decimal integers ("%d") can be Locale dependent - I believe they are formatted differently for some Indian Locale.

To enforce a consistent representation, this commit explicitly uses Locale.US for formatting of integers via String.format("%d", ...) outside of log statements. Potentially in a future commit we can consider specifying a Locale when formatting for logs, too.

I also fixed one occurrence of String.toLowerCase(), which is also Locale dependent.
