### PR TITLE
Include unit tests and add CBOR type helpers

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build -x test
     - name: Run unit tests
       run: ./gradlew test
 

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -31,8 +31,11 @@ dependencies {
     implementation "org.bouncycastle:bcprov-jdk15on:$bouncy_castle_bcprov_version"
     implementation("org.bouncycastle:bcpkix-jdk15on:$bouncy_castle_bcpkix_version")
 
-    // JUnit 4 framework
+    testImplementation "androidx.test.espresso:espresso-core:$espresso_core_version"
+    testImplementation "androidx.test.ext:junit:$junit_test"
     testImplementation "junit:junit:$junit_version"
+    testImplementation "org.bouncycastle:bcprov-jdk15on:$bouncy_castle_bcprov_version"
+
     androidTestImplementation "androidx.test.ext:junit:$junit_test"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_core_version"
 }
@@ -49,6 +52,12 @@ task generateApiDoc(type: Javadoc) {
 
     destinationDir = file("../docs/javadoc/")
     failOnError false
+}
+
+tasks.withType(Test) {
+    testLogging {
+        events "standardOut", "passed", "skipped", "failed"
+    }
 }
 
 afterEvaluate {

--- a/identity/src/main/java/com/android/identity/CredentialData.java
+++ b/identity/src/main/java/com/android/identity/CredentialData.java
@@ -1081,7 +1081,7 @@ class CredentialData {
                 if (!(expirationDateMillisItem instanceof Number)) {
                     throw new RuntimeException("expirationDateMillis not a number");
                 }
-                expirationDateMillis = ((Number) expirationDateMillisItem).getValue().longValue();
+                expirationDateMillis = Util.checkedLongValue(expirationDateMillisItem);
             }
             Calendar expirationDate = Calendar.getInstance();
             expirationDate.setTimeInMillis(expirationDateMillis);

--- a/identity/src/main/java/com/android/identity/SessionEncryptionDevice.java
+++ b/identity/src/main/java/com/android/identity/SessionEncryptionDevice.java
@@ -49,7 +49,6 @@ import co.nstant.in.cbor.builder.MapBuilder;
 import co.nstant.in.cbor.model.ByteString;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.Map;
-import co.nstant.in.cbor.model.Number;
 import co.nstant.in.cbor.model.UnicodeString;
 
 /**
@@ -209,10 +208,7 @@ final class SessionEncryptionDevice {
         OptionalLong status = OptionalLong.empty();
         DataItem dataItemStatus = map.get(new UnicodeString("status"));
         if (dataItemStatus != null) {
-            if (!(dataItemStatus instanceof Number)) {
-                throw new IllegalArgumentException("status is not a number");
-            }
-            status = OptionalLong.of(((Number) dataItemStatus).getValue().longValue());
+            status = OptionalLong.of(Util.checkedLongValue(dataItemStatus));
         }
 
         byte[] plainText = null;

--- a/identity/src/main/java/com/android/identity/SessionEncryptionReader.java
+++ b/identity/src/main/java/com/android/identity/SessionEncryptionReader.java
@@ -126,7 +126,7 @@ final class SessionEncryptionReader {
         if (!(cipherSuiteDataItem instanceof Number)) {
             throw new IllegalArgumentException("Cipher suite not a Number");
         }
-        long cipherSuite = ((Number) cipherSuiteDataItem).getValue().longValue();
+        final long cipherSuite = Util.checkedLongValue(cipherSuiteDataItem);
         if (cipherSuite != 1) {
             throw new IllegalArgumentException("Expected cipher suite 1, got " + cipherSuite);
         }

--- a/identity/src/test/java/com/android/identity/TestUtilities.java
+++ b/identity/src/test/java/com/android/identity/TestUtilities.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import androidx.annotation.NonNull;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.cert.CertIOException;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+public class TestUtilities {
+
+    static @NonNull X509Certificate generateSelfSignedCert(KeyPair keyPair) {
+        try {
+            final Date notBefore = Date.from(Instant.now());
+            final Date notAfter = Date.from(Instant.now().plus(Duration.ofDays(30)));
+            final X500Name subjectIssuerName = new X500Name("CN=test");
+            final ContentSigner signer;
+            signer = new JcaContentSignerBuilder("SHA256WithECDSA")
+                .build(keyPair.getPrivate());
+            final X509CertificateHolder certHolder =
+                new JcaX509v3CertificateBuilder(
+                    subjectIssuerName,
+                    BigInteger.valueOf(10101),
+                    notBefore,
+                    notAfter,
+                    subjectIssuerName,
+                    keyPair.getPublic())
+                    .addExtension(Extension.basicConstraints, true, new BasicConstraints(true))
+                    .build(signer);
+            return new JcaX509CertificateConverter()
+                .setProvider(new BouncyCastleProvider())
+                .getCertificate(certHolder);
+        } catch (OperatorCreationException | CertIOException | CertificateException e) {
+            throw new IllegalStateException("Error generating self-signed certificate", e);
+        }
+    }
+}

--- a/identity/src/test/java/com/android/identity/TestUtilities.java
+++ b/identity/src/test/java/com/android/identity/TestUtilities.java
@@ -38,6 +38,8 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 public class TestUtilities {
 
+    private TestUtilities() {}
+
     static @NonNull X509Certificate generateSelfSignedCert(KeyPair keyPair) {
         try {
             final Date notBefore = Date.from(Instant.now());


### PR DESCRIPTION
Two commits here (which shouldn't be squashed into one):

The first enables unit tests, converting `UtilTest` into the first test that may be run outside of an Android device.

The second commit adds type coercion helpers for string and integer `DataItem`s