### PR TITLE
Use StrongBox implementation of Android KeyStore when available.

### DIFF
--- a/identity/src/main/java/com/android/identity/CredentialData.java
+++ b/identity/src/main/java/com/android/identity/CredentialData.java
@@ -20,7 +20,9 @@ import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.icu.util.Calendar;
+import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import android.security.keystore.UserNotAuthenticatedException;
@@ -1299,8 +1301,17 @@ class CredentialData {
                             aliasForAuthKey,
                             KeyProperties.PURPOSE_SIGN | KeyProperties.PURPOSE_VERIFY)
                             .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512);
+
+                    boolean isStrongBoxBacked = false;
+                    PackageManager pm = mContext.getPackageManager();
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P &&
+                            pm.hasSystemFeature(PackageManager.FEATURE_STRONGBOX_KEYSTORE)) {
+                        isStrongBoxBacked = true;
+                        builder.setIsStrongBoxBacked(true);
+                    }
                     kpg.initialize(builder.build());
                     kpg.generateKeyPair();
+                    Log.i(TAG, "AuthKey created, strongBoxBacked=" + isStrongBoxBacked);
 
                     X509Certificate certificate = generateAuthenticationKeyCert(
                             aliasForAuthKey, mCredentialKeyAlias, mProofOfProvisioningSha256);

--- a/identity/src/main/java/com/android/identity/Utility.java
+++ b/identity/src/main/java/com/android/identity/Utility.java
@@ -29,6 +29,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 
@@ -268,8 +270,18 @@ public class Utility {
         store.deleteCredentialByName(credentialName);
         WritableIdentityCredential wc = store.createCredential(credentialName, docType);
 
-        // We don't care about the returned proof of provisioning nor the certificate chain.
-        wc.getCredentialKeyCertificateChain(provisioningChallenge);
+        Collection<X509Certificate> certChain = wc.getCredentialKeyCertificateChain(provisioningChallenge);
+        Log.i(TAG, String.format(Locale.US, "Cert chain for self-signed credential '%s' has %d elements",
+                credentialName, certChain.size()));
+        int certNum = 0;
+        for (X509Certificate certificate : certChain) {
+            try {
+                Log.i(TAG, String.format(Locale.US, "Certificate %d: %s",
+                        certNum++, Util.toHex(certificate.getEncoded())));
+            } catch (CertificateEncodingException e) {
+                e.printStackTrace();
+            }
+        }
         wc.personalize(personalizationData);
 
         IdentityCredential c = store.getCredentialByName(credentialName,


### PR DESCRIPTION
Android KeyStore StrongBox - see Android CDD section 9.11.2 - allows
app developers to store cryptographic keys in a dedicated secure
processor.  Since this provides some additional protections of keys,
use it when available for CredentialKey and AuthKeys.

Also modify Utility.provisionSelfSignedCredential() to log the
certificate chain for inspection.

Bug: None
Test: Manually tested on Pixel devices.
