### PR TITLE
Allow actions to access more domains

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -27,6 +27,8 @@ jobs:
           maven.google.com:443
           mp1yacprodeus1file3.blob.core.windows.net:443
           services.gradle.org:443
+          downloads.gradle-dn.com:443
+          jcenter.bintray.com:443
 
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
     - name: set up JDK 11


### PR DESCRIPTION
The unit test workflow was being blocked by the harden-runner action as
some domains were not allow-listed, and packages couldn't be resolved.