### PR TITLE
BLE: Change requested MTU to 515 and add better debug for chunking.

### DIFF
--- a/identity/src/main/java/com/android/identity/GattServer.java
+++ b/identity/src/main/java/com/android/identity/GattServer.java
@@ -37,6 +37,7 @@ import com.android.identity.Constants.LoggingFlag;
 
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayDeque;
+import java.util.Locale;
 import java.util.Queue;
 import java.util.UUID;
 
@@ -337,11 +338,27 @@ class GattServer extends BluetoothGattServerCallback {
                 return;
             }
             mIncomingMessage.write(value, 1, value.length - 1);
+            mLog.transportVerbose(String.format(Locale.US,
+                    "Received chunk with %d bytes (last=%s), incomingMessage.length=%d",
+                    value.length, value[0] == 0x00, mIncomingMessage.toByteArray().length));
             if (value[0] == 0x00) {
                 // Last message.
                 byte[] entireMessage = mIncomingMessage.toByteArray();
                 mIncomingMessage.reset();
                 reportMessageReceived(entireMessage);
+            } else if (value[0] == 0x01) {
+                if (value.length != mNegotiatedMtu - 3) {
+                    reportError(new Error(String.format(Locale.US,
+                            "Invalid size %d of data written Client2Server characteristic, "
+                            + "expected size %d",
+                            value.length, mNegotiatedMtu - 3)));
+                    return;
+                }
+            } else {
+                reportError(new Error(String.format(Locale.US,
+                        "Invalid first byte %d in Client2Server data chunk, expected 0 or 1",
+                        value[0])));
+                return;
             }
 
             if (responseNeeded) {
@@ -417,10 +434,9 @@ class GattServer extends BluetoothGattServerCallback {
             return;
         }
 
-        if (mLog.isTransportVerboseEnabled()) {
-            Util.dumpHex(TAG, "writing chunk to " + mCharacteristicServer2Client.getUuid(), chunk);
-        }
-
+        mLog.transportVerbose(String.format(Locale.US,
+                "Sending chunk with %d bytes (last=%s)",
+                chunk.length, chunk[0] == 0x00));
         mCharacteristicServer2Client.setValue(chunk);
         try {
             if (!mGattServer.notifyCharacteristicChanged(mCurrentConnection,


### PR DESCRIPTION
Android supports MTUs up to 517 which we usually will get if the
communication is between two Android devices. However this means that
the chunks being written to Client2Server and Server2Client
characteristics are 514 bytes long which is in violation of the
Bluetooth spec which says they cannot be bigger than 512 bytes
(Bluetooth Core specification section Part F 3.2.9 Long attribute
values).

Starting with Android 13, it seems like this 512 limit is enforced
which means that our mDL app stopped working when either the mDL or
the mDL reader is on Android 13.

The problem is fixed by simply requesting an MTU of size 515 instead
of 517.

Also add better debug/logging to help catch this and similar problems
and add code to report an error if a non-final chunk isn't the MTU
size less 3, as required by 18013-5.

Bug: None
Tests: mDL and mDL reader apps work on Android 13.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR