### PR TITLE
Partially break dependency on android.icu

### DIFF
--- a/identity/src/androidTest/java/com/android/identity/DeviceResponseParserTest.java
+++ b/identity/src/androidTest/java/com/android/identity/DeviceResponseParserTest.java
@@ -16,9 +16,6 @@
 
 package com.android.identity;
 
-import android.icu.text.DateFormat;
-import android.icu.text.SimpleDateFormat;
-
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.SmallTest;
 
@@ -31,7 +28,6 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
-import java.util.Collection;
 import java.util.List;
 
 @SuppressWarnings("deprecation")
@@ -75,10 +71,11 @@ public class DeviceResponseParserTest {
 
         // Check ValidityInfo is correctly parsed, these values are all from
         // ISO/IEC 18013-5 Annex D.4.1.2 mdoc response.
-        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
-        Assert.assertEquals("2020-10-01T13:30:02Z", df.format(d.getValidityInfoSigned()));
-        Assert.assertEquals("2020-10-01T13:30:02Z", df.format(d.getValidityInfoValidFrom()));
-        Assert.assertEquals("2021-10-01T13:30:02Z", df.format(d.getValidityInfoValidUntil()));
+        // 2020-10-01T13:30:02Z == 1601559002000
+        Assert.assertEquals(1601559002000L, d.getValidityInfoSigned().toEpochMilli());
+        Assert.assertEquals(1601559002000L, d.getValidityInfoValidFrom().toEpochMilli());
+        // 2021-10-01T13:30:02Z == 1601559002000
+        Assert.assertEquals(1633095002000L, d.getValidityInfoValidUntil().toEpochMilli());
         Assert.assertNull(d.getValidityInfoExpectedUpdate());
 
         // Check DeviceKey is correctly parsed

--- a/identity/src/androidTest/java/com/android/identity/UtilTest.java
+++ b/identity/src/androidTest/java/com/android/identity/UtilTest.java
@@ -22,9 +22,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import android.icu.util.Calendar;
-import android.icu.util.GregorianCalendar;
-import android.icu.util.TimeZone;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 
@@ -43,8 +40,11 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Signature;
 import java.security.cert.X509Certificate;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.LinkedList;
 import java.util.Random;
+import java.util.TimeZone;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -280,38 +280,38 @@ public class UtilTest {
         c = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
         c.clear();
         c.set(2019, Calendar.JULY, 8, 11, 51, 42);
-        data = Util.cborEncodeDateTime(c);
+        data = Util.cborEncodeDateTime(Timestamp.ofEpochMilli(c.getTimeInMillis()));
         assertEquals("tag 0 '2019-07-08T11:51:42Z'", Util.cborPrettyPrint(data));
         assertEquals("tag 0 '2019-07-08T11:51:42Z'",
                 Util.cborPrettyPrint(Util.cborEncodeDateTime(Util.cborDecodeDateTime(data))));
-        assertEquals(0, c.compareTo(Util.cborDecodeDateTime(data)));
+        assertEquals(c.getTimeInMillis(), Util.cborDecodeDateTime(data).toEpochMilli());
 
         c = new GregorianCalendar(TimeZone.getTimeZone("GMT-04:00"));
         c.clear();
         c.set(2019, Calendar.JULY, 8, 11, 51, 42);
-        data = Util.cborEncodeDateTime(c);
-        assertEquals("tag 0 '2019-07-08T11:51:42-04:00'", Util.cborPrettyPrint(data));
-        assertEquals("tag 0 '2019-07-08T11:51:42-04:00'",
+        data = Util.cborEncodeDateTime(Timestamp.ofEpochMilli(c.getTimeInMillis()));
+        assertEquals("tag 0 '2019-07-08T15:51:42Z'", Util.cborPrettyPrint(data));
+        assertEquals("tag 0 '2019-07-08T15:51:42Z'",
                 Util.cborPrettyPrint(Util.cborEncodeDateTime(Util.cborDecodeDateTime(data))));
-        assertEquals(0, c.compareTo(Util.cborDecodeDateTime(data)));
+        assertEquals(c.getTimeInMillis(), Util.cborDecodeDateTime(data).toEpochMilli());
 
         c = new GregorianCalendar(TimeZone.getTimeZone("GMT-08:00"));
         c.clear();
         c.set(2019, Calendar.JULY, 8, 11, 51, 42);
-        data = Util.cborEncodeDateTime(c);
-        assertEquals("tag 0 '2019-07-08T11:51:42-08:00'", Util.cborPrettyPrint(data));
-        assertEquals("tag 0 '2019-07-08T11:51:42-08:00'",
+        data = Util.cborEncodeDateTime(Timestamp.ofEpochMilli(c.getTimeInMillis()));
+        assertEquals("tag 0 '2019-07-08T19:51:42Z'", Util.cborPrettyPrint(data));
+        assertEquals("tag 0 '2019-07-08T19:51:42Z'",
                 Util.cborPrettyPrint(Util.cborEncodeDateTime(Util.cborDecodeDateTime(data))));
-        assertEquals(0, c.compareTo(Util.cborDecodeDateTime(data)));
+        assertEquals(c.getTimeInMillis(), Util.cborDecodeDateTime(data).toEpochMilli());
 
         c = new GregorianCalendar(TimeZone.getTimeZone("GMT+04:30"));
         c.clear();
         c.set(2019, Calendar.JULY, 8, 11, 51, 42);
-        data = Util.cborEncodeDateTime(c);
-        assertEquals("tag 0 '2019-07-08T11:51:42+04:30'", Util.cborPrettyPrint(data));
-        assertEquals("tag 0 '2019-07-08T11:51:42+04:30'",
+        data = Util.cborEncodeDateTime(Timestamp.ofEpochMilli(c.getTimeInMillis()));
+        assertEquals("tag 0 '2019-07-08T07:21:42Z'", Util.cborPrettyPrint(data));
+        assertEquals("tag 0 '2019-07-08T07:21:42Z'",
                 Util.cborPrettyPrint(Util.cborEncodeDateTime(Util.cborDecodeDateTime(data))));
-        assertEquals(0, c.compareTo(Util.cborDecodeDateTime(data)));
+        assertEquals(c.getTimeInMillis(), Util.cborDecodeDateTime(data).toEpochMilli());
     }
 
     @Test
@@ -322,42 +322,42 @@ public class UtilTest {
         c = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
         c.clear();
         c.set(2019, Calendar.JULY, 8, 11, 51, 42);
-        data = Util.cborEncodeDateTimeFor18013_5(c);
+        data = Util.cborEncodeDateTimeFor18013_5(Timestamp.ofEpochMilli(c.getTimeInMillis()));
         assertEquals("tag 0 '2019-07-08T11:51:42Z'", Util.cborPrettyPrint(data));
         assertEquals("tag 0 '2019-07-08T11:51:42Z'",
                 Util.cborPrettyPrint(
                         Util.cborEncodeDateTimeFor18013_5(Util.cborDecodeDateTime(data))));
-        assertEquals(0, c.compareTo(Util.cborDecodeDateTime(data)));
+        assertEquals(c.getTimeInMillis(), Util.cborDecodeDateTime(data).toEpochMilli());
 
         c = new GregorianCalendar(TimeZone.getTimeZone("GMT-04:00"));
         c.clear();
         c.set(2019, Calendar.JULY, 8, 11, 51, 42);
-        data = Util.cborEncodeDateTimeFor18013_5(c);
+        data = Util.cborEncodeDateTimeFor18013_5(Timestamp.ofEpochMilli(c.getTimeInMillis()));
         assertEquals("tag 0 '2019-07-08T15:51:42Z'", Util.cborPrettyPrint(data));
         assertEquals("tag 0 '2019-07-08T15:51:42Z'",
                 Util.cborPrettyPrint(
                         Util.cborEncodeDateTimeFor18013_5(Util.cborDecodeDateTime(data))));
-        assertEquals(0, c.compareTo(Util.cborDecodeDateTime(data)));
+        assertEquals(c.getTimeInMillis(), Util.cborDecodeDateTime(data).toEpochMilli());
 
         c = new GregorianCalendar(TimeZone.getTimeZone("GMT-08:00"));
         c.clear();
         c.set(2019, Calendar.JULY, 8, 11, 51, 42);
-        data = Util.cborEncodeDateTimeFor18013_5(c);
+        data = Util.cborEncodeDateTimeFor18013_5(Timestamp.ofEpochMilli(c.getTimeInMillis()));
         assertEquals("tag 0 '2019-07-08T19:51:42Z'", Util.cborPrettyPrint(data));
         assertEquals("tag 0 '2019-07-08T19:51:42Z'",
                 Util.cborPrettyPrint(
                         Util.cborEncodeDateTimeFor18013_5(Util.cborDecodeDateTime(data))));
-        assertEquals(0, c.compareTo(Util.cborDecodeDateTime(data)));
+        assertEquals(c.getTimeInMillis(), Util.cborDecodeDateTime(data).toEpochMilli());
 
         c = new GregorianCalendar(TimeZone.getTimeZone("GMT+04:30"));
         c.clear();
         c.set(2019, Calendar.JULY, 8, 11, 51, 42);
-        data = Util.cborEncodeDateTimeFor18013_5(c);
+        data = Util.cborEncodeDateTimeFor18013_5(Timestamp.ofEpochMilli(c.getTimeInMillis()));
         assertEquals("tag 0 '2019-07-08T07:21:42Z'", Util.cborPrettyPrint(data));
         assertEquals("tag 0 '2019-07-08T07:21:42Z'",
                 Util.cborPrettyPrint(
                         Util.cborEncodeDateTimeFor18013_5(Util.cborDecodeDateTime(data))));
-        assertEquals(0, c.compareTo(Util.cborDecodeDateTime(data)));
+        assertEquals(c.getTimeInMillis(), Util.cborDecodeDateTime(data).toEpochMilli());
     }
 
     @Test
@@ -366,11 +366,11 @@ public class UtilTest {
         c.clear();
         c.set(2019, Calendar.JULY, 8, 11, 51, 42);
         c.set(Calendar.MILLISECOND, 123);
-        byte[] data = Util.cborEncodeDateTime(c);
+        byte[] data = Util.cborEncodeDateTime(Timestamp.ofEpochMilli(c.getTimeInMillis()));
         assertEquals("tag 0 '2019-07-08T11:51:42.123Z'", Util.cborPrettyPrint(data));
         assertEquals("tag 0 '2019-07-08T11:51:42.123Z'",
                 Util.cborPrettyPrint(Util.cborEncodeDateTime(Util.cborDecodeDateTime(data))));
-        assertEquals(0, c.compareTo(Util.cborDecodeDateTime(data)));
+        assertEquals(c.getTimeInMillis(), Util.cborDecodeDateTime(data).toEpochMilli());
     }
 
     @Test
@@ -380,13 +380,15 @@ public class UtilTest {
         c.set(2019, Calendar.JULY, 8, 11, 51, 42);
         Calendar cWithoutMilliseconds = (Calendar) c.clone();
         c.set(Calendar.MILLISECOND, 123);
-        byte[] data = Util.cborEncodeDateTimeFor18013_5(c);
+        byte[] data = Util.cborEncodeDateTimeFor18013_5(
+                Timestamp.ofEpochMilli(c.getTimeInMillis()));
         assertEquals("tag 0 '2019-07-08T11:51:42Z'", Util.cborPrettyPrint(data));
         assertEquals("tag 0 '2019-07-08T11:51:42Z'",
                 Util.cborPrettyPrint(
                         Util.cborEncodeDateTimeFor18013_5(Util.cborDecodeDateTime(data))));
-        assertEquals(1, c.compareTo(Util.cborDecodeDateTime(data)));
-        assertEquals(0, cWithoutMilliseconds.compareTo(Util.cborDecodeDateTime(data)));
+        assertEquals(123, c.getTimeInMillis() - Util.cborDecodeDateTime(data).toEpochMilli());
+        assertEquals(cWithoutMilliseconds.getTimeInMillis(),
+                Util.cborDecodeDateTime(data).toEpochMilli());
     }
 
     @Test
@@ -431,7 +433,7 @@ public class UtilTest {
                 .add("2019-07-08T11:51:42.26-11:30")
                 .build());
         data = baos.toByteArray();
-        assertEquals("tag 0 '2019-07-08T11:51:42.260-11:30'",
+        assertEquals("tag 0 '2019-07-08T23:21:42.260Z'",
                 Util.cborPrettyPrint(Util.cborEncodeDateTime(Util.cborDecodeDateTime(data))));
     }
 

--- a/identity/src/main/java/com/android/identity/DeviceResponseParser.java
+++ b/identity/src/main/java/com/android/identity/DeviceResponseParser.java
@@ -16,7 +16,6 @@
 
 package com.android.identity;
 
-import android.icu.util.Calendar;
 import android.util.Log;
 import android.util.Pair;
 
@@ -464,10 +463,10 @@ public final class DeviceResponseParser {
         int mNumIssuerEntryDigestMatchFailures;
         boolean mDeviceSignedAuthenticated;
         boolean mIssuerSignedAuthenticated;
-        Calendar mValidityInfoSigned;
-        Calendar mValidityInfoValidFrom;
-        Calendar mValidityInfoValidUntil;
-        Calendar mValidityInfoExpectedUpdate;
+        Timestamp mValidityInfoSigned;
+        Timestamp mValidityInfoValidFrom;
+        Timestamp mValidityInfoValidUntil;
+        Timestamp mValidityInfoExpectedUpdate;
         PublicKey mDeviceKey;
         boolean mDeviceSignedAuthenticatedViaSignature;
 
@@ -483,41 +482,41 @@ public final class DeviceResponseParser {
         /**
          * Returns the <code>signed</code> date from the MSO.
          *
-         * @return a {@code Calendar} for when the MSO was signed.
+         * @return a {@code Timestamp} for when the MSO was signed.
          */
         public @NonNull
-        Calendar getValidityInfoSigned() {
+        Timestamp getValidityInfoSigned() {
             return mValidityInfoSigned;
         }
 
         /**
          * Returns the <code>validFrom</code> date from the MSO.
          *
-         * @return a {@code Calendar} for when the MSO is valid from.
+         * @return a {@code Timestamp} for when the MSO is valid from.
          */
         public @NonNull
-        Calendar getValidityInfoValidFrom() {
+        Timestamp getValidityInfoValidFrom() {
             return mValidityInfoValidFrom;
         }
 
         /**
          * Returns the <code>validUntil</code> date from the MSO.
          *
-         * @return a {@code Calendar} for when the MSO is valid until.
+         * @return a {@code Timestamp} for when the MSO is valid until.
          */
         public @NonNull
-        Calendar getValidityInfoValidUntil() {
+        Timestamp getValidityInfoValidUntil() {
             return mValidityInfoValidUntil;
         }
 
         /**
          * Returns the <code>expectedUpdate</code> date from the MSO.
          *
-         * @return a {@code Calendar} for when the MSO is valid until or {@code null} if
+         * @return a {@code Timestamp} for when the MSO is valid until or {@code null} if
          *   this isn't set.
          */
         public @Nullable
-        Calendar getValidityInfoExpectedUpdate() {
+        Timestamp getValidityInfoExpectedUpdate() {
             return mValidityInfoExpectedUpdate;
         }
 
@@ -693,14 +692,14 @@ public final class DeviceResponseParser {
 
         /**
          * Like {@link #getIssuerEntryData(String, String)} but returns the CBOR decoded
-         * as a {@link Calendar}.
+         * as a {@link Timestamp}.
          *
          * @param namespaceName the name of the namespace to get a data element value from.
          * @param name the name of the data element in the given namespace.
          * @return the decoded data.
          * @exception IllegalArgumentException if the CBOR data isn't in data or not the right type.
          */
-        public @NonNull Calendar getIssuerEntryDateTime(@NonNull String namespaceName,
+        public @NonNull Timestamp getIssuerEntryDateTime(@NonNull String namespaceName,
                 @NonNull String name) {
             byte[] value = getIssuerEntryData(namespaceName, name);
             return Util.cborDecodeDateTime(value);
@@ -840,14 +839,14 @@ public final class DeviceResponseParser {
 
         /**
          * Like {@link #getDeviceEntryData(String, String)} but returns the CBOR decoded
-         * as a {@link Calendar}.
+         * as a {@link Timestamp}.
          *
          * @param namespaceName the name of the namespace to get a data element value from.
          * @param name the name of the data element in the given namespace.
          * @return the decoded data.
          * @exception IllegalArgumentException if the CBOR data isn't in data or not the right type.
          */
-        public @NonNull Calendar getDeviceEntryDateTime(@NonNull String namespaceName,
+        public @NonNull Timestamp getDeviceEntryDateTime(@NonNull String namespaceName,
                 @NonNull String name) {
             byte[] value = getDeviceEntryData(namespaceName, name);
             return Util.cborDecodeDateTime(value);
@@ -899,22 +898,22 @@ public final class DeviceResponseParser {
                 return this;
             }
 
-            Builder setValidityInfoSigned(@NonNull Calendar value) {
+            Builder setValidityInfoSigned(@NonNull Timestamp value) {
                 mResult.mValidityInfoSigned = value;
                 return this;
             }
 
-            Builder setValidityInfoValidFrom(@NonNull Calendar value) {
+            Builder setValidityInfoValidFrom(@NonNull Timestamp value) {
                 mResult.mValidityInfoValidFrom = value;
                 return this;
             }
 
-            Builder setValidityInfoValidUntil(@NonNull Calendar value) {
+            Builder setValidityInfoValidUntil(@NonNull Timestamp value) {
                 mResult.mValidityInfoValidUntil = value;
                 return this;
             }
 
-            Builder setValidityInfoExpectedUpdate(@NonNull Calendar value) {
+            Builder setValidityInfoExpectedUpdate(@NonNull Timestamp value) {
                 mResult.mValidityInfoExpectedUpdate = value;
                 return this;
             }

--- a/identity/src/main/java/com/android/identity/PersonalizationData.java
+++ b/identity/src/main/java/com/android/identity/PersonalizationData.java
@@ -256,8 +256,9 @@ public class PersonalizationData {
         public @NonNull Builder putEntryCalendar(@NonNull String namespace, @NonNull String name,
                 @NonNull Collection<AccessControlProfileId> accessControlProfileIds,
                 @NonNull Calendar value) {
+            Timestamp time = Timestamp.ofEpochMilli(value.getTimeInMillis());
             return putEntry(namespace, name, accessControlProfileIds,
-                    Util.cborEncode(Util.cborBuildDateTime(value)));
+                    Util.cborEncode(Util.cborBuildDateTime(time)));
         }
 
         /**

--- a/identity/src/main/java/com/android/identity/ResultData.java
+++ b/identity/src/main/java/com/android/identity/ResultData.java
@@ -19,6 +19,8 @@ package com.android.identity;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 import android.icu.util.Calendar;
+import android.icu.util.GregorianCalendar;
+import android.icu.util.TimeZone;
 
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
@@ -318,7 +320,9 @@ public abstract class ResultData {
         if (value == null) {
             return null;
         }
-        return Util.cborDecodeDateTime(value);
+        Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        calendar.setTimeInMillis(Util.cborDecodeDateTime(value).toEpochMilli());
+        return calendar;
     }
 
     /**

--- a/identity/src/main/java/com/android/identity/Timestamp.java
+++ b/identity/src/main/java/com/android/identity/Timestamp.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Represents a single instant in time. Ideally, we'd use {@code java.time.Instant}, but we cannot
+ * do so until we move to API level 26.
+ */
+public final class Timestamp {
+    private final long mEpochMillis;
+
+    private Timestamp(long epochMillis) {
+        mEpochMillis = epochMillis;
+    }
+
+    /**
+     * @return a {@code Timestamp} representing the current time
+     */
+    @NonNull
+    public static Timestamp now() {
+        return new Timestamp(System.currentTimeMillis());
+    }
+
+    /**
+     * @return a {@code Timestamp} representing the given time
+     */
+    @NonNull
+    public static Timestamp ofEpochMilli(long epochMillis) {
+        return new Timestamp(epochMillis);
+    }
+
+    /**
+     * @return this represented as the number of milliseconds since midnight, January 1, 1970 UTC
+     */
+    public long toEpochMilli() {
+        return mEpochMillis;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "Timestamp{epochMillis=" + mEpochMillis + "}";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return (other instanceof Timestamp) && ((Timestamp) other).mEpochMillis == mEpochMillis;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(mEpochMillis);
+    }
+}

--- a/identity/src/main/java/com/android/identity/Utility.java
+++ b/identity/src/main/java/com/android/identity/Utility.java
@@ -269,10 +269,11 @@ public class Utility {
         c.setAvailableAuthenticationKeys(numAuthKeys, maxUsesPerKey);
         Collection<X509Certificate> authKeysNeedCert = c.getAuthKeysNeedingCertification();
 
-        Calendar signedDate = Calendar.getInstance();
-        Calendar validFromDate = Calendar.getInstance();
-        Calendar validToDate = Calendar.getInstance();
-        validToDate.add(Calendar.MONTH, 12);
+        final Timestamp signedDate = Timestamp.now();
+        final Timestamp validFromDate = Timestamp.now();
+        Calendar validToCalendar = Calendar.getInstance();
+        validToCalendar.add(Calendar.MONTH, 12);
+        final Timestamp validToDate = Timestamp.ofEpochMilli(validToCalendar.getTimeInMillis());
 
         for (X509Certificate authKeyCert : authKeysNeedCert) {
             PublicKey authKey = authKeyCert.getPublicKey();
@@ -377,7 +378,7 @@ public class Utility {
             byte[] staticAuthData = encodeStaticAuthData(
                     issuerSignedMapping, encodedIssuerAuth);
             c.storeStaticAuthenticationData(authKeyCert,
-                    validToDate,
+                    validToCalendar,
                     staticAuthData);
 
         } // for each authkey

--- a/identity/src/test/java/com/android/identity/TimestampTest.java
+++ b/identity/src/test/java/com/android/identity/TimestampTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class TimestampTest {
+
+    @Test
+    public void now() throws InterruptedException {
+        final Timestamp firstTime = Timestamp.now();
+        Thread.sleep(5);
+        final Timestamp secondTime = Timestamp.now();
+        assertTrue(firstTime.toEpochMilli() + " < " + secondTime.toEpochMilli(),
+            firstTime.toEpochMilli() < secondTime.toEpochMilli());
+    }
+
+    @Test
+    public void testEpochMilli() {
+        assertEquals(42, Timestamp.ofEpochMilli(42).toEpochMilli());
+        assertEquals(31415, Timestamp.ofEpochMilli(31415).toEpochMilli());
+    }
+
+    @Test
+    public void testToString() {
+      assertEquals(Timestamp.ofEpochMilli(0).toString(), "Timestamp{epochMillis=0}");
+      assertEquals(Timestamp.ofEpochMilli(101).toString(), "Timestamp{epochMillis=101}");
+    }
+
+    @Test
+    public void testEquals() {
+      assertEquals(Timestamp.ofEpochMilli(1234), Timestamp.ofEpochMilli(1234));
+      assertEquals(Timestamp.ofEpochMilli(8675309), Timestamp.ofEpochMilli(8675309));
+      assertNotEquals(Timestamp.ofEpochMilli(1234), Timestamp.ofEpochMilli(8675309));
+    }
+
+    @Test
+    public void testHashCode() {
+      assertEquals(Timestamp.ofEpochMilli(0).hashCode(), Timestamp.ofEpochMilli(0).hashCode());
+      assertEquals(Timestamp.ofEpochMilli(1).hashCode(), Timestamp.ofEpochMilli(1).hashCode());
+      assertNotEquals(Timestamp.ofEpochMilli(0).hashCode(), Timestamp.ofEpochMilli(1).hashCode());
+    }
+}


### PR DESCRIPTION
We want to allow this code to run on the JVM as well as in Android. This means
we need to avoid dependencies on Android-only classes like the android.icu.*
namespace.

The main use of android.icu is the Calendar class. Replace all internal uses with
a new Timestamp class. Public APIs still use Calendar for now, as we don't want
to break API compatibility just yet.