### PR TITLE
Add services.gradle.org to the host allow list

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,6 +26,7 @@ jobs:
           github.com:443
           maven.google.com:443
           mp1yacprodeus1file3.blob.core.windows.net:443
+          services.gradle.org:443
 
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
     - name: set up JDK 11


### PR DESCRIPTION
The gradle setup script tries to download from gradle.org, but this
was being blocked by the harden-security action.