### PR TITLE
Rename IdentityCredentialStore.getInstance() -> getDefaultInstance.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/document/DocumentManager.kt
+++ b/appholder/src/main/java/com/android/mdl/app/document/DocumentManager.kt
@@ -76,7 +76,7 @@ class DocumentManager private constructor(private val context: Context) {
             IdentityCredentialStore.getSoftwareInstance(context)
         }
     } else {
-        val mStore = IdentityCredentialStore.getInstance(context)
+        val mStore = IdentityCredentialStore.getDefaultInstance(context)
         // This app needs feature version 202201, if hardware implementation doesn't support
         // get software implementation
         if (mStore.capabilities.featureVersion != FEATURE_VERSION_202201) {

--- a/identity/src/androidTest/java/com/android/identity/IdentityCredentialTest.java
+++ b/identity/src/androidTest/java/com/android/identity/IdentityCredentialTest.java
@@ -133,7 +133,7 @@ public class IdentityCredentialTest {
   public static Collection<Object[]> parameters() {
     List<IdentityCredentialStore> resultStores = new ArrayList<>();
     Context appContext = androidx.test.InstrumentationRegistry.getTargetContext();
-    IdentityCredentialStore defaultStore = IdentityCredentialStore.getInstance(appContext);
+    IdentityCredentialStore defaultStore = IdentityCredentialStore.getDefaultInstance(appContext);
     resultStores.add(IdentityCredentialStore.getSoftwareInstance(appContext));
     IdentityCredentialStore hwStore = IdentityCredentialStore.getHardwareInstance(appContext);
     if (hwStore != null) {

--- a/identity/src/main/java/com/android/identity/IdentityCredentialStore.java
+++ b/identity/src/main/java/com/android/identity/IdentityCredentialStore.java
@@ -83,18 +83,18 @@ import java.security.cert.X509Certificate;
  * of the methods in that class will state whether it's implemented in the software-based
  * implementation.
  *
- * <p>When provisioning a document, applications should use {@link #getInstance(Context)} to
- * obtain an {@link IdentityCredentialStore} instance. This method returns a hardware-backed
+ * <p>When provisioning a document, applications should use {@link #getDefaultInstance(Context)}
+ * to obtain an {@link IdentityCredentialStore} instance. This method returns a hardware-backed
  * store if available and a software-based store if not and the application should use
  * {@link IdentityCredentialStoreCapabilities} to examine if the store supports the
  * capabilities required by the application. In the negative, the application can
  * obtain the software-based store by calling {@link #getSoftwareInstance(Context)}.
  *
  * <p>Since it's possible for an OS upgrade on a device to include an updated version of the
- * drivers used for secure hardware, it's possible that {@link #getInstance(Context)} returns the
- * software implementation at one point and the hardware implementation at a later point.
- * Therefore, applications should only use {@link #getInstance(Context)} only when creating a
- * credential, record whether it's hardware- or software-backed (using
+ * drivers used for secure hardware, it's possible that {@link #getDefaultInstance(Context)}
+ * returns the software implementation at one point and the hardware implementation at a later
+ * point. Therefore, applications should only use {@link #getDefaultInstance(Context)} only when
+ * creating a credential, record whether it's hardware- or software-backed (using
  * {@link IdentityCredentialStoreCapabilities#isHardwareBacked()}, and then use this information
  * when retrieving the credential (using either {@link #getSoftwareInstance(Context)} or
  * {@link #getHardwareInstance(Context)}).
@@ -132,13 +132,26 @@ public abstract class IdentityCredentialStore {
      */
     public static final int CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256 = 1;
 
+
     /**
-     * Gets the default {@link IdentityCredentialStore}.
+     * @deprecated Use {@link #getDefaultInstance(Context)} instead.
+     */
+    @Deprecated // TODO: Delete this method sufficiently long after June 2022, e.g. EOY 2022.
+    public static @NonNull IdentityCredentialStore getInstance(@NonNull Context context) {
+        return getDefaultInstance(context);
+    }
+
+    /**
+     * Gets the default {@link IdentityCredentialStore} instance. This does not guarantee any
+     * particular {@link IdentityCredentialStoreCapabilities}, in particular it may be hardware-
+     * or software backed. The kind of instance returned by this method may change over time even
+     * on the same device, for example a device might gain the capability of a hardware-backed
+     * instance through an Android version upgrade.
      *
      * @param context the application context.
      * @return the {@link IdentityCredentialStore}.
      */
-    public static @NonNull IdentityCredentialStore getInstance(@NonNull Context context) {
+    public static @NonNull IdentityCredentialStore getDefaultInstance(@NonNull Context context) {
         Context appContext = context.getApplicationContext();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             IdentityCredentialStore store =


### PR DESCRIPTION
To give client time to migrate, keep a @deprecated method under the old name that delegates to the new one. I've added a TODO to get rid of the deprecated method in the longer term.

Also expand documentation of the method.
