### PR TITLE
Switch egress hardening to audit mode

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -18,14 +18,18 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@248ae51c2e8cc9622ecf50685c8bf7150c6e8813  # v1.4.3
       with:
-        egress-policy: block
+        # We are in audit mode on egress until the following issue is fixed:
+        # https://github.com/step-security/harden-runner/issues/83
+        # Things hosted on the Microsoft CDN end up on different hostnames,
+        # and we should allow-list *.blob.core.windows.net. However, we cannot
+        # really do that so are stuck with audit mode for now.
+        egress-policy: audit
         disable-telemetry: true
         allowed-endpoints: >
           artifactcache.actions.githubusercontent.com:443
           dl.google.com:443
           github.com:443
           maven.google.com:443
-          mp1yacprodeus1file3.blob.core.windows.net:443
           services.gradle.org:443
           downloads.gradle-dn.com:443
           jcenter.bintray.com:443


### PR DESCRIPTION
One of the endpoints we need is part of a Microsoft-hosted CDN, and we
get bounced to different servers in this domain depending on the whims
of the load balancer. Thus, we cannot allow-list the exact server,
but harden-runner also doesn't support wildcards. Just use audit mode
for now so we can at least see what's being accessed in the logs.