### PR TITLE
Fix error-prone featureVersion / ICS.getDefaultInstance() API.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/document/DocumentManager.kt
+++ b/appholder/src/main/java/com/android/mdl/app/document/DocumentManager.kt
@@ -76,16 +76,10 @@ class DocumentManager private constructor(private val context: Context) {
             IdentityCredentialStore.getSoftwareInstance(context)
         }
     } else {
-        val mStore = IdentityCredentialStore.getDefaultInstance(context)
-        // This app needs feature version 202201, if hardware implementation doesn't support
-        // get software implementation
-        if (mStore.capabilities.featureVersion != FEATURE_VERSION_202201) {
-            PreferencesHelper.setHardwareBacked(context, false)
-            IdentityCredentialStore.getSoftwareInstance(context)
-        } else {
-            PreferencesHelper.setHardwareBacked(context, mStore.capabilities.isHardwareBacked)
-            mStore
-        }
+        // This app needs feature version 202201, which may only be supported by the software
+        // implementation.
+        val mStore = IdentityCredentialStore.getDefaultInstance(context, FEATURE_VERSION_202201);
+        PreferencesHelper.setHardwareBacked(context, mStore.capabilities.isHardwareBacked)
     }
 
     // Database to store document information

--- a/identity/src/androidTest/java/com/android/identity/IdentityCredentialStoreTest.java
+++ b/identity/src/androidTest/java/com/android/identity/IdentityCredentialStoreTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import static com.android.identity.IdentityCredentialStore.getDefaultInstance;
+import static com.android.identity.IdentityCredentialStoreCapabilities.FEATURE_VERSION_202009;
+import static com.android.identity.IdentityCredentialStoreCapabilities.FEATURE_VERSION_202101;
+import static com.android.identity.IdentityCredentialStoreCapabilities.FEATURE_VERSION_202201;
+import static com.android.identity.IdentityCredentialStoreCapabilities.FEATURE_VERSION_BASE;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.content.Context;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class IdentityCredentialStoreTest {
+
+  private static final List<Integer> FEATURE_VERSIONS =
+          Collections.unmodifiableList(Arrays.asList(
+                  FEATURE_VERSION_BASE,
+                  FEATURE_VERSION_202009,
+                  FEATURE_VERSION_202101,
+                  FEATURE_VERSION_202201));
+
+  private Context appContext;
+
+  @Before
+  public void setUp() {
+    appContext = androidx.test.InstrumentationRegistry.getTargetContext();
+  }
+
+  @Test
+  public void getDefaultInstance_defaultsToBaseVersion() {
+    IdentityCredentialStore defaultStore = getDefaultInstance(appContext);
+    IdentityCredentialStore baseStore = getDefaultInstance(appContext, FEATURE_VERSION_BASE);
+    assertEquals(baseStore.getClass(), defaultStore.getClass());
+    assertEquals(baseStore.getCapabilities().getFeatureVersion(),
+            defaultStore.getCapabilities().getFeatureVersion());
+  }
+
+  @Test
+  public void getDefaultInstance_isHardwareOrSoftwareBacked() {
+    for (int featureVersion : FEATURE_VERSIONS) {
+      IdentityCredentialStore store = getDefaultInstance(appContext, featureVersion);
+      List<Class<? extends IdentityCredentialStore>> expectedClasses = Arrays.asList(
+              SoftwareIdentityCredentialStore.class, HardwareIdentityCredentialStore.class);
+      assertTrue("Unexpected store impl: " + store.getClass(),
+              expectedClasses.contains(store.getClass()));
+    }
+  }
+
+  @Test
+  public void getDefaultInstanceWithUnsupportedFeatureVersion() {
+    try {
+      // Ask for a featureVersion larger than any supported one.
+      getDefaultInstance(appContext, Integer.MAX_VALUE);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      // pass
+    }
+  }
+
+  @Test
+  public void getDefaultInstanceWithSupportedFeatureVersion() {
+    // Assertions below rely on ascending order
+    List<Integer> sortedVersions = FEATURE_VERSIONS.stream().sorted().collect(toList());
+    Integer lowestSoftwareVersion = null;
+    int previousVersionSeen = Integer.MIN_VALUE;
+    for (int requestedVersion : sortedVersions) {
+      IdentityCredentialStore store = getDefaultInstance(
+              appContext, requestedVersion);
+      int actualVersion = store.getCapabilities().getFeatureVersion();
+
+      // Requested featureVersion should be supported.
+      assertTrue("Expected value >= " + requestedVersion + ", got " + actualVersion,
+              actualVersion >= requestedVersion);
+
+      // If version X falls back to software, versions Y >= X should, too.
+      if (store.getCapabilities().isHardwareBacked()) {
+        assertNull("Version " + lowestSoftwareVersion + " falls back to software, but later " +
+                        "version " + requestedVersion + " unexpectedly supported in hardware.",
+                lowestSoftwareVersion);
+      } else {
+        lowestSoftwareVersion = requestedVersion;
+      }
+
+      // Supported features should not decrease as requested features increase.
+      assertTrue("Capabilities version decreased at requested version " + requestedVersion,
+               actualVersion >= previousVersionSeen);
+    }
+  }
+
+}

