### PR TITLE
Ignore milliseconds on timestamps

### DIFF
--- a/identity/src/androidTest/java/com/android/identity/UtilTest.java
+++ b/identity/src/androidTest/java/com/android/identity/UtilTest.java
@@ -315,80 +315,17 @@ public class UtilTest {
     }
 
     @Test
-    public void cborCalendarFor18013_5() {
-        GregorianCalendar c;
-        byte[] data;
-
-        c = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
-        c.clear();
-        c.set(2019, Calendar.JULY, 8, 11, 51, 42);
-        data = Util.cborEncodeDateTimeFor18013_5(Timestamp.ofEpochMilli(c.getTimeInMillis()));
-        assertEquals("tag 0 '2019-07-08T11:51:42Z'", Util.cborPrettyPrint(data));
-        assertEquals("tag 0 '2019-07-08T11:51:42Z'",
-                Util.cborPrettyPrint(
-                        Util.cborEncodeDateTimeFor18013_5(Util.cborDecodeDateTime(data))));
-        assertEquals(c.getTimeInMillis(), Util.cborDecodeDateTime(data).toEpochMilli());
-
-        c = new GregorianCalendar(TimeZone.getTimeZone("GMT-04:00"));
-        c.clear();
-        c.set(2019, Calendar.JULY, 8, 11, 51, 42);
-        data = Util.cborEncodeDateTimeFor18013_5(Timestamp.ofEpochMilli(c.getTimeInMillis()));
-        assertEquals("tag 0 '2019-07-08T15:51:42Z'", Util.cborPrettyPrint(data));
-        assertEquals("tag 0 '2019-07-08T15:51:42Z'",
-                Util.cborPrettyPrint(
-                        Util.cborEncodeDateTimeFor18013_5(Util.cborDecodeDateTime(data))));
-        assertEquals(c.getTimeInMillis(), Util.cborDecodeDateTime(data).toEpochMilli());
-
-        c = new GregorianCalendar(TimeZone.getTimeZone("GMT-08:00"));
-        c.clear();
-        c.set(2019, Calendar.JULY, 8, 11, 51, 42);
-        data = Util.cborEncodeDateTimeFor18013_5(Timestamp.ofEpochMilli(c.getTimeInMillis()));
-        assertEquals("tag 0 '2019-07-08T19:51:42Z'", Util.cborPrettyPrint(data));
-        assertEquals("tag 0 '2019-07-08T19:51:42Z'",
-                Util.cborPrettyPrint(
-                        Util.cborEncodeDateTimeFor18013_5(Util.cborDecodeDateTime(data))));
-        assertEquals(c.getTimeInMillis(), Util.cborDecodeDateTime(data).toEpochMilli());
-
-        c = new GregorianCalendar(TimeZone.getTimeZone("GMT+04:30"));
-        c.clear();
-        c.set(2019, Calendar.JULY, 8, 11, 51, 42);
-        data = Util.cborEncodeDateTimeFor18013_5(Timestamp.ofEpochMilli(c.getTimeInMillis()));
-        assertEquals("tag 0 '2019-07-08T07:21:42Z'", Util.cborPrettyPrint(data));
-        assertEquals("tag 0 '2019-07-08T07:21:42Z'",
-                Util.cborPrettyPrint(
-                        Util.cborEncodeDateTimeFor18013_5(Util.cborDecodeDateTime(data))));
-        assertEquals(c.getTimeInMillis(), Util.cborDecodeDateTime(data).toEpochMilli());
-    }
-
-    @Test
     public void cborCalendarMilliseconds() throws CborException {
         Calendar c = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
         c.clear();
         c.set(2019, Calendar.JULY, 8, 11, 51, 42);
         c.set(Calendar.MILLISECOND, 123);
+        // Even if we see a time with fractional seconds, we ignore them
         byte[] data = Util.cborEncodeDateTime(Timestamp.ofEpochMilli(c.getTimeInMillis()));
-        assertEquals("tag 0 '2019-07-08T11:51:42.123Z'", Util.cborPrettyPrint(data));
-        assertEquals("tag 0 '2019-07-08T11:51:42.123Z'",
-                Util.cborPrettyPrint(Util.cborEncodeDateTime(Util.cborDecodeDateTime(data))));
-        assertEquals(c.getTimeInMillis(), Util.cborDecodeDateTime(data).toEpochMilli());
-    }
-
-    @Test
-    public void cborCalendarMillisecondsFor18013_5() throws CborException {
-        Calendar c = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
-        c.clear();
-        c.set(2019, Calendar.JULY, 8, 11, 51, 42);
-        Calendar cWithoutMilliseconds = (Calendar) c.clone();
-        c.set(Calendar.MILLISECOND, 123);
-        byte[] data = Util.cborEncodeDateTimeFor18013_5(
-                Timestamp.ofEpochMilli(c.getTimeInMillis()));
         assertEquals("tag 0 '2019-07-08T11:51:42Z'", Util.cborPrettyPrint(data));
         assertEquals("tag 0 '2019-07-08T11:51:42Z'",
-                Util.cborPrettyPrint(
-                        Util.cborEncodeDateTimeFor18013_5(Util.cborDecodeDateTime(data))));
-        assertEquals(123, c.getTimeInMillis() - Util.cborDecodeDateTime(data).toEpochMilli());
-        assertEquals(cWithoutMilliseconds.getTimeInMillis(),
-                Util.cborDecodeDateTime(data).toEpochMilli());
+                Util.cborPrettyPrint(Util.cborEncodeDateTime(Util.cborDecodeDateTime(data))));
+        assertEquals(c.getTimeInMillis() - 123, Util.cborDecodeDateTime(data).toEpochMilli());
     }
 
     @Test
