### PR TITLE
Add support for HW-backed Identity Credential feature version 202201.

### DIFF
--- a/appholder/build.gradle
+++ b/appholder/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.android.mdl.app"

--- a/appholder/src/main/java/com/android/mdl/app/document/DocumentManager.kt
+++ b/appholder/src/main/java/com/android/mdl/app/document/DocumentManager.kt
@@ -103,14 +103,20 @@ class DocumentManager private constructor(private val context: Context) {
         // No preference for which store to use ... first try with the HW-backed implementation
         // and use it only if it reports a sufficiently new version.
         val hwStore = IdentityCredentialStore.getHardwareInstance(context)
+        if (hwStore != null) {
+            Log.i(LOG_TAG, "Found HW-backed store with version ${hwStore.featureVersion}")
+        }
         if (hwStore != null && hwStore.featureVersion >= FEATURE_VERSION_202201) {
+            Log.i(LOG_TAG, "Using HW-backed store with version ${hwStore.featureVersion}")
             PreferencesHelper.setHardwareBacked(context, true)
             hwStore
         } else {
             // Nope, fall back to Keystore implementation
             PreferencesHelper.setHardwareBacked(context, false)
-            IdentityCredentialStore.getKeystoreInstance(context,
+            val ksStore = IdentityCredentialStore.getKeystoreInstance(context,
                 PreferencesHelper.getKeystoreBackedStorageLocation(context))
+            Log.i(LOG_TAG, "Using KS-backed store with version ${ksStore.featureVersion}")
+            ksStore
         }
     }
 

--- a/appverifier/build.gradle
+++ b/appverifier/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.android.mdl.appreader"

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
         cardview_version = '1.0.0'
         android_gradle_plugin = '7.2.0'
         androidx_identity_credential = '1.0.0-alpha02'
-        androidx_biometrics = '1.2.0-alpha04'
+        androidx_biometrics = '1.2.0-alpha05'
         androidx_preference = '1.1.1'
         androidx_room_version = '2.4.2'
         apache_http_version = '4.4.14'

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdk 33
 
     defaultConfig {
         minSdkVersion 24

--- a/identity/src/main/java/com/android/identity/CredentialDataRequest.java
+++ b/identity/src/main/java/com/android/identity/CredentialDataRequest.java
@@ -16,8 +16,11 @@
 
 package com.android.identity;
 
+import android.os.Build;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -119,6 +122,20 @@ final public class CredentialDataRequest {
     boolean mIncrementUseCount = true;
     byte[] mRequestMessage = null;
     byte[] mReaderSignature = null;
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    @NonNull android.security.identity.CredentialDataRequest getAsPlatformRequest() {
+        android.security.identity.CredentialDataRequest.Builder builder = new
+                android.security.identity.CredentialDataRequest.Builder();
+        builder.setAllowUsingExhaustedKeys(mAllowUsingExhaustedKeys);
+        builder.setAllowUsingExpiredKeys(mAllowUsingExpiredKeys);
+        builder.setIncrementUseCount(mIncrementUseCount);
+        builder.setDeviceSignedEntriesToRequest(mDeviceSignedEntriesToRequest);
+        builder.setIssuerSignedEntriesToRequest(mIssuerSignedEntriesToRequest);
+        builder.setRequestMessage(mRequestMessage);
+        builder.setReaderSignature(mReaderSignature);
+        return builder.build();
+    }
 
     /**
      * A builder for {@link CredentialDataRequest}.

--- a/identity/src/main/java/com/android/identity/HardwarePresentationSession.java
+++ b/identity/src/main/java/com/android/identity/HardwarePresentationSession.java
@@ -1,0 +1,69 @@
+package com.android.identity;
+
+import android.content.Context;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.biometric.BiometricPrompt;
+
+import java.io.File;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.PublicKey;
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+public class HardwarePresentationSession extends PresentationSession {
+    private static final String TAG = "HwPresentationSession"; // limit to <= 23 chars
+    private final android.security.identity.PresentationSession mSession;
+
+    HardwarePresentationSession(android.security.identity.PresentationSession session) {
+        mSession = session;
+    }
+
+    @NonNull
+    @Override
+    public KeyPair getEphemeralKeyPair() {
+        return mSession.getEphemeralKeyPair();
+    }
+
+    @Override
+    public void setReaderEphemeralPublicKey(@NonNull PublicKey readerEphemeralPublicKey) throws InvalidKeyException {
+        mSession.setReaderEphemeralPublicKey(readerEphemeralPublicKey);
+    }
+
+    @Override
+    public void setSessionTranscript(@NonNull byte[] sessionTranscript) {
+        mSession.setSessionTranscript(sessionTranscript);
+    }
+
+    @Nullable
+    @Override
+    public CredentialDataResult getCredentialData(@NonNull String credentialName, @NonNull CredentialDataRequest request) throws NoAuthenticationKeyAvailableException, InvalidReaderSignatureException, InvalidRequestMessageException, EphemeralPublicKeyNotFoundException {
+
+        android.security.identity.CredentialDataRequest platformRequest =
+                request.getAsPlatformRequest();
+        try {
+            android.security.identity.CredentialDataResult platformResult =
+                    mSession.getCredentialData(credentialName, platformRequest);
+
+            return new PlatformCredentialDataResult(platformResult);
+
+        } catch (android.security.identity.EphemeralPublicKeyNotFoundException e) {
+            throw new EphemeralPublicKeyNotFoundException(e.getMessage(), e);
+        } catch (android.security.identity.InvalidReaderSignatureException e) {
+            throw new InvalidReaderSignatureException(e.getMessage(), e);
+        } catch (android.security.identity.InvalidRequestMessageException e) {
+            throw new InvalidRequestMessageException(e.getMessage(), e);
+        } catch (android.security.identity.NoAuthenticationKeyAvailableException e) {
+            throw new NoAuthenticationKeyAvailableException(e.getMessage(), e);
+        }
+    }
+
+    @Nullable
+    @Override
+    public BiometricPrompt.CryptoObject getCryptoObject() {
+        return new BiometricPrompt.CryptoObject(mSession);
+    }
+}

--- a/identity/src/main/java/com/android/identity/PlatformCredentialDataResult.java
+++ b/identity/src/main/java/com/android/identity/PlatformCredentialDataResult.java
@@ -1,0 +1,166 @@
+package com.android.identity;
+
+import android.annotation.SuppressLint;
+import android.icu.util.Calendar;
+import android.icu.util.GregorianCalendar;
+import android.icu.util.TimeZone;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+import java.util.Collection;
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+public class PlatformCredentialDataResult extends CredentialDataResult {
+
+    private final android.security.identity.CredentialDataResult mResult;
+    private final CredstoreEntries mDeviceSignedEntries;
+    private final CredstoreEntries mIssuerSignedEntries;
+
+    public PlatformCredentialDataResult(android.security.identity.CredentialDataResult platformResult) {
+        mResult = platformResult;
+        mDeviceSignedEntries = new CredstoreEntries(platformResult.getDeviceSignedEntries());
+        mIssuerSignedEntries = new CredstoreEntries(platformResult.getIssuerSignedEntries());
+    }
+
+    @NonNull
+    @Override
+    public byte[] getDeviceNameSpaces() {
+        return mResult.getDeviceNameSpaces();
+    }
+
+    @Nullable
+    @Override
+    public byte[] getDeviceMac() {
+        return mResult.getDeviceMac();
+    }
+
+    @Nullable
+    @Override
+    public byte[] getDeviceSignature() {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public byte[] getStaticAuthenticationData() {
+        return mResult.getStaticAuthenticationData();
+    }
+
+    @NonNull
+    @Override
+    public Entries getDeviceSignedEntries() {
+        return mDeviceSignedEntries;
+    }
+
+    @NonNull
+    @Override
+    public Entries getIssuerSignedEntries() {
+        return mIssuerSignedEntries;
+    }
+
+    static class CredstoreEntries implements CredentialDataResult.Entries {
+        android.security.identity.CredentialDataResult.Entries mEntries;
+
+        @SuppressWarnings("deprecation")
+        CredstoreEntries(android.security.identity.CredentialDataResult.Entries entries) {
+            mEntries = entries;
+        }
+
+        @Override
+        public @NonNull
+        Collection<String> getNamespaces() {
+            return mEntries.getNamespaces();
+        }
+
+        @Override
+        public @NonNull Collection<String> getEntryNames(@NonNull String namespaceName) {
+            return mEntries.getEntryNames(namespaceName);
+        }
+
+        @Override
+        public @NonNull Collection<String> getRetrievedEntryNames(@NonNull String namespaceName) {
+            return mEntries.getRetrievedEntryNames(namespaceName);
+        }
+
+        @Override
+        @Status
+        @SuppressLint("WrongConstant")
+        public int getStatus(@NonNull String namespaceName, @NonNull String name) {
+            return mEntries.getStatus(namespaceName, name);
+        }
+
+        @Override
+        public @Nullable byte[] getEntry(@NonNull String namespaceName, @NonNull String name) {
+            return mEntries.getEntry(namespaceName, name);
+        }
+
+        @Nullable
+        @Override
+        public String getEntryString(@NonNull String namespaceName, @NonNull String name) {
+            byte[] value = getEntry(namespaceName, name);
+            if (value == null) {
+                return null;
+            }
+            return Util.cborDecodeString(value);
+        }
+
+        @Nullable
+        @Override
+        public byte[] getEntryBytestring(@NonNull String namespaceName, @NonNull String name) {
+            byte[] value = getEntry(namespaceName, name);
+            if (value == null) {
+                return null;
+            }
+            return Util.cborDecodeByteString(value);
+        }
+
+        @Override
+        public long getEntryInteger(@NonNull String namespaceName, @NonNull String name) {
+            byte[] value = getEntry(namespaceName, name);
+            if (value == null) {
+                return 0;
+            }
+            return Util.cborDecodeLong(value);
+        }
+
+        @Override
+        public boolean getEntryBoolean(@NonNull String namespaceName, @NonNull String name) {
+            byte[] value = getEntry(namespaceName, name);
+            if (value == null) {
+                return false;
+            }
+            return Util.cborDecodeBoolean(value);
+        }
+
+        @Nullable
+        @Override
+        public Calendar getEntryCalendar(@NonNull String namespaceName, @NonNull String name) {
+            byte[] value = getEntry(namespaceName, name);
+            if (value == null) {
+                return null;
+            }
+            Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+            calendar.setTimeInMillis(Util.cborDecodeDateTime(value).toEpochMilli());
+            return calendar;
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public boolean isUserAuthenticationNeeded() {
+            for (String namespaceName : mEntries.getNamespaces()) {
+                for (String entryName : mEntries.getEntryNames(namespaceName)) {
+                    if (mEntries.getStatus(namespaceName, entryName)
+                            == android.security.identity.CredentialDataResult.Entries.STATUS_USER_AUTHENTICATION_FAILED) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+    }
+
+}


### PR DESCRIPTION
This requires updating to the latest version of the biometric Jetpack with support for platform android.security.identity.PresentationSession. Also requires depending on an SDK for API 33.

Bug: None
Test: Verified that Pixel 4a running Android 13 is using HW-backed Identity Credential.
