### PR TITLE
Switch all CBOR integer handling to use long

### DIFF
--- a/identity/src/androidTest/java/com/android/identity/SessionEncryptionDeviceTest.java
+++ b/identity/src/androidTest/java/com/android/identity/SessionEncryptionDeviceTest.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
 
 import java.math.BigInteger;
 import java.security.PrivateKey;
-import java.util.OptionalInt;
+import java.util.OptionalLong;
 
 import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.ByteString;
@@ -58,7 +58,7 @@ public class SessionEncryptionDeviceTest {
                 eDeviceKeyPrivate, encodedDeviceEngagement, encodedHandover);
 
         // Check that decryption works.
-        Pair<byte[], OptionalInt> result = sessionEncryption.decryptMessageFromReader(
+        Pair<byte[], OptionalLong> result = sessionEncryption.decryptMessageFromReader(
                 Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_ESTABLISHMENT));
         Assert.assertFalse(result.second.isPresent());
         Assert.assertArrayEquals(
@@ -80,18 +80,18 @@ public class SessionEncryptionDeviceTest {
                 Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_DATA),
                 sessionEncryption.encryptMessageToReader(
                         Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE),
-                        OptionalInt.empty()));
+                        OptionalLong.empty()));
 
         // Check that we parse status correctly.
         result = sessionEncryption.decryptMessageFromReader(
                 Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_TERMINATION));
-        Assert.assertEquals(20, result.second.getAsInt());
+        Assert.assertEquals(20, result.second.getAsLong());
         Assert.assertNull(result.first);
 
         // Check we can generate messages with status.
         Assert.assertArrayEquals(
                 Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_TERMINATION),
-                sessionEncryption.encryptMessageToReader(null, OptionalInt.of(20)));
+                sessionEncryption.encryptMessageToReader(null, OptionalLong.of(20)));
     }
 
 }

--- a/identity/src/main/java/com/android/identity/Constants.java
+++ b/identity/src/main/java/com/android/identity/Constants.java
@@ -19,6 +19,7 @@ package com.android.identity;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 import androidx.annotation.IntDef;
+import androidx.annotation.LongDef;
 
 import java.lang.annotation.Retention;
 