@@ -403,7 +340,7 @@ public class UtilTest {
                 .add("2019-07-08T11:51:42.25Z")
                 .build());
         data = baos.toByteArray();
-        assertEquals("tag 0 '2019-07-08T11:51:42.250Z'",
+        assertEquals("tag 0 '2019-07-08T11:51:42Z'",
                 Util.cborPrettyPrint(Util.cborEncodeDateTime(Util.cborDecodeDateTime(data))));
 
         // milliseconds set to 0
@@ -423,7 +360,7 @@ public class UtilTest {
                 .add("2019-07-08T11:51:42.9876Z")
                 .build());
         data = baos.toByteArray();
-        assertEquals("tag 0 '2019-07-08T11:51:42.987Z'",
+        assertEquals("tag 0 '2019-07-08T11:51:42Z'",
                 Util.cborPrettyPrint(Util.cborEncodeDateTime(Util.cborDecodeDateTime(data))));
 
         // milliseconds and timezone
@@ -433,7 +370,7 @@ public class UtilTest {
                 .add("2019-07-08T11:51:42.26-11:30")
                 .build());
         data = baos.toByteArray();
-        assertEquals("tag 0 '2019-07-08T23:21:42.260Z'",
+        assertEquals("tag 0 '2019-07-08T23:21:42Z'",
                 Util.cborPrettyPrint(Util.cborEncodeDateTime(Util.cborDecodeDateTime(data))));
     }
 

--- a/identity/src/main/java/com/android/identity/Util.java
+++ b/identity/src/main/java/com/android/identity/Util.java
@@ -235,31 +235,12 @@ class Util {
         return cborEncode(cborBuildDateTime(timestamp));
     }
 
-    static @NonNull
-    byte[] cborEncodeDateTimeFor18013_5(@NonNull Timestamp timestamp) {
-        return cborEncode(cborBuildDateTimeFor18013_5(timestamp));
-    }
-
     /**
      * Returns #6.0(tstr) where tstr is the ISO 8601 encoding of the given point in time.
      * Only supports UTC times.
      */
     static @NonNull
     DataItem cborBuildDateTime(@NonNull Timestamp timestamp) {
-        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.US);
-        if (timestamp.toEpochMilli() % 1000 != 0) {
-            df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US);
-        }
-        df.setTimeZone(TimeZone.getTimeZone("UTC"));
-        Date val = new Date(timestamp.toEpochMilli());
-        String dateString = df.format(val);
-        DataItem dataItem = new UnicodeString(dateString);
-        dataItem.setTag(0);
-        return dataItem;
-    }
-
-    static @NonNull
-    DataItem cborBuildDateTimeFor18013_5(@NonNull Timestamp timestamp) {
         SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.US);
         df.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date val = new Date(timestamp.toEpochMilli());
@@ -329,20 +310,13 @@ class Util {
             parsedTz = TimeZone.getTimeZone("GMT" + timeZoneSubstr);
         }
 
-        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.US);
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US);
         df.setTimeZone(parsedTz);
         Date date = null;
         try {
             date = df.parse(dateString);
         } catch (ParseException e) {
-            // Try again, this time without the milliseconds
-            df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US);
-            df.setTimeZone(parsedTz);
-            try {
-                date = df.parse(dateString);
-            } catch (ParseException e2) {
-                throw new RuntimeException("Error parsing string", e2);
-            }
+            throw new RuntimeException("Error parsing string", e);
         }
 
         return Timestamp.ofEpochMilli(date.getTime());

--- a/identity/src/main/java/com/android/identity/Utility.java
+++ b/identity/src/main/java/com/android/identity/Utility.java
@@ -346,11 +346,9 @@ public class Utility {
                     .put(new UnicodeString("valueDigests"), vdBuilder.build().get(0))
                     .put("docType", docType)
                     .putMap("validityInfo")
-                    .put(new UnicodeString("signed"), Util.cborBuildDateTimeFor18013_5(signedDate))
-                    .put(new UnicodeString("validFrom"),
-                            Util.cborBuildDateTimeFor18013_5(validFromDate))
-                    .put(new UnicodeString("validUntil"),
-                            Util.cborBuildDateTimeFor18013_5(validToDate))
+                    .put(new UnicodeString("signed"), Util.cborBuildDateTime(signedDate))
+                    .put(new UnicodeString("validFrom"), Util.cborBuildDateTime(validFromDate))
+                    .put(new UnicodeString("validUntil"), Util.cborBuildDateTime(validToDate))
                     .end()
                     .putMap("deviceKeyInfo")
                     .put(new UnicodeString("deviceKey"), Util.cborBuildCoseKey(authKey))


### PR DESCRIPTION
18013-5 says: "The timestamps in the ValidityInfo structure shall not
use fractions of seconds"

Additionally, OpenJDK and Android differ on how they deal with decimal
seconds values that are not three digits. Instead of dealing with possible
inconsistency, just ignore fractions of a second.