### PR TITLE
L2CAP: Fix threading issues, progress callbacks, and enable L2CAP by default

### DIFF
--- a/identity/src/main/java/com/android/identity/DataTransportBle.java
+++ b/identity/src/main/java/com/android/identity/DataTransportBle.java
@@ -57,6 +57,9 @@ abstract class DataTransportBle extends DataTransport {
     // Indicates to use L2CAP for BLE transfer by default
     protected boolean mUseL2CAPIfAvailable = false;
 
+    // The size of buffer for read() calls when using L2CAP sockets.
+    static final int L2CAP_BUF_SIZE = 4096;
+
     public DataTransportBle(
             @NonNull Context context, @LoggingFlag int loggingFlags) {
         super(context);

--- a/identity/src/main/java/com/android/identity/GattClient.java
+++ b/identity/src/main/java/com/android/identity/GattClient.java
@@ -275,7 +275,7 @@ class GattClient extends BluetoothGattCallback {
                         + characteristic.getUuid() + ", L2CAP not supported"));
                 return;
             }
-            mL2CAPClient = new L2CAPClient(new L2CAPClient.Listener() {
+            mL2CAPClient = new L2CAPClient(mContext, new L2CAPClient.Listener() {
                 @Override
                 public void onPeerConnected() {
                     reportPeerConnected();
@@ -294,6 +294,11 @@ class GattClient extends BluetoothGattCallback {
                 @Override
                 public void onError(@NonNull Throwable error) {
                     reportError(error);
+                }
+
+                @Override
+                public void onMessageSendProgress(long progress, long max) {
+                    reportMessageSendProgress(progress, max);
                 }
             }, mLog.getLoggingFlags());
 
@@ -521,8 +526,8 @@ class GattClient extends BluetoothGattCallback {
             Util.dumpHex(TAG, "sendMessage", data);
         }
 
-        // Use socket for L2CAP if it is connected
-        if (mL2CAPClient != null && mL2CAPClient.isConnected()) {
+        // Use socket for L2CAP if applicable
+        if (mL2CAPClient != null) {
             mL2CAPClient.sendMessage(data);
             return;
         }
@@ -623,8 +628,5 @@ class GattClient extends BluetoothGattCallback {
         void onError(@NonNull Throwable error);
 
         void onMessageSendProgress(long progress, long max);
-
     }
-
-
 }

--- a/identity/src/main/java/com/android/identity/L2CAPClient.java
+++ b/identity/src/main/java/com/android/identity/L2CAPClient.java
@@ -16,8 +16,11 @@
 
 package com.android.identity;
 
+import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothManager;
 import android.bluetooth.BluetoothSocket;
+import android.content.Context;
 import android.os.Build;
 import android.util.Log;
 
@@ -29,28 +32,28 @@ import com.android.identity.Constants.LoggingFlag;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
+import java.util.Locale;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
 
 class L2CAPClient {
     private static final String TAG = "L2CAPClient";
-
+    private final Context mContext;
     Listener mListener;
     final Util.Logger mLog;
 
     private BluetoothSocket mSocket;
     private BlockingQueue<byte[]> mWriterQueue = new LinkedTransferQueue<>();
-    private BlockingQueue<byte[]> mMessageReceivedQueue = new LinkedTransferQueue<>();
     Thread mWritingThread;
-    Thread mReportReceivedMessageThread;
 
     private boolean mInhibitCallbacks = false;
 
-    L2CAPClient(@Nullable Listener listener, @LoggingFlag int loggingFlags) {
+    L2CAPClient(Context context, @Nullable Listener listener, @LoggingFlag int loggingFlags) {
+        mContext = context;
         mListener = listener;
         mLog = new Util.Logger(TAG, loggingFlags);
     }
@@ -63,14 +66,6 @@ class L2CAPClient {
                 mWritingThread.join();
             } catch (InterruptedException e) {
                 Log.e(TAG, "Caught exception while joining writing thread: " + e);
-            }
-        }
-        if (mReportReceivedMessageThread != null) {
-            mMessageReceivedQueue.add(new byte[0]);
-            try {
-                mReportReceivedMessageThread.join();
-            } catch (InterruptedException e) {
-                Log.e(TAG, "Caught exception while joining report message received thread: " + e);
             }
         }
         try {
@@ -100,35 +95,47 @@ class L2CAPClient {
         int psm = ByteBuffer.wrap(psmSized).getInt();
         mLog.transport("Received psmValue: " + Util.toHex(psmValue) + " psm: " + psm);
 
-        try {
-            // Using insecure L2CAP allows the app to use L2CAP friction less, otherwise
-            // Android will require bluetooth pairing with other device showing the pairing code
-            mSocket = bluetoothDevice.createInsecureL2capChannel(psm);
-            mSocket.connect();
-            if (isConnected()) {
-                mLog.transport("Connected using L2CAP on PSM: " + psm);
-                mWritingThread = new Thread(this::writeToSocket);
-                mWritingThread.start();
-
-                Thread readingThread = new Thread(this::readFromSocket);
-                readingThread.start();
-
-                mReportReceivedMessageThread = new Thread(this::reportMessageReceived);
-                mReportReceivedMessageThread.start();
-
-                reportPeerConnected();
-            } else {
-                reportError(new Error("Unable to connect L2CAP socket"));
-            }
-        } catch (IOException e) {
-            Log.e(TAG, "Error connecting to socket L2CAP " + e.getMessage(), e);
-            reportError(new Error("Error connecting to socket L2CAP", e));
+        // As per https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#cancelDiscovery()
+        // we should cancel any ongoing discovery since it interfere with the connection process
+        BluetoothAdapter adapter =
+                ((BluetoothManager) mContext.getSystemService(BluetoothManager.class)).getAdapter();
+        if (!adapter.cancelDiscovery()) {
+            reportError(new Error("Error canceling BluetoothDiscovery"));
+            return;
         }
 
+        Thread connectThread = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    // Using insecure L2CAP allows the app to use L2CAP frictionless, otherwise
+                    // Android will require bluetooth pairing with other device showing the pairing code
+                    mSocket = bluetoothDevice.createInsecureL2capChannel(psm);
+                    mLog.transport("Connecting using L2CAP on PSM: " + psm);
+                    mSocket.connect();
+                } catch (IOException e) {
+                    Log.e(TAG, "Error connecting to socket L2CAP " + e.getMessage(), e);
+                    reportError(new Error("Error connecting to socket L2CAP", e));
+                }
+
+                mLog.transport("Connected using L2CAP");
+
+                // Let the app know we're connected.
+                reportPeerConnected();
+
+                // Start writing thread
+                mWritingThread = new Thread(L2CAPClient.this::writeToSocket);
+                mWritingThread.start();
+
+                // Reuse this thread for reading
+                readFromSocket();
+            }
+        };
+        connectThread.start();
     }
 
-    private void writeToSocket() {
-        while (isConnected()) {
+    void writeToSocket() {
+        while (true) {
             byte[] messageToSend;
             try {
                 messageToSend = mWriterQueue.poll(1000, TimeUnit.MILLISECONDS);
@@ -136,8 +143,8 @@ class L2CAPClient {
                     continue;
                 }
                 if (messageToSend.length == 0) {
-                    mLog.transportVerbose("Empty message, shutting down writing message");
-                    break;
+                    mLog.transport("Empty message, exiting writer thread");
+                    return;
                 }
             } catch (InterruptedException e) {
                 continue;
@@ -147,41 +154,54 @@ class L2CAPClient {
                 OutputStream os = mSocket.getOutputStream();
                 os.write(messageToSend);
                 os.flush();
-
+                reportMessageSendProgress(messageToSend.length, messageToSend.length);
+                mLog.transport(String.format(Locale.US, "Wrote CBOR data item of size %d bytes",
+                        messageToSend.length));
             } catch (IOException e) {
                 Log.e(TAG, "Error writing message on L2CAP socket", e);
                 reportError(new Error("Error writing message on L2CAP socket", e));
                 return;
+            }
+            // TODO: If we don't do this we run into problems when sending a session termination
+            //   message and then immediately closing the connection, as is usual.
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Log.e(TAG, "Error sleeping after writing", e);
             }
         }
     }
 
     private void readFromSocket() {
         mLog.transport("Start reading socket input");
-        // Use the max size as buffer for L2CAP socket
-        byte[] mmBuffer = new byte[mSocket.getMaxReceivePacketSize()];
-        ByteArrayOutputStream incomingMessage = new ByteArrayOutputStream();
+        ByteArrayOutputStream pendingDataBaos = new ByteArrayOutputStream();
+
         // Keep listening to the InputStream until an exception occurs.
-        while (isConnected()) {
+        InputStream inputStream = null;
+        try {
+            inputStream = mSocket.getInputStream();
+        } catch (IOException e) {
+            reportError(new Error("Error on listening input stream from socket L2CAP", e));
+            return;
+        }
+        while (true) {
+            byte[] buf = new byte[DataTransportBle.L2CAP_BUF_SIZE];
             try {
-                // Read from the InputStream.
-                int numBytes = mSocket.getInputStream().read(mmBuffer);
-                // Returns -1 once end of the stream has been reached.
-                if (numBytes == -1) {
+                int numBytesRead = inputStream.read(buf);
+                if (numBytesRead == -1) {
                     mLog.transport("End of stream reading from socket");
                     reportPeerDisconnected();
                     break;
                 }
-                if (mLog.isTransportVerboseEnabled()) {
-                    Util.dumpHex(TAG, "Chunk received by socket: (" + numBytes + ")", Arrays.copyOf(mmBuffer, numBytes));
+                pendingDataBaos.write(buf, 0, numBytesRead);
+
+                byte[] dataItemBytes = Util.cborExtractFirstDataItem(pendingDataBaos);
+                if (dataItemBytes == null) {
+                    continue;
                 }
-                // Report message received.
-                incomingMessage.write(mmBuffer, 0, numBytes);
-                // Add cbor item to the queue that will be reported as message received
-                byte[] data = Util.splitCborItemsIntoQueue(incomingMessage.toByteArray(), mMessageReceivedQueue);
-                // keep any remaining data to combine with the next chunk
-                incomingMessage.reset();
-                incomingMessage.write(data);
+                mLog.transport(String.format(Locale.US, "Received CBOR data item of size %d bytes",
+                        dataItemBytes.length));
+                reportMessageReceived(dataItemBytes);
             } catch (IOException e) {
                 reportError(new Error("Error on listening input stream from socket L2CAP", e));
                 break;
@@ -190,6 +210,7 @@ class L2CAPClient {
     }
 
     void sendMessage(@NonNull byte[] data) {
+        reportMessageSendProgress(0, data.length);
         mWriterQueue.add(data);
     }
 
@@ -205,23 +226,9 @@ class L2CAPClient {
         }
     }
 
-    void reportMessageReceived() {
-        while (mListener != null && !mInhibitCallbacks) {
-            byte[] messageReceived;
-            try {
-                messageReceived = mMessageReceivedQueue.poll(1000, TimeUnit.MILLISECONDS);
-                if (messageReceived == null) {
-                    continue;
-                }
-                if (messageReceived.length == 0) {
-                    mLog.transportVerbose("Empty message, shutting down message received");
-                    break;
-                }
-            } catch (InterruptedException e) {
-                continue;
-            }
-            mLog.transport("Data size from message received: (" + messageReceived.length + " bytes)");
-            mListener.onMessageReceived(messageReceived);
+    void reportMessageReceived(@NonNull byte[] data) {
+        if (mListener != null && !mInhibitCallbacks) {
+            mListener.onMessageReceived(data);
         }
     }
 
@@ -231,8 +238,10 @@ class L2CAPClient {
         }
     }
 
-    public boolean isConnected() {
-        return mSocket != null && mSocket.isConnected();
+    void reportMessageSendProgress(long progress, long max) {
+        if (mListener != null && !mInhibitCallbacks) {
+            mListener.onMessageSendProgress(progress, max);
+        }
     }
 
     interface Listener {
@@ -243,5 +252,7 @@ class L2CAPClient {
         void onMessageReceived(@NonNull byte[] data);
 
         void onError(@NonNull Throwable error);
+
+        void onMessageSendProgress(long progress, long max);
     }
 }

--- a/identity/src/main/java/com/android/identity/L2CAPServer.java
+++ b/identity/src/main/java/com/android/identity/L2CAPServer.java
@@ -30,10 +30,10 @@ import com.android.identity.Constants.LoggingFlag;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.Queue;
+import java.util.Locale;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
@@ -47,9 +47,7 @@ class L2CAPServer {
     private BluetoothServerSocket mServerSocket;
     private BluetoothSocket mSocket;
     private BlockingQueue<byte[]> mWriterQueue = new LinkedTransferQueue<>();
-    private BlockingQueue<byte[]> mMessageReceivedQueue = new LinkedTransferQueue<>();
     Thread mWritingThread;
-    Thread mReportReceivedMessageThread;
 
     L2CAPServer(@Nullable L2CAPServer.Listener listener, @LoggingFlag int loggingFlags) {
         mListener = listener;
@@ -57,139 +55,38 @@ class L2CAPServer {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.Q)
-    boolean start(@NonNull BluetoothAdapter bluetoothAdapter) {
+    byte[] start(@NonNull BluetoothAdapter bluetoothAdapter) {
         try {
-            // Using insecure L2CAP allows the app to use L2CAP friction less, otherwise
+            // Using insecure L2CAP allows the app to use L2CAP frictionless, otherwise
             // Android will require bluetooth pairing with other device showing the pairing code
             mServerSocket = bluetoothAdapter.listenUsingInsecureL2capChannel();
+
+            // TODO: it's not clear this is the right way to encode the PSM and 18013-5 doesn't
+            //   seem to give enough guidance on it.
+            int psm = mServerSocket.getPsm();
+            byte[] psmValue = ByteBuffer.allocate(4).putInt(psm).array();
+            mLog.transport("PSM Value generated: " + psm + " byte: " + Util.toHex(psmValue));
+
+            Thread waitingForConnectionThread = new Thread(this::waitForConnectionThread);
+            waitingForConnectionThread.start();
+
+            return psmValue;
         } catch (IOException e) {
             // It is unable to listen L2CAP channel
-            Log.w(TAG, "Unable to listen L2CAP channel " + e.getMessage());
+            Log.w(TAG, "Error creating L2CAP channel " + e.getMessage());
             mServerSocket = null;
-            return false;
+            return null;
         }
-        return true;
     }
 
     void stop() {
         mInhibitCallbacks = true;
-        closeServerSocket();
-    }
-
-    @RequiresApi(api = Build.VERSION_CODES.Q)
-    public byte[] getPsmValue() {
-        if (mServerSocket == null) {
-            reportError(new Error("Socket for L2CAP not available"));
-            return null;
-        }
-        int psm = mServerSocket.getPsm();
-        byte[] psmValue = ByteBuffer.allocate(4).putInt(psm).array();
-        mLog.transport("PSM Value generated: " + psm + " byte: " + Util.toHex(psmValue));
-
-        return psmValue;
-    }
-
-    public void acceptConnection() {
-            try {
-                mSocket = mServerSocket.accept();
-                if (isConnected()) {
-                    // Stop accepting new connections
-                    mServerSocket.close();
-                    mServerSocket = null;
-
-                    mWritingThread = new Thread(this::writeToSocket);
-                    mWritingThread.start();
-
-                    Thread readingThread = new Thread(this::readFromSocket);
-                    readingThread.start();
-
-                    mReportReceivedMessageThread = new Thread(this::reportMessageReceived);
-                    mReportReceivedMessageThread.start();
-
-                    reportPeerConnected();
-                }
-            } catch (IOException e) {
-                Log.e(TAG, "Error getting connection from socket server for L2CAP " + e.getMessage(), e);
-                reportError(new Error("Error getting connection from socket server for L2CAP", e));
-            }
-    }
-
-    private void writeToSocket() {
-        while (isConnected()) {
-            byte[] messageToSend;
-            try {
-                messageToSend = mWriterQueue.poll(1000, TimeUnit.MILLISECONDS);
-                if (messageToSend == null) {
-                    continue;
-                }
-                if (messageToSend.length == 0) {
-                    mLog.transportVerbose("Empty message, shutting down writing message");
-                    break;
-                }
-            } catch (InterruptedException e) {
-                continue;
-            }
-
-            try {
-                OutputStream os = mSocket.getOutputStream();
-                os.write(messageToSend);
-                os.flush();
-
-            } catch (IOException e) {
-                Log.e(TAG, "Error writing message on L2CAP socket", e);
-                reportError(new Error("Error writing message on L2CAP socket", e));
-                return;
-            }
-        }
-    }
-
-    private void readFromSocket() {
-        mLog.transport("Start reading socket input");
-        // Use the max size as buffer for L2CAP socket
-        byte[] mmBuffer = new byte[mSocket.getMaxReceivePacketSize()];
-        ByteArrayOutputStream incomingMessage = new ByteArrayOutputStream();
-        // Keep listening to the InputStream until an exception occurs.
-        while (isConnected()) {
-            try {
-                int numBytes = mSocket.getInputStream().read(mmBuffer, 0, mmBuffer.length);
-                // Returns -1 once end of the stream has been reached.
-                if (numBytes == -1) {
-                    mLog.transport("End of stream reading from socket");
-                    reportPeerDisconnected();
-                    break;
-                }
-                if (mLog.isTransportVerboseEnabled()) {
-                    Util.dumpHex(TAG, "Chunk received by socket: (" + numBytes + ")", Arrays.copyOf(mmBuffer, numBytes));
-                }
-                // Report message received.
-                incomingMessage.write(mmBuffer, 0, numBytes);
-                // Add cbor item to the queue that will be reported as message received
-                byte[] data = Util.splitCborItemsIntoQueue(incomingMessage.toByteArray(), mMessageReceivedQueue);
-                // keep any remaining data to combine with the next chunk
-                incomingMessage.reset();
-                incomingMessage.write(data);
-            } catch (IOException e) {
-                reportError(new Error("Error on listening input stream from socket L2CAP"));
-                break;
-            }
-        }
-    }
-
-    private void closeServerSocket() {
         if (mWritingThread != null) {
             mWriterQueue.add(new byte[0]);
             try {
                 mWritingThread.join();
             } catch (InterruptedException e) {
                 Log.e(TAG, "Caught exception while joining writing thread: " + e);
-            }
-        }
-        if (mReportReceivedMessageThread != null) {
-            mMessageReceivedQueue.add(new byte[0]);
-            try {
-                mReportReceivedMessageThread.join();
-            } catch (InterruptedException e) {
-                Log.e(TAG, "Caught exception while joining report message received thread: " + e);
             }
         }
         try {
@@ -202,18 +99,118 @@ class L2CAPServer {
             Log.e(TAG, " Error closing server socket connection " + e.getMessage(), e);
         }
         try {
-            if (isConnected()) {
+            if (mSocket != null) {
                 mSocket.close();
                 mSocket = null;
             }
         } catch (IOException e) {
             // Ignoring this error
-            Log.e(TAG, " Error closing server socket connection " + e.getMessage(), e);
+            Log.e(TAG, " Error closing socket connection " + e.getMessage(), e);
         }
     }
 
+    private void waitForConnectionThread() {
+        try {
+            mLog.transport("Calling accept() to wait for connection");
+            mSocket = mServerSocket.accept();
+            mLog.transport("Accepted a connection");
+
+            // Stop accepting new connections
+            mServerSocket.close();
+            mServerSocket = null;
+        } catch (IOException e) {
+            Log.e(TAG, "Error getting connection from socket server for L2CAP " + e.getMessage(), e);
+            reportError(new Error("Error getting connection from socket server for L2CAP", e));
+        }
+
+        // Let the app know we have a connection
+        reportPeerConnected();
+
+        // Start writing thread
+        mWritingThread = new Thread(this::writeToSocket);
+        mWritingThread.start();
+
+        // Reuse this thread for reading
+        readFromSocket();
+    }
+
+    private void writeToSocket() {
+        while (true) {
+            byte[] messageToSend;
+            try {
+                messageToSend = mWriterQueue.poll(1000, TimeUnit.MILLISECONDS);
+                if (messageToSend == null) {
+                    continue;
+                }
+                if (messageToSend.length == 0) {
+                    mLog.transport("Empty message, exiting writer thread");
+                    return;
+                }
+            } catch (InterruptedException e) {
+                continue;
+            }
+
+            try {
+                OutputStream os = mSocket.getOutputStream();
+                os.write(messageToSend);
+                os.flush();
+                reportMessageSendProgress(messageToSend.length, messageToSend.length);
+                mLog.transport(String.format(Locale.US, "Wrote CBOR data item of size %d bytes",
+                        messageToSend.length));
+            } catch (IOException e) {
+                Log.e(TAG, "Error writing message on L2CAP socket", e);
+                reportError(new Error("Error writing message on L2CAP socket", e));
+                return;
+            }
+            // TODO: If we don't do this we run into problems when sending a session termination
+            //   message and then immediately closing the connection, as is usual.
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Log.e(TAG, "Error sleeping after writing", e);
+            }
+        }
+    }
+
+    private void readFromSocket() {
+        mLog.transport("Start reading socket input");
+        ByteArrayOutputStream pendingDataBaos = new ByteArrayOutputStream();
+
+        // Keep listening to the InputStream until an exception occurs.
+        InputStream inputStream = null;
+        try {
+            inputStream = mSocket.getInputStream();
+        } catch (IOException e) {
+            reportError(new Error("Error on listening input stream from socket L2CAP", e));
+            return;
+        }
+        while (true) {
+            byte[] buf = new byte[DataTransportBle.L2CAP_BUF_SIZE];
+            try {
+                int numBytesRead = inputStream.read(buf);
+                if (numBytesRead == -1) {
+                    mLog.transport("End of stream reading from socket");
+                    reportPeerDisconnected();
+                    break;
+                }
+                pendingDataBaos.write(buf, 0, numBytesRead);
+
+                byte[] dataItemBytes = Util.cborExtractFirstDataItem(pendingDataBaos);
+                if (dataItemBytes == null) {
+                    continue;
+                }
+                mLog.transport(String.format(Locale.US, "Received CBOR data item of size %d bytes",
+                        dataItemBytes.length));
+                reportMessageReceived(dataItemBytes);
+            } catch (IOException e) {
+                reportError(new Error("Error on listening input stream from socket L2CAP", e));
+                break;
+            }
+        }
+    }
 
     void sendMessage(@NonNull byte[] data) {
+        reportMessageSendProgress(0, data.length);
         mWriterQueue.add(data);
     }
 
@@ -229,23 +226,9 @@ class L2CAPServer {
         }
     }
 
-    void reportMessageReceived() {
-        while (mListener != null && !mInhibitCallbacks) {
-            byte[] messageReceived;
-            try {
-                messageReceived = mMessageReceivedQueue.poll(1000, TimeUnit.MILLISECONDS);
-                if (messageReceived == null) {
-                    continue;
-                }
-                if (messageReceived.length == 0) {
-                    mLog.transportVerbose("Empty message, shutting down message received");
-                    break;
-                }
-            } catch (InterruptedException e) {
-                continue;
-            }
-            mLog.transport("Data size from message received: (" + messageReceived.length + " bytes)");
-            mListener.onMessageReceived(messageReceived);
+    void reportMessageReceived(@NonNull byte[] data) {
+        if (mListener != null && !mInhibitCallbacks) {
+            mListener.onMessageReceived(data);
         }
     }
 
@@ -255,8 +238,10 @@ class L2CAPServer {
         }
     }
 
-    public boolean isConnected() {
-        return mSocket != null && mSocket.isConnected();
+    void reportMessageSendProgress(long progress, long max) {
+        if (mListener != null && !mInhibitCallbacks) {
+            mListener.onMessageSendProgress(progress, max);
+        }
     }
 
     interface Listener {
@@ -267,5 +252,7 @@ class L2CAPServer {
         void onMessageReceived(@NonNull byte[] data);
 
         void onError(@NonNull Throwable error);
+
+        void onMessageSendProgress(long progress, long max);
     }
 }

--- a/identity/src/main/java/com/android/identity/PresentationHelper.java
+++ b/identity/src/main/java/com/android/identity/PresentationHelper.java
@@ -24,6 +24,7 @@ import android.nfc.cardemulation.HostApduService;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Base64;
+import android.util.Log;
 import android.util.Pair;
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;


### PR DESCRIPTION
- Both accept() and connect() are blocking so need to be called
  in worker threads

- Avoid extraneous thread for reading messages.

- When reading, Don't look at isConnected() since may need to
  empty the socket before handling end-of-stream.

- Add a 100ms sleep in writing threads after each write to give the
  data a chance to be sent before we're closing the socket (close
  joins on the writing thread). This is to work around a suspected bug
  in BluetoothSocket. Real world impact should be zero since apps
  rarely send two messages right after each other.

- Implement progress callbacks

Also to get some more testing of L2CAP, turn this on by default.

Test: Manually tested incl. session termination on both sides.
Bug: None