### PR TITLE
BLE: Add a setting to clear BLE Service Cache just before service discovery

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/fragment/SettingsFragment.kt
+++ b/appholder/src/main/java/com/android/mdl/app/fragment/SettingsFragment.kt
@@ -5,6 +5,7 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import com.android.mdl.app.R
+import com.android.mdl.app.util.PreferencesHelper.BLE_CLEAR_CACHE
 import com.android.mdl.app.util.PreferencesHelper.BLE_DATA_RETRIEVAL
 import com.android.mdl.app.util.PreferencesHelper.BLE_DATA_RETRIEVAL_PERIPHERAL_MODE
 import com.android.mdl.app.util.PreferencesHelper.BLE_DATA_L2CAP
@@ -24,8 +25,10 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 if (!pref.isChecked) {
                     pref.isChecked = !hasDataRetrieval()
                 }
-                // Disable L2CAP if neither BLE_DATA_RETRIEVAL and BLE_DATA_RETRIEVAL_PERIPHERAL_MODE is selected
+                // Disable L2CAP and BLE_CLEAR_CACHE if neither BLE_DATA_RETRIEVAL or
+                // BLE_DATA_RETRIEVAL_PERIPHERAL_MODE are selected
                 findPreference<SwitchPreference>(BLE_DATA_L2CAP)?.isEnabled = isBleSelected()
+                findPreference<SwitchPreference>(BLE_CLEAR_CACHE)?.isEnabled = isBleSelected()
                 true
             }
 //            USE_READER_AUTH -> {

--- a/appholder/src/main/java/com/android/mdl/app/transfer/TransferManager.kt
+++ b/appholder/src/main/java/com/android/mdl/app/transfer/TransferManager.kt
@@ -93,6 +93,9 @@ class TransferManager private constructor(private val context: Context) {
         if (bleOptions != 0 && PreferencesHelper.isBleL2capEnabled(context)) {
             bleOptions += Constants.BLE_DATA_RETRIEVAL_OPTION_L2CAP
         }
+        if (bleOptions != 0 && PreferencesHelper.isBleClearCacheEnabled(context)) {
+            bleOptions += Constants.BLE_DATA_RETRIEVAL_CLEAR_CACHE
+        }
 
         val dataRetrievalConfiguration = DataRetrievalListenerConfiguration.Builder()
             .setBleEnabled(bleOptions != 0)

--- a/appholder/src/main/java/com/android/mdl/app/util/PreferencesHelper.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/PreferencesHelper.kt
@@ -10,6 +10,7 @@ object PreferencesHelper {
     const val BLE_DATA_RETRIEVAL = "ble_transport"
     const val BLE_DATA_RETRIEVAL_PERIPHERAL_MODE = "ble_transport_peripheral_mode"
     const val BLE_DATA_L2CAP = "ble_l2cap"
+    const val BLE_CLEAR_CACHE = "ble_clear_cache"
     const val WIFI_DATA_RETRIEVAL = "wifi_transport"
     const val NFC_DATA_RETRIEVAL = "nfc_transport"
     private const val LOG_INFO = "log_info"
@@ -64,6 +65,12 @@ object PreferencesHelper {
     fun isBleL2capEnabled(context: Context): Boolean {
         return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
             BLE_DATA_L2CAP, false
+        )
+    }
+
+    fun isBleClearCacheEnabled(context: Context): Boolean {
+        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
+            BLE_CLEAR_CACHE, false
         )
     }
 

--- a/appholder/src/main/res/xml/root_preferences.xml
+++ b/appholder/src/main/res/xml/root_preferences.xml
@@ -25,6 +25,13 @@
             app:title="Enable BLE with L2CAP" />
 
         <SwitchPreference
+            android:defaultValue="false"
+            app:key="ble_clear_cache"
+            app:summaryOff="Don't clear the cache"
+            app:summaryOn="Clear the cache"
+            app:title="Clear BLE Service Cache" />
+
+        <SwitchPreference
             app:key="wifi_transport"
             app:summaryOff="Wifi Aware transfer deactivated"
             app:summaryOn="Wifi Aware transfer activated"

--- a/appverifier/src/main/java/com/android/mdl/appreader/transfer/TransferManager.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/transfer/TransferManager.kt
@@ -63,6 +63,7 @@ class TransferManager private constructor(private val context: Context) {
         verification?.setListener(responseListener, context.mainExecutor())
         verification?.setLoggingFlags(PreferencesHelper.getLoggingFlags(context))
         verification?.setUseL2CAP(PreferencesHelper.isBleL2capEnabled(context))
+        verification?.setBleClearCache(PreferencesHelper.isBleClearCacheEnabled(context))
     }
 
     fun setQrDeviceEngagement(qrDeviceEngagement: String) {

--- a/appverifier/src/main/java/com/android/mdl/appreader/util/PreferencesHelper.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/util/PreferencesHelper.kt
@@ -6,6 +6,7 @@ import com.android.identity.Constants
 
 object PreferencesHelper {
     private const val BLE_DATA_L2CAP = "ble_l2cap"
+    private const val BLE_CLEAR_CACHE = "ble_clear_cache"
     private const val READER_AUTHENTICATION = "reader_authentication"
     private const val LOG_INFO = "log_info"
     private const val LOG_DEVICE_ENGAGEMENT = "log_device_engagement"
@@ -16,6 +17,12 @@ object PreferencesHelper {
     fun isBleL2capEnabled(context: Context): Boolean {
         return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
             BLE_DATA_L2CAP, false
+        )
+    }
+
+    fun isBleClearCacheEnabled(context: Context): Boolean {
+        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
+            BLE_CLEAR_CACHE, false
         )
     }
 

--- a/appverifier/src/main/res/xml/root_preferences.xml
+++ b/appverifier/src/main/res/xml/root_preferences.xml
@@ -8,6 +8,13 @@
         app:summaryOff="Don't use L2CAP"
         app:summaryOn="Use L2CAP"
         app:title="Use L2CAP if available" />
+
+    <SwitchPreference
+        android:defaultValue="false"
+        app:key="ble_clear_cache"
+        app:summaryOff="Don't clear the cache"
+        app:summaryOn="Clear the cache"
+        app:title="Clear BLE Service Cache" />
     </PreferenceCategory>
     <PreferenceCategory app:title="Debug Logging options">
         <SwitchPreference

--- a/identity/src/main/java/com/android/identity/Constants.java
+++ b/identity/src/main/java/com/android/identity/Constants.java
@@ -113,6 +113,11 @@ public class Constants {
      * Flag indicating that L2CAP should be used for data retrieval if available and supported.
      */
     public static final int BLE_DATA_RETRIEVAL_OPTION_L2CAP = (1 << 2);
+    /**
+     * Flag indicating that BLE Services Cache should be cleared before service discovery
+     * when acting as a GATT Client.
+     */
+    public static final int BLE_DATA_RETRIEVAL_CLEAR_CACHE = (1 << 3);
 
     /**
      * The status code of the document response.
@@ -158,7 +163,8 @@ public class Constants {
             value = {
                     BLE_DATA_RETRIEVAL_OPTION_MDOC_CENTRAL_CLIENT_MODE,
                     BLE_DATA_RETRIEVAL_OPTION_MDOC_PERIPHERAL_SERVER_MODE,
-                    BLE_DATA_RETRIEVAL_OPTION_L2CAP
+                    BLE_DATA_RETRIEVAL_OPTION_L2CAP,
+                    BLE_DATA_RETRIEVAL_CLEAR_CACHE
             })
     public @interface BleDataRetrievalOption {
     }

--- a/identity/src/main/java/com/android/identity/DataTransportBle.java
+++ b/identity/src/main/java/com/android/identity/DataTransportBle.java
@@ -59,6 +59,8 @@ abstract class DataTransportBle extends DataTransport {
 
     // The size of buffer for read() calls when using L2CAP sockets.
     static final int L2CAP_BUF_SIZE = 4096;
+    protected UUID mServiceUuid;
+    protected boolean mClearCache;
 
     public DataTransportBle(
             @NonNull Context context, @LoggingFlag int loggingFlags) {
@@ -272,6 +274,22 @@ abstract class DataTransportBle extends DataTransport {
     void setUseL2CAPIfAvailable(boolean useL2CAPIfAvailable) {
         this.mUseL2CAPIfAvailable = useL2CAPIfAvailable;
     }
+
+    /**
+     * Sets whether to clear service cache if acting as a GATT client.
+     *
+     * Used by PresentationHelper and VerificationHelper to inform the user preference.
+     *
+     * @param clearCache indicates if service cache should be clear if acting as a GATT client.
+     */
+    void setClearCache(boolean clearCache) {
+        mClearCache = clearCache;
+    }
+
+    void setServiceUuid(@NonNull UUID serviceUuid) {
+        mServiceUuid = serviceUuid;
+    }
+
 
     static abstract class DataRetrievalAddressBle extends DataRetrievalAddress {
 

--- a/identity/src/main/java/com/android/identity/DataTransportBleCentralClientMode.java
+++ b/identity/src/main/java/com/android/identity/DataTransportBleCentralClientMode.java
@@ -65,7 +65,6 @@ class DataTransportBleCentralClientMode extends DataTransportBle {
     GattClient mGattClient;
     BluetoothLeScanner mScanner;
     byte[] mEncodedEDeviceKeyBytes;
-    UUID mServiceUuid;
     long mTimeScanningStartedMillis;
     ScanCallback mScanCallback = new ScanCallback() {
         @Override
@@ -123,6 +122,7 @@ class DataTransportBleCentralClientMode extends DataTransportBle {
                 mLog.transport("Scanned for " + scanTimeMillis + " milliseconds. "
                         + "Connecting to device with address " + result.getDevice().getAddress());
             }
+            mGattClient.setClearCache(mClearCache);
             mGattClient.connect(result.getDevice());
             if (mScanner != null) {
                 mLog.transport("Stopped scanning for UUID " + mServiceUuid);
@@ -179,10 +179,6 @@ class DataTransportBleCentralClientMode extends DataTransportBle {
     public @NonNull
     DataRetrievalAddress getListeningAddress() {
         return mListeningAddress;
-    }
-
-    public void setServiceUuid(@NonNull UUID serviceUuid) {
-        mServiceUuid = serviceUuid;
     }
 
     @Override

--- a/identity/src/main/java/com/android/identity/DataTransportBlePeripheralServerMode.java
+++ b/identity/src/main/java/com/android/identity/DataTransportBlePeripheralServerMode.java
@@ -65,7 +65,6 @@ class DataTransportBlePeripheralServerMode extends DataTransportBle {
     GattClient mGattClient;
     BluetoothLeScanner mScanner;
     byte[] mEncodedEDeviceKeyBytes;
-    UUID mServiceUuid;
     long mTimeScanningStartedMillis;
     /**
      * Callback to receive information about the advertisement process.
@@ -135,6 +134,7 @@ class DataTransportBlePeripheralServerMode extends DataTransportBle {
                 mLog.transport("Scanned for " + scanTimeMillis + " milliseconds. "
                         + "Connecting to device with address " + result.getDevice().getAddress());
             }
+            mGattClient.setClearCache(mClearCache);
             mGattClient.connect(result.getDevice());
             if (mScanner != null) {
                 mLog.transport("Stopped scanning for UUID " + mServiceUuid);
@@ -177,10 +177,6 @@ class DataTransportBlePeripheralServerMode extends DataTransportBle {
     public @NonNull
     DataRetrievalAddress getListeningAddress() {
         return mListeningAddress;
-    }
-
-    public void setServiceUuid(@NonNull UUID serviceUuid) {
-        mServiceUuid = serviceUuid;
     }
 
     @Override

--- a/identity/src/main/java/com/android/identity/PresentationHelper.java
+++ b/identity/src/main/java/com/android/identity/PresentationHelper.java
@@ -307,11 +307,14 @@ public class PresentationHelper {
             UUID serviceUuid = UUID.randomUUID();
             boolean useL2CAPIfAvailable = (opts & Constants.BLE_DATA_RETRIEVAL_OPTION_L2CAP) != 0;
 
+            boolean bleClearCache = (opts & Constants.BLE_DATA_RETRIEVAL_CLEAR_CACHE) != 0;
+
             if ((opts & Constants.BLE_DATA_RETRIEVAL_OPTION_MDOC_CENTRAL_CLIENT_MODE) != 0) {
                 DataTransportBleCentralClientMode bleTransport =
                         new DataTransportBleCentralClientMode(mContext, mLoggingFlags);
                 bleTransport.setServiceUuid(serviceUuid);
                 bleTransport.setUseL2CAPIfAvailable(useL2CAPIfAvailable);
+                bleTransport.setClearCache(bleClearCache);
                 mLog.info("Adding BLE mdoc central client mode transport");
                 mTransports.add(bleTransport);
             }
@@ -321,6 +324,10 @@ public class PresentationHelper {
                 bleTransport.setServiceUuid(serviceUuid);
                 bleTransport.setUseL2CAPIfAvailable(useL2CAPIfAvailable);
                 mLog.info("Adding BLE mdoc peripheral server mode transport");
+                if (bleClearCache) {
+                    mLog.info("Ignoring bleClearCache flag since it only applies to "
+                            + "BLE mdoc central client mode when acting as a holder");
+                }
                 mTransports.add(bleTransport);
             }
         }

--- a/identity/src/main/java/com/android/identity/VerificationHelper.java
+++ b/identity/src/main/java/com/android/identity/VerificationHelper.java
@@ -86,6 +86,7 @@ public class VerificationHelper {
     Util.Logger mLog;
     private boolean mIsListening;
     private boolean mUseL2CAP;
+    private boolean mBleClearCache;
 
     /**
      * Creates a new VerificationHelper object.
@@ -98,6 +99,7 @@ public class VerificationHelper {
         mSessionEncryptionReader = null;
         mLog = new Util.Logger(TAG, 0);
         mUseL2CAP = false;
+        mBleClearCache = false;
     }
 
     /**
@@ -122,6 +124,20 @@ public class VerificationHelper {
     public void setUseL2CAP(boolean useL2CAP) {
         mUseL2CAP = useL2CAP;
     }
+
+
+    /**
+     * Sets whether to clear the BLE Service Cache before service discovery when acting as
+     * a GATT Client.
+     *
+     * <p>The default value for this is <em>false</em>.
+     *
+     * @param bleClearCache indicates if the BLE Service Cache should be cleared.
+     */
+    public void setBleClearCache(boolean bleClearCache) {
+        mBleClearCache = bleClearCache;
+    }
+
 
     /**
      * Starts listening for device engagement.
@@ -396,6 +412,11 @@ public class VerificationHelper {
         } else if (mDataTransport instanceof DataTransportBle) {
             // Set the preference for using L2CAP
             ((DataTransportBle) mDataTransport).setUseL2CAPIfAvailable(mUseL2CAP);
+            ((DataTransportBle) mDataTransport).setClearCache(mBleClearCache);
+            if (mBleClearCache && mDataTransport instanceof DataTransportBleCentralClientMode) {
+                mLog.info("Ignoring bleClearCache flag since it only applies to "
+                        + "BLE mdoc peripheral server mode when acting as a reader");
+            }
         }
 
         // Careful, we're using the user-provided Executor below so these callbacks might happen


### PR DESCRIPTION
We have reports that when using BLE mdoc central client mode with a
particular reader things will work better if we force Android to clear
its internal BLE Service Cache before we initiate service
discovery. This is possible using only unsupported API and
introspection. The function in question is the refresh() method on the
BluetoothGatt class.

To better debug and investigate this, add API to enable this behavior
and surface this setting in both the holder and reader reference
apps. The default value for this setting is off.

Test: Manually tested
Bug: None