### PR TITLE
Rename UtilTests -> UtilTest.

### DIFF
--- a/identity/src/androidTest/java/com/android/identity/UtilTest.java
+++ b/identity/src/androidTest/java/com/android/identity/UtilTest.java
@@ -65,7 +65,7 @@ import co.nstant.in.cbor.model.UnsignedInteger;
 @MediumTest
 @RunWith(AndroidJUnit4.class)
 @SuppressWarnings("deprecation")
-public class UtilTests {
+public class UtilTest {
     @Test
     public void prettyPrintMultipleCompleteTypes() throws CborException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
The name of this class was not idiomatic. This commit fixes it.

I only noticed that the misnamed test class existed after I had already uploaded https://github.com/google/identity-credential/pull/68 :-(

If you merge this pull request, I can redo the commits from that pull request.

Alternatively (easier for me but slightly messier git history), if you merge that pull request, then I'll create a follow-up pull request that merges the two test classes. Up to you.