### PR TITLE
BLE: Specify that GATT connections are expected to only be to LE devices

### DIFF
--- a/identity/src/main/java/com/android/identity/GattClient.java
+++ b/identity/src/main/java/com/android/identity/GattClient.java
@@ -92,7 +92,7 @@ class GattClient extends BluetoothGattCallback {
         byte[] salt = new byte[]{};
         mIdentValue = Util.computeHkdf("HmacSha256", ikm, salt, info, 16);
         try {
-            mGatt = device.connectGatt(mContext, false, this);
+            mGatt = device.connectGatt(mContext, false, this, BluetoothDevice.TRANSPORT_LE);
         } catch (SecurityException e) {
             reportError(e);
         }


### PR DESCRIPTION
Without this, the stack will also try to connect to Bluetooth Classic
devices which includes a bit of complexity and is a source of
potential bugs.