--- a/identity/src/main/java/com/android/identity/IdentityCredentialStoreCapabilities.java
+++ b/identity/src/main/java/com/android/identity/IdentityCredentialStoreCapabilities.java
@@ -18,8 +18,10 @@ package com.android.identity;
 
 import android.icu.util.Calendar;
 
+import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
-
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.security.cert.X509Certificate;
 import java.util.Set;
 
@@ -48,6 +50,12 @@ public class IdentityCredentialStoreCapabilities {
     IdentityCredentialStoreCapabilities() {}
 
     /**
+     * The feature version corresponding to no version-dependent features being supported.
+     * This version is guaranteed to be {@code <=} any other documented feature version.
+     */
+    public static final int FEATURE_VERSION_BASE = Integer.MIN_VALUE;
+
+    /**
      * The feature version corresponding to features included in the Identity Credential API
      * shipped in Android 11.
      */
@@ -72,12 +80,28 @@ public class IdentityCredentialStoreCapabilities {
     public static final int FEATURE_VERSION_202201 = 202201;
 
     /**
+     * Feature versions. {@code int} values other than these are discouraged because their semantics
+     * match those of the next equal-or-higher defined version.
+     */
+    @Retention(RetentionPolicy.CLASS)
+    @IntDef({FEATURE_VERSION_BASE, FEATURE_VERSION_202009, FEATURE_VERSION_202101, FEATURE_VERSION_202201})
+    public @interface FeatureVersion {}
+
+    /**
      * Returns the feature version of the {@link IdentityCredentialStore}.
      *
      * @return the feature version.
      */
-    public int getFeatureVersion() {
+    public @FeatureVersion int getFeatureVersion() {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns whether the associated {@link IdentityCredentialStore} supports the features up
+     * to at least the specified version.
+     */
+    final boolean isFeatureVersionSupported(@FeatureVersion int featureVersion) {
+        return getFeatureVersion() >= featureVersion;
     }
 
     /**


### PR DESCRIPTION
While we're at it, fix an incorrect usage of the old API: compared versions using != when it should have been <.

Another client implementation that I'm aware of also had bugs in their logic for obtaining an IdentityCredentialStore instance. In both cases, the logic that was broken _could have_ lived in the library, i.e. it was needlessly pushed onto the client apps.

This commit fixes the library API surface to make it easier to use correctly / harder to misuse.

Concretely:
  - Before this commit, clients are supposed to check ```IdentityCredentialStoreCapabilities.getFeatureVersion()``` for whether an implementation meets their needs. Comparing the returned int value is left to the caller, which is a needless source of bugs - this is what DocumentManager.kt got wrong, it would have broken as soon as later version was defined.
    - This commit adds a method ```boolean isFeatureVersionSupported()``` that includes the version comparison logic. However, I'm keeping the method package private for now because of the below.
  - Before this commit, the need to check featureVersion in the first place (potentially falling back to software-backed instance) was pushed onto clients. An implementation got this wrong (b/232444072). This commit adds an overload ```IdentityCredentialStore.getInstance(Context, int)``` that implements this fallback method, so that clients don't have to.
  - Before this commit, featureVersions were weakly typed int values. This commit introduces an ```@IntDef FeatureVersion``` to formally document which values are allowed in a way that static analysis tools can understand.
   - For the use case where one doesn't need a particular feature, this CL introduces ```FEATURE_VERSION_BASE```. I'm not sure if we should set it to Integer.MIN_VALUE or the lowest defined version version.

Future commits could potentially implement one or more of these additional ideas to improve the API:

  - Change the parameter to be int... so that one can provide multiple feature versions. This way, we avoid forcing the human to have to compute the maximum of the required feature values, and keep the door open in case we ever want to have a non-ordered set of features in future (e.g. being hardware-backed could then be expressed as a feature).

  - Introduce constants such as static final int ```FEATURE_CREATE_PRESENTATION_SESSION = FEATURE_VERSION_202201```. This way, the features in client code can be expressed in names that are readable / carry obvious semantics, rather than having to cross-check for human readable javadoc such as ```"This is supported in feature version {https://github.com/link #FEATURE_VERSION_202201} and later."``` on the javadoc for ```isCreatePresentationSessionSupported()```, again making the API less error prone to use.

  - To ensure continuity, both client implementations currently remember in preferences whether they previously used a hw- vs. sw-backed instance. This logic could also move into the library, although in order to support migrations from one to the other, one would probably want to tell the library one's preference. One way this could be achieved is via the approach two bullet points further up.