### PR TITLE
IdentityCredentialStore: Rename getHardwareKeystoreInstance() to getKeystoreInstance()

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/document/DocumentManager.kt
+++ b/appholder/src/main/java/com/android/mdl/app/document/DocumentManager.kt
@@ -96,7 +96,7 @@ class DocumentManager private constructor(private val context: Context) {
         if (PreferencesHelper.isHardwareBacked(context)) {
             IdentityCredentialStore.getHardwareInstance(context)!!
         } else {
-            IdentityCredentialStore.getHardwareKeystoreInstance(context,
+            IdentityCredentialStore.getKeystoreInstance(context,
                 PreferencesHelper.getKeystoreBackedStorageLocation(context))
         }
     } else {
@@ -109,7 +109,7 @@ class DocumentManager private constructor(private val context: Context) {
         } else {
             // Nope, fall back to Keystore implementation
             PreferencesHelper.setHardwareBacked(context, false)
-            IdentityCredentialStore.getHardwareKeystoreInstance(context,
+            IdentityCredentialStore.getKeystoreInstance(context,
                 PreferencesHelper.getKeystoreBackedStorageLocation(context))
         }
     }
@@ -615,10 +615,10 @@ class DocumentManager private constructor(private val context: Context) {
     fun deleteCredential(document: Document, credential: IdentityCredential): ByteArray? {
         val mStore = if (document.hardwareBacked)
             IdentityCredentialStore.getHardwareInstance(context)
-                ?: IdentityCredentialStore.getHardwareKeystoreInstance(context,
+                ?: IdentityCredentialStore.getKeystoreInstance(context,
                     PreferencesHelper.getKeystoreBackedStorageLocation(context))
         else
-            IdentityCredentialStore.getHardwareKeystoreInstance(context,
+            IdentityCredentialStore.getKeystoreInstance(context,
                 PreferencesHelper.getKeystoreBackedStorageLocation(context))
 
         // Delete data from local storage
@@ -637,10 +637,10 @@ class DocumentManager private constructor(private val context: Context) {
 
         val mStore = if (document.hardwareBacked)
             IdentityCredentialStore.getHardwareInstance(context)
-                ?: IdentityCredentialStore.getHardwareKeystoreInstance(context,
+                ?: IdentityCredentialStore.getKeystoreInstance(context,
                     PreferencesHelper.getKeystoreBackedStorageLocation(context))
         else
-            IdentityCredentialStore.getHardwareKeystoreInstance(context,
+            IdentityCredentialStore.getKeystoreInstance(context,
                 PreferencesHelper.getKeystoreBackedStorageLocation(context))
 
         val credential = mStore.getCredentialByName(
@@ -664,10 +664,10 @@ class DocumentManager private constructor(private val context: Context) {
     fun getCredential(document: Document): IdentityCredential? {
         val mStore = if (document.hardwareBacked)
             IdentityCredentialStore.getHardwareInstance(context)
-                ?: IdentityCredentialStore.getHardwareKeystoreInstance(context,
+                ?: IdentityCredentialStore.getKeystoreInstance(context,
                     PreferencesHelper.getKeystoreBackedStorageLocation(context))
         else
-            IdentityCredentialStore.getHardwareKeystoreInstance(context,
+            IdentityCredentialStore.getKeystoreInstance(context,
                 PreferencesHelper.getKeystoreBackedStorageLocation(context))
 
         return mStore.getCredentialByName(

--- a/appholder/src/main/java/com/android/mdl/app/transfer/TransferManager.kt
+++ b/appholder/src/main/java/com/android/mdl/app/transfer/TransferManager.kt
@@ -60,10 +60,10 @@ class TransferManager private constructor(private val context: Context) {
         // what was used to store the first document on this device.
         store = if (PreferencesHelper.isHardwareBacked(context))
             IdentityCredentialStore.getHardwareInstance(context)
-                ?: IdentityCredentialStore.getHardwareKeystoreInstance(context,
+                ?: IdentityCredentialStore.getKeystoreInstance(context,
                     PreferencesHelper.getKeystoreBackedStorageLocation(context))
         else
-            IdentityCredentialStore.getHardwareKeystoreInstance(context,
+            IdentityCredentialStore.getKeystoreInstance(context,
                 PreferencesHelper.getKeystoreBackedStorageLocation(context))
 
         session = store?.createPresentationSession(

--- a/identity/src/main/java/com/android/identity/IdentityCredentialStore.java
+++ b/identity/src/main/java/com/android/identity/IdentityCredentialStore.java
@@ -91,7 +91,7 @@ import java.security.cert.X509Certificate;
  * in the keystore-based implementation.
  *
  * <p>When provisioning a document, applications should use either
- * {@link #getHardwareInstance(Context)} or {@link #getHardwareKeystoreInstance(Context, File)}
+ * {@link #getHardwareInstance(Context)} or {@link #getKeystoreInstance(Context, File)}
  * to obtain an {@link IdentityCredentialStore} instance and prefer the former if it
  * meets the app's feature version requirement, if any.
  *
@@ -232,7 +232,7 @@ public abstract class IdentityCredentialStore {
      *
      * Known backing types are {@link #IMPLEMENTATION_TYPE_HARDWARE} (corresponding to what
      * {@link #getHardwareInstance(Context)} returns) and {@link #IMPLEMENTATION_TYPE_KEYSTORE}
-     * (corresponding to what {@link #getHardwareKeystoreInstance(Context, File)} returns).
+     * (corresponding to what {@link #getKeystoreInstance(Context, File)} returns).
      *
      * @return the type of implementation of the store, either {@link #IMPLEMENTATION_TYPE_HARDWARE}
      *   or {@link #IMPLEMENTATION_TYPE_KEYSTORE}.
@@ -339,7 +339,7 @@ public abstract class IdentityCredentialStore {
      * of Hardware-Backed Android Keystore.
      */
     @SuppressWarnings("deprecation")
-    public static @NonNull IdentityCredentialStore getHardwareKeystoreInstance(
+    public static @NonNull IdentityCredentialStore getKeystoreInstance(
             @NonNull Context context,
             @NonNull File storageDirectory) {
         return KeystoreIdentityCredentialStore.getInstance(context, storageDirectory);

--- a/identity/src/main/java/com/android/identity/Util.java
+++ b/identity/src/main/java/com/android/identity/Util.java
@@ -1789,7 +1789,7 @@ class Util {
         // See b/164480361 for more discussion.
         //
         //return IdentityCredentialStore.getHardwareInstance(context);
-        return IdentityCredentialStore.getHardwareKeystoreInstance(context, context.getNoBackupFilesDir());
+        return IdentityCredentialStore.getKeystoreInstance(context, context.getNoBackupFilesDir());
     }
 
     /**


### PR DESCRIPTION

It's confusing to have both getHardwareInstance() and
getHardwareKeystoreInstance() so rename the latter to be just
getKeystoreInstance().

Bug: None
Test: Manually tested presentation.
