### PR TITLE
Introduce interface for sending NFC response back to mdoc reader.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/transfer/TransferManager.kt
+++ b/appholder/src/main/java/com/android/mdl/app/transfer/TransferManager.kt
@@ -181,7 +181,10 @@ class TransferManager private constructor(private val context: Context) {
     }
 
     fun nfcEngagementProcessCommandApdu(service: HostApduService, commandApdu: ByteArray) {
-        presentation?.nfcProcessCommandApdu(service, commandApdu)
+        presentation?.setNfcResponder {
+            service.sendResponseApdu(it)
+        }
+        presentation?.nfcProcessCommandApdu(commandApdu)
     }
 
     fun nfcEngagementOnDeactivated(service: HostApduService, reason: Int) {


### PR DESCRIPTION
The current PresentationHelper design requires the caller to pass an
instance of android.nfc.cardemulation.HostApduService which makes it
tricky to unit test and also use in a multi-process application.

This change introduces a simple NfcResponse interface which does the
same thing.

Bug: None
Test: Manually tested, NFC device engagement still works.
