### PR TITLE
Minor fixes related to NFC engagement.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/util/PreferencesHelper.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/PreferencesHelper.kt
@@ -48,7 +48,7 @@ object PreferencesHelper {
 
     fun isBleDataRetrievalPeripheralModeEnabled(context: Context): Boolean {
         return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
-            BLE_DATA_RETRIEVAL_PERIPHERAL_MODE, true
+            BLE_DATA_RETRIEVAL_PERIPHERAL_MODE, false
         )
     }
 

--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/DeviceEngagementFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/DeviceEngagementFragment.kt
@@ -100,7 +100,7 @@ class DeviceEngagementFragment : Fragment() {
                         requireContext(), "Error invalid callback connected",
                         Toast.LENGTH_SHORT
                     ).show()
-                    findNavController().navigate(R.id.action_Transfer_to_RequestOptions)
+                    findNavController().navigate(R.id.action_ScanDeviceEngagement_to_RequestOptions)
                 }
                 TransferStatus.RESPONSE -> {
                     Log.d(LOG_TAG, "Device response received")
@@ -108,7 +108,7 @@ class DeviceEngagementFragment : Fragment() {
                         requireContext(), "Error invalid callback response",
                         Toast.LENGTH_SHORT
                     ).show()
-                    findNavController().navigate(R.id.action_Transfer_to_RequestOptions)
+                    findNavController().navigate(R.id.action_ScanDeviceEngagement_to_RequestOptions)
                 }
                 TransferStatus.DISCONNECTED -> {
                     Log.d(LOG_TAG, "Device disconnected")
@@ -116,7 +116,7 @@ class DeviceEngagementFragment : Fragment() {
                         requireContext(), "Device disconnected",
                         Toast.LENGTH_SHORT
                     ).show()
-                    findNavController().navigate(R.id.action_Transfer_to_RequestOptions)
+                    findNavController().navigate(R.id.action_ScanDeviceEngagement_to_RequestOptions)
                 }
                 TransferStatus.ERROR -> {
                     Log.d(LOG_TAG, "Error received")
@@ -124,7 +124,7 @@ class DeviceEngagementFragment : Fragment() {
                         requireContext(), "Error connecting to holder",
                         Toast.LENGTH_SHORT
                     ).show()
-                    findNavController().navigate(R.id.action_Transfer_to_RequestOptions)
+                    findNavController().navigate(R.id.action_ScanDeviceEngagement_to_RequestOptions)
                 }
             }
         })

--- a/appverifier/src/main/java/com/android/mdl/appreader/transfer/TransferManager.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/transfer/TransferManager.kt
@@ -72,11 +72,7 @@ class TransferManager private constructor(private val context: Context) {
     fun setNdefDeviceEngagement(adapter: NfcAdapter, activity: Activity) {
         adapter.enableReaderMode(
             activity, readerModeListener,
-            NfcAdapter.FLAG_READER_NFC_A
-                    + NfcAdapter.FLAG_READER_NFC_B
-                    + NfcAdapter.FLAG_READER_NFC_F
-                    + NfcAdapter.FLAG_READER_NFC_V
-                    + NfcAdapter.FLAG_READER_NFC_BARCODE,
+            NfcAdapter.FLAG_READER_NFC_A + NfcAdapter.FLAG_READER_NFC_B,
             null)
         verification?.startListening()
     }

--- a/identity/src/main/java/com/android/identity/PresentationHelper.java
+++ b/identity/src/main/java/com/android/identity/PresentationHelper.java
@@ -124,11 +124,11 @@ public class PresentationHelper {
     private static final byte[] CAPABILITY_FILE_CONTENTS = new byte[]{
             (byte) 0x00, (byte) 0x0f,  // size of capability container '00 0F' = 15 bytes
             (byte) 0x20,               // mapping version v2.0
-            (byte) 0x7f, (byte) 0xFf,  // maximum response data length '7F FF'
-            (byte) 0x7f, (byte) 0xFf,  // maximum command data length '7F FF'
+            (byte) 0x7f, (byte) 0xff,  // maximum response data length '7F FF'
+            (byte) 0x7f, (byte) 0xff,  // maximum command data length '7F FF'
             (byte) 0x04, (byte) 0x06,  // NDEF File Control TLV
             (byte) 0xe1, (byte) 0x04,  // NDEF file identifier 'E1 04'
-            (byte) 0xff, (byte) 0xfe,  // maximum NDEF file size 'FF FE'
+            (byte) 0x7f, (byte) 0xff,  // maximum NDEF file size '7F FF'
             (byte) 0x00,               // file read access condition (allow read)
             (byte) 0xff                // file write access condition (do not write)
     };
@@ -1100,9 +1100,13 @@ public class PresentationHelper {
      * See {@link #setUseTransportSpecificSessionTermination(boolean)} for more information about
      * what transport specific session termination is.
      *
-     * @return <code>true</code> if transport specific termination is available.
+     * @return <code>true</code> if transport specific termination is available, <code>false</code>
+     *   if not or if not connected.
      */
     public boolean isTransportSpecificTerminationSupported() {
+        if (mActiveTransport == null) {
+            return false;
+        }
         return mActiveTransport.supportsTransportSpecificTerminationMessage();
     }
 

--- a/identity/src/main/java/com/android/identity/VerificationHelper.java
+++ b/identity/src/main/java/com/android/identity/VerificationHelper.java
@@ -696,17 +696,14 @@ public class VerificationHelper {
      * {@link #isTransportSpecificTerminationSupported()} method can be used to determine whether
      * it's available for the current transport.
      *
+     * <p>If {@link #isTransportSpecificTerminationSupported()} indicates that this is not
+     * available for the current transport this is a noop.
+     *
      * @param useTransportSpecificSessionTermination Whether to use transport-specific session
      *                                               termination.
-     * @throws IllegalStateException if {@link #isTransportSpecificTerminationSupported()}
-     *   indicates that this is not available for the current transport.
      */
     public void setUseTransportSpecificSessionTermination(
             boolean useTransportSpecificSessionTermination) {
-        if (!isTransportSpecificTerminationSupported()) {
-            throw new IllegalStateException("Transport-specific session termination is not "
-                    + "supported");
-        }
         mUseTransportSpecificSessionTermination = useTransportSpecificSessionTermination;
     }
 
@@ -716,9 +713,13 @@ public class VerificationHelper {
      * See {@link #setUseTransportSpecificSessionTermination(boolean)} for more information about
      * what transport specific session termination is.
      *
-     * @return <code>true</code> if transport specific termination is available.
+     * @return <code>true</code> if transport specific termination is available, <code>false</code>
+     *   if not or if not connected.
      */
     public boolean isTransportSpecificTerminationSupported() {
+        if (mDataTransport == null) {
+            return false;
+        }
         return mDataTransport.supportsTransportSpecificTerminationMessage();
     }
 


### PR DESCRIPTION
- For the reader, we only need to poll for Nfc-A and Nfc-B technology.

- For the capability file, we incorrectly conveyed that max NDEF file
  size is 0xfffe but the standard says it can be no bigger than 0x7fff
  and values 0x8000 through 0xffff are RFU.

- Use the right navigation link values in reader for error conditions.

- In both PresentationHelper and VerificationHelper, change semantics
  of methods related to session-termination so they are always safe to
  call and never will throw exceptions.

- In holder, the preference UI indicates that mdoc BLE central client
  mode is the only available transport but the preference object
  indicates that both mdoc BLE central client mode and mdoc BLE
  peripheral server mode is available. Fix the latter so only mdoc BLE
  central client mode is available.

Bug: 240261780
Test: Manually tested.