@@ -33,14 +34,14 @@ public class Constants {
      *
      * <p>This value is defined in ISO/IEC 18013-5 Table 8.
      */
-    public static final int DEVICE_RESPONSE_STATUS_OK = 0;
+    public static final long DEVICE_RESPONSE_STATUS_OK = 0;
     /**
      * The mdoc returns an error without any given
      * reason. No data is returned.
      *
      * <p>This value is defined in ISO/IEC 18013-5 Table 8.
      */
-    public static final int DEVICE_RESPONSE_STATUS_GENERAL_ERROR = 10;
+    public static final long DEVICE_RESPONSE_STATUS_GENERAL_ERROR = 10;
     /**
      * The mdoc indicates an error during CBOR decoding
      * that the data received is not valid CBOR. Returning
@@ -48,7 +49,7 @@ public class Constants {
      *
      * <p>This value is defined in ISO/IEC 18013-5 Table 8.
      */
-    public static final int DEVICE_RESPONSE_STATUS_CBOR_DECODING_ERROR = 11;
+    public static final long DEVICE_RESPONSE_STATUS_CBOR_DECODING_ERROR = 11;
     /**
      * The mdoc indicates an error during CBOR
      * validation, e.g. wrong CBOR structures. Returning
@@ -56,7 +57,7 @@ public class Constants {
      *
      * <p>This value is defined in ISO/IEC 18013-5 Table 8.
      */
-    public static final int DEVICE_RESPONSE_STATUS_CBOR_VALIDATION_ERROR = 12;
+    public static final long DEVICE_RESPONSE_STATUS_CBOR_VALIDATION_ERROR = 12;
     /**
      * If this flag is set, {@link PresentationHelper} and {@link VerificationHelper}
      * will log informational messages.
@@ -117,7 +118,7 @@ public class Constants {
      * @hidden
      */
     @Retention(SOURCE)
-    @IntDef({DEVICE_RESPONSE_STATUS_OK,
+    @LongDef({DEVICE_RESPONSE_STATUS_OK,
             DEVICE_RESPONSE_STATUS_GENERAL_ERROR,
             DEVICE_RESPONSE_STATUS_CBOR_DECODING_ERROR,
             DEVICE_RESPONSE_STATUS_CBOR_VALIDATION_ERROR})

--- a/identity/src/main/java/com/android/identity/DataTransportNfc.java
+++ b/identity/src/main/java/com/android/identity/DataTransportNfc.java
@@ -157,8 +157,10 @@ class DataTransportNfc extends DataTransport {
         long responseDataFieldMaxLength = Util.cborMapExtractNumber(options,
                 RETRIEVAL_OPTION_KEY_RESPONSE_DATA_FIELD_MAX_LENGTH);
 
-        if (commandDataFieldMaxLength > Integer.MAX_VALUE ||
-                responseDataFieldMaxLength  > Integer.MAX_VALUE) {
+        if (commandDataFieldMaxLength > Integer.MAX_VALUE
+            || commandDataFieldMaxLength <= 0
+            || responseDataFieldMaxLength  > Integer.MAX_VALUE
+            || responseDataFieldMaxLength  <= 0 ) {
             Log.w(TAG, "Invalid max length. Command max: " + commandDataFieldMaxLength +
                     ", response max: " + responseDataFieldMaxLength);
             return null;

--- a/identity/src/main/java/com/android/identity/DataTransportNfc.java
+++ b/identity/src/main/java/com/android/identity/DataTransportNfc.java
@@ -152,14 +152,21 @@ class DataTransportNfc extends DataTransport {
         }
         Map options = ((Map) items[2]);
 
-        int commandDataFieldMaxLength = Util.cborMapExtractNumber(options,
+        long commandDataFieldMaxLength = Util.cborMapExtractNumber(options,
                 RETRIEVAL_OPTION_KEY_COMMAND_DATA_FIELD_MAX_LENGTH);
-        int responseDataFieldMaxLength = Util.cborMapExtractNumber(options,
+        long responseDataFieldMaxLength = Util.cborMapExtractNumber(options,
                 RETRIEVAL_OPTION_KEY_RESPONSE_DATA_FIELD_MAX_LENGTH);
 
+        if (commandDataFieldMaxLength > Integer.MAX_VALUE ||
+                responseDataFieldMaxLength  > Integer.MAX_VALUE) {
+            Log.w(TAG, "Invalid max length. Command max: " + commandDataFieldMaxLength +
+                    ", response max: " + responseDataFieldMaxLength);
+            return null;
+        }
+
         List<DataRetrievalAddress> addresses = new ArrayList<>();
-        addresses.add(new DataRetrievalAddressNfc(commandDataFieldMaxLength,
-                responseDataFieldMaxLength));
+        addresses.add(new DataRetrievalAddressNfc((int)commandDataFieldMaxLength,
+                (int)responseDataFieldMaxLength));
         return addresses;
     }
 

--- a/identity/src/main/java/com/android/identity/DataTransportTcp.java
+++ b/identity/src/main/java/com/android/identity/DataTransportTcp.java
@@ -94,10 +94,15 @@ class DataTransportTcp extends DataTransport {
         Map options = ((Map) items[2]);
 
         String host = Util.cborMapExtractString(options, RETRIEVAL_OPTION_KEY_ADDRESS);
-        int port = Util.cborMapExtractNumber(options, RETRIEVAL_OPTION_KEY_PORT);
+        long port = Util.cborMapExtractNumber(options, RETRIEVAL_OPTION_KEY_PORT);
+
+        if (port > 65535) {
+            Log.w(TAG, "Port is invalid: " + port);
+            return null;
+        }
 
         List<DataRetrievalAddress> addresses = new ArrayList<>();
-        addresses.add(new DataRetrievalAddressTcp(host, port));
+        addresses.add(new DataRetrievalAddressTcp(host, (int)port));
         return addresses;
     }
 

--- a/identity/src/main/java/com/android/identity/DataTransportTcp.java
+++ b/identity/src/main/java/com/android/identity/DataTransportTcp.java
@@ -96,7 +96,7 @@ class DataTransportTcp extends DataTransport {
         String host = Util.cborMapExtractString(options, RETRIEVAL_OPTION_KEY_ADDRESS);
         long port = Util.cborMapExtractNumber(options, RETRIEVAL_OPTION_KEY_PORT);
 
-        if (port > 65535) {
+        if (!isValidServerPort(port)) {
             Log.w(TAG, "Port is invalid: " + port);
             return null;
         }
@@ -335,6 +335,12 @@ class DataTransportTcp extends DataTransport {
     @Override
     boolean supportsTransportSpecificTerminationMessage() {
         return false;
+    }
+
+    private static boolean isValidServerPort(long port) {
+        // 0 is not valid, as that is the wildcard port, telling the OS to pick a free port for
+        // us. A server could never be listening on port 0.
+        return port > 0 && port <= 65535;
     }
 
     static class DataRetrievalAddressTcp extends DataRetrievalAddress {

--- a/identity/src/main/java/com/android/identity/DataTransportWifiAware.java
+++ b/identity/src/main/java/com/android/identity/DataTransportWifiAware.java
@@ -67,7 +67,7 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Random;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
@@ -116,8 +116,8 @@ class DataTransportWifiAware extends DataTransport {
     List<DataRetrievalAddress> parseNdefRecord(@NonNull NdefRecord record) {
         String passphraseInfoPassphrase = null;
         byte[] bandInfoSupportedBands = null;
-        OptionalInt channelInfoChannelNumber = OptionalInt.empty();
-        OptionalInt channelInfoOperatingClass = OptionalInt.empty();
+        OptionalLong channelInfoChannelNumber = OptionalLong.empty();
+        OptionalLong channelInfoOperatingClass = OptionalLong.empty();
 
         // See above for OOB data and where it's defined.
         //
@@ -165,13 +165,13 @@ class DataTransportWifiAware extends DataTransport {
         if (Util.cborMapHasKey(options, 0)) {
             passphraseInfoPassphrase = Util.cborMapExtractString(options, 0);
         }
-        OptionalInt channelInfoChannelNumber = OptionalInt.empty();
+        OptionalLong channelInfoChannelNumber = OptionalLong.empty();
         if (Util.cborMapHasKey(options, 1)) {
-            channelInfoChannelNumber = OptionalInt.of(Util.cborMapExtractNumber(options, 1));
+            channelInfoChannelNumber = OptionalLong.of(Util.cborMapExtractNumber(options, 1));
         }
-        OptionalInt channelInfoOperatingClass = OptionalInt.empty();
+        OptionalLong channelInfoOperatingClass = OptionalLong.empty();
         if (Util.cborMapHasKey(options, 2)) {
-            channelInfoOperatingClass = OptionalInt.of(Util.cborMapExtractNumber(options, 2));
+            channelInfoOperatingClass = OptionalLong.of(Util.cborMapExtractNumber(options, 2));
         }
         byte[] bandInfoSupportedBands = null;
         if (Util.cborMapHasKey(options, 3)) {
@@ -268,7 +268,7 @@ class DataTransportWifiAware extends DataTransport {
         byte[] bandInfoSupportedBands = new byte[]{(byte) (supportedBandsBitmap & 0xff)};
 
         mListeningAddress = new DataRetrievalAddressWifiAware(passphraseInfoPassphrase,
-                OptionalInt.empty(), OptionalInt.empty(),
+                OptionalLong.empty(), OptionalLong.empty(),
                 bandInfoSupportedBands);
 
         reportListeningSetupCompleted(mListeningAddress);
@@ -720,14 +720,14 @@ class DataTransportWifiAware extends DataTransport {
     static class DataRetrievalAddressWifiAware extends DataRetrievalAddress {
         @Nullable
         String passphraseInfoPassphrase;
-        OptionalInt channelInfoChannelNumber;
-        OptionalInt channelInfOperatingClass;
+        OptionalLong channelInfoChannelNumber;
+        OptionalLong channelInfOperatingClass;
         @Nullable
         byte[] bandInfoSupportedBands;
         // TODO: support MAC address
         DataRetrievalAddressWifiAware(@Nullable String passphraseInfoPassphrase,
-                OptionalInt channelInfoChannelNumber,
-                OptionalInt channelInfOperatingClass,
+                OptionalLong channelInfoChannelNumber,
+                OptionalLong channelInfOperatingClass,
                 @Nullable byte[] bandInfoSupportedBands) {
             this.passphraseInfoPassphrase = passphraseInfoPassphrase;
             this.channelInfoChannelNumber = channelInfoChannelNumber;
@@ -847,11 +847,11 @@ class DataTransportWifiAware extends DataTransport {
                     passphraseInfoPassphrase);
             if (channelInfoChannelNumber.isPresent()) {
                 mapBuilder.put(RETRIEVAL_OPTION_KEY_CHANNEL_INFO_CHANNEL_NUMBER,
-                        channelInfoChannelNumber.getAsInt());
+                        channelInfoChannelNumber.getAsLong());
             }
             if (channelInfOperatingClass.isPresent()) {
                 mapBuilder.put(RETRIEVAL_OPTION_KEY_CHANNEL_INFO_OPERATING_CLASS,
-                        channelInfOperatingClass.getAsInt());
+                        channelInfOperatingClass.getAsLong());
             }
             mapBuilder.put(RETRIEVAL_OPTION_KEY_BAND_INFO_SUPPORTED_BANDS, bandInfoSupportedBands);
             mapBuilder.end();
@@ -868,11 +868,11 @@ class DataTransportWifiAware extends DataTransport {
             }
             if (channelInfoChannelNumber.isPresent()) {
                 builder.append(":channel_info_channel_number=");
-                builder.append(channelInfoChannelNumber.getAsInt());
+                builder.append(channelInfoChannelNumber.getAsLong());
             }
             if (channelInfOperatingClass.isPresent()) {
                 builder.append(":channel_info_operating_class=");
-                builder.append(channelInfOperatingClass.getAsInt());
+                builder.append(channelInfOperatingClass.getAsLong());
             }
             if (bandInfoSupportedBands != null) {
                 builder.append(":base_info_supported_bands=");

--- a/identity/src/main/java/com/android/identity/DeviceResponseGenerator.java
+++ b/identity/src/main/java/com/android/identity/DeviceResponseGenerator.java
@@ -35,7 +35,7 @@ import co.nstant.in.cbor.model.UnicodeString;
 public final class DeviceResponseGenerator {
 
     private final ArrayBuilder<CborBuilder> mDocumentsBuilder;
-    @Constants.DeviceResponseStatus private final int mStatusCode;
+    @Constants.DeviceResponseStatus private final long mStatusCode;
 
     /**
      * Creates a new {@link DeviceResponseGenerator}.
@@ -46,7 +46,7 @@ public final class DeviceResponseGenerator {
      * {@link Constants#DEVICE_RESPONSE_STATUS_CBOR_DECODING_ERROR}, or
      * {@link Constants#DEVICE_RESPONSE_STATUS_CBOR_VALIDATION_ERROR}.
      */
-    public DeviceResponseGenerator(@Constants.DeviceResponseStatus int statusCode) {
+    public DeviceResponseGenerator(@Constants.DeviceResponseStatus long statusCode) {
         mStatusCode = statusCode;
         mDocumentsBuilder = new CborBuilder().addArray();
     }

--- a/identity/src/main/java/com/android/identity/PresentationHelper.java
+++ b/identity/src/main/java/com/android/identity/PresentationHelper.java
@@ -42,7 +42,7 @@ import java.security.KeyPair;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 
@@ -399,7 +399,7 @@ public class PresentationHelper {
 
                 @Override
                 public void onMessageReceived(@NonNull byte[] data) {
-                    Pair<byte[], OptionalInt> decryptedMessage = null;
+                    Pair<byte[], OptionalLong> decryptedMessage = null;
                     try {
                         decryptedMessage = mSessionEncryption.decryptMessageFromReader(data);
                         mDeviceEngagementMethod = DEVICE_ENGAGEMENT_METHOD_QR_CODE;
@@ -467,7 +467,7 @@ public class PresentationHelper {
                             transport.close();
                             reportError(new Error("No data and no status in SessionData"));
                         } else {
-                            int statusCode = decryptedMessage.second.getAsInt();
+                            long statusCode = decryptedMessage.second.getAsLong();
 
                             mLog.session("Message received from reader with status: " + statusCode);
 
@@ -975,7 +975,7 @@ public class PresentationHelper {
             Util.dumpHex(TAG, "Sending DeviceResponse", deviceResponseBytes);
         }
         byte[] encryptedData =
-                mSessionEncryption.encryptMessageToReader(deviceResponseBytes, OptionalInt.empty());
+                mSessionEncryption.encryptMessageToReader(deviceResponseBytes, OptionalLong.empty());
         mActiveTransport.sendMessage(encryptedData);
     }
 
@@ -1025,7 +1025,7 @@ public class PresentationHelper {
                 } else {
                     mLog.info("Sending generic session termination message");
                     byte[] sessionTermination = mSessionEncryption.encryptMessageToReader(
-                            null, OptionalInt.of(20));
+                            null, OptionalLong.of(20));
                     mActiveTransport.sendMessage(sessionTermination);
                 }
             } else {

--- a/identity/src/main/java/com/android/identity/SessionEncryptionDevice.java
+++ b/identity/src/main/java/com/android/identity/SessionEncryptionDevice.java
@@ -32,7 +32,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.List;
-import java.util.OptionalInt;
+import java.util.OptionalLong;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -111,7 +111,7 @@ final class SessionEncryptionDevice {
      *                                  message from the reader has been received.
      */
     public @NonNull byte[] encryptMessageToReader(@Nullable byte[] messagePlaintext,
-            @NonNull OptionalInt statusCode) {
+            @NonNull OptionalLong statusCode) {
         if (!mEReaderKeyReceived) {
             throw new IllegalStateException("Cannot send messages to reader until a message "
                     + "from the reader has been received");
@@ -146,7 +146,7 @@ final class SessionEncryptionDevice {
             mapBuilder.put("data", messageCiphertextAndAuthTag);
         }
         if (statusCode.isPresent()) {
-            mapBuilder.put("status", statusCode.getAsInt());
+            mapBuilder.put("status", statusCode.getAsLong());
         }
         mapBuilder.end();
         return Util.cborEncode(builder.build().get(0));
@@ -166,7 +166,7 @@ final class SessionEncryptionDevice {
      *         status, as described above.
      * @exception IllegalArgumentException if the passed in data does not conform to the CDDL.
      */
-    public @Nullable Pair<byte[], OptionalInt> decryptMessageFromReader(
+    public @Nullable Pair<byte[], OptionalLong> decryptMessageFromReader(
             @NonNull byte[] messageData) {
         ByteArrayInputStream bais = new ByteArrayInputStream(messageData);
         List<DataItem> dataItems = null;
@@ -206,13 +206,13 @@ final class SessionEncryptionDevice {
             messageCiphertext = ((ByteString) dataItemData).getBytes();
         }
 
-        OptionalInt status = OptionalInt.empty();
+        OptionalLong status = OptionalLong.empty();
         DataItem dataItemStatus = map.get(new UnicodeString("status"));
         if (dataItemStatus != null) {
             if (!(dataItemStatus instanceof Number)) {
                 throw new IllegalArgumentException("status is not a number");
             }
-            status = OptionalInt.of(((Number) dataItemStatus).getValue().intValue());
+            status = OptionalLong.of(((Number) dataItemStatus).getValue().longValue());
         }
 
         byte[] plainText = null;
@@ -279,7 +279,7 @@ final class SessionEncryptionDevice {
 
     /**
      * Gets the number of messages encrypted with
-     * {@link #encryptMessageToReader(byte[], OptionalInt)} .
+     * {@link #encryptMessageToReader(byte[], OptionalLong)} .
      *
      * @return Number of messages encrypted.
      */

--- a/identity/src/main/java/com/android/identity/SessionEncryptionReader.java
+++ b/identity/src/main/java/com/android/identity/SessionEncryptionReader.java
@@ -126,7 +126,7 @@ final class SessionEncryptionReader {
         if (!(cipherSuiteDataItem instanceof Number)) {
             throw new IllegalArgumentException("Cipher suite not a Number");
         }
-        int cipherSuite = ((Number) cipherSuiteDataItem).getValue().intValue();
+        long cipherSuite = ((Number) cipherSuiteDataItem).getValue().longValue();
         if (cipherSuite != 1) {
             throw new IllegalArgumentException("Expected cipher suite 1, got " + cipherSuite);
         }

--- a/identity/src/main/java/com/android/identity/Util.java
+++ b/identity/src/main/java/com/android/identity/Util.java
@@ -1070,7 +1070,7 @@ class Util {
     }
 
     static @NonNull
-    Collection<Integer> cborMapExtractMapNumberKeys(@NonNull DataItem map) {
+    Collection<Long> cborMapExtractMapNumberKeys(@NonNull DataItem map) {
         List<Long> ret = new ArrayList<>();
         for (DataItem item : castTo(Map.class, map).getKeys()) {
             ret.add(castTo(Number.class, item).getValue().longValue());


### PR DESCRIPTION
CBOR uses 64 bit signed integers by default, so we should also
use a 64 bit type so that we don't run into any odd behaviors in
case of integers with very large magnitudes.