### PR TITLE
Fix crash on Android 11.

### DIFF
--- a/identity/src/main/java/com/android/identity/HardwareIdentityCredentialStore.java
+++ b/identity/src/main/java/com/android/identity/HardwareIdentityCredentialStore.java
@@ -149,7 +149,10 @@ class HardwareIdentityCredentialStore extends IdentityCredentialStore {
         } else if (pm.hasSystemFeature(featureName)) {
             return 202009;
         }
-        throw new IllegalStateException(String.format(Locale.US, "Feature %s not found"));
+        // Note that FEATURE_IDENTITY_CREDENTIAL_HARDWARE* didn't exist until Android 12 so it's
+        // possible to have the API implemented but no feature flag. In this case, just return
+        // the feature version for Android 11.
+        return 202009;
     }
 
     @Override


### PR DESCRIPTION
On Android 11 there is no feature flag so if the API is available, return
feature version 202009.

Bug: None
Test: Manually tested holder app on Android 11
