### PR TITLE
NFC: Handle extended length encoding for READ_BINARY command

### DIFF
--- a/identity/src/main/java/com/android/identity/PresentationHelper.java
+++ b/identity/src/main/java/com/android/identity/PresentationHelper.java
@@ -42,6 +42,7 @@ import java.security.KeyPair;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.Executor;
@@ -917,13 +918,21 @@ public class PresentationHelper {
 
     private @NonNull
     byte[] nfcEngagementHandleReadBinary(@NonNull byte[] apdu) {
-        mLog.session("in nfcEngagementHandleReadBinary");
         if (apdu.length < 5) {
             return STATUS_WORD_FILE_NOT_FOUND;
         }
         byte[] contents = mSelectedNfcFile;
         int offset = (apdu[2] & 0xff) * 256 + (apdu[3] & 0xff);
         int size = apdu[4] & 0xff;
+        if (size == 0) {
+            // Handle Extended Length encoding
+            if (apdu.length < 7) {
+                return STATUS_WORD_FILE_NOT_FOUND;
+            }
+            size = (apdu[5] & 0xff) * 256;
+            size += apdu[6] & 0xff;
+        }
+        mLog.info(String.format(Locale.US, "nfcEngagementHandleReadBinary: offset=%d size=%d", offset, size));
 
         if (offset >= contents.length) {
             return STATUS_WORD_WRONG_PARAMETERS;


### PR DESCRIPTION
Starting with Android 12, the NFC tag reader code will use extended
length encoding if the host says it supports it. We didn't properly
handle this when processing a READ_BINARY command so NFC engagement
didn't work if the mDL reader was running on Android 12 or later.

Bug: 240261780
Test: Manually tested, NFC engagement with mDL reader on Android 12 now works.
