### PR TITLE
De-duplicate repetitive boiler plate code around type casting.

### DIFF
--- a/identity/src/main/java/com/android/identity/SessionEncryptionDevice.java
+++ b/identity/src/main/java/com/android/identity/SessionEncryptionDevice.java
@@ -186,7 +186,7 @@ final class SessionEncryptionDevice {
         if (!mEReaderKeyReceived) {
             // If it's the first message, retrieve reader key and setup crypto
             DataItem dataItemEReaderKey = map.get(new UnicodeString("eReaderKey"));
-            if (dataItemEReaderKey == null || !(dataItemEReaderKey instanceof ByteString)) {
+            if (!(dataItemEReaderKey instanceof ByteString)) {
                 throw new IllegalArgumentException("No 'eReaderKey' item found or not bstr");
             }
             byte[] eReaderKeyBytes = ((ByteString) dataItemEReaderKey).getBytes();


### PR DESCRIPTION
 1. foo instanceof Foo implies foo != null, so there is no need to check for null separately.

 2. Numerous places in Util.java duplicate the type that one was casting to across three places (instanceof check, typecast, and error message string literal), and the expression being cast across the first two; this commit introduces a helper method castTo() that de-duplicates this.

 3. One of the string literals was quoting the wrong type; this commit fixes that.

This commit is a refactoring with no behavior change except that it unifies the exception message, which sometimes means one needs the line number to find exactly the right place but is more consistent and saves bytes because it avoids a ton of near-duplicate string literals.

In a follow up commit, we could optionally consider changing exception behavior to be more idiomatic for .java code:

  - Throw NullPointerException instead of IllegalArgumentException in case of null
  - Throw ClassCastException instead of IllegalArgumentException in case of non-null wrong type
  - Optionally we could quote the offending value rather than just its class in exception messages.

But this is a separate decision so I didn't do it as part of this commit.

Also not addressed in this commit:

 - There are some additional places that do a normal typecast. These could be made consistent.
 - Several of these cast to fully qualified library classes that are also imported, e.g. co.nstant.in.cbor.model.Array. Since they are also imported they could be shortened to "Array".

I've checked that all tests still pass (checked on Pixel 3 API 28 emulator).