### PR TITLE
Move device engagement out of PresentationHelper.

### DIFF
--- a/appholder/src/main/AndroidManifest.xml
+++ b/appholder/src/main/AndroidManifest.xml
@@ -63,9 +63,9 @@
         </activity>
 
         <service
-            android:name=".util.NfcHandler"
+            android:name=".util.NfcEngagementHandler"
             android:exported="true"
-            android:label="@string/engagement_service_desc"
+            android:label="@string/nfc_engagement_service_desc"
             android:permission="android.permission.BIND_NFC_SERVICE">
             <intent-filter>
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
@@ -75,6 +75,21 @@
             <meta-data
                 android:name="android.nfc.cardemulation.host_apdu_service"
                 android:resource="@xml/nfc_engagement_apdu_service" />
+        </service>
+
+        <service
+            android:name=".util.NfcDataTransferHandler"
+            android:exported="true"
+            android:label="@string/nfc_data_transfer_service_desc"
+            android:permission="android.permission.BIND_NFC_SERVICE">
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <action android:name="android.nfc.cardemulation.action.HOST_APDU_SERVICE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.nfc.cardemulation.host_apdu_service"
+                android:resource="@xml/nfc_data_transfer_apdu_service" />
         </service>
     </application>
 

--- a/appholder/src/main/java/com/android/mdl/app/fragment/ShareDocumentFragment.kt
+++ b/appholder/src/main/java/com/android/mdl/app/fragment/ShareDocumentFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import com.android.mdl.app.databinding.FragmentShareDocumentBinding
+import com.android.mdl.app.transfer.TransferManager
 import com.android.mdl.app.util.TransferStatus
 import com.android.mdl.app.viewmodel.ShareDocumentViewModel
 
@@ -44,11 +45,13 @@ class ShareDocumentFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         vm.startPresentation()
 
+        vm.message.set("NFC tap with mdoc verifier device")
+
         vm.getTransferStatus().observe(viewLifecycleOwner, {
             when (it) {
-                TransferStatus.ENGAGEMENT_READY -> {
+                TransferStatus.QR_ENGAGEMENT_READY -> {
                     vm.message.set("Scan QR code or NFC tap with mdoc verifier device")
-                    vm.setDeviceEngagement()
+                    vm.showQrCode()
                 }
                 TransferStatus.CONNECTED -> {
                     vm.message.set("Connected!")
@@ -92,4 +95,10 @@ class ShareDocumentFragment : Fragment() {
             ShareDocumentFragmentDirections.actionShareDocumentFragmentToSelectDocumentFragment()
         )
     }
+
+    fun onShowQrCodeClicked() {
+        binding.btShowQr?.isEnabled = false
+        vm.onShowQrCodeClicked()
+    }
+
 }

--- a/appholder/src/main/java/com/android/mdl/app/fragment/TransferDocumentFragment.kt
+++ b/appholder/src/main/java/com/android/mdl/app/fragment/TransferDocumentFragment.kt
@@ -63,7 +63,7 @@ class TransferDocumentFragment : Fragment() {
 
         vm.getTransferStatus().observe(viewLifecycleOwner, { transferStatus ->
             when (transferStatus) {
-                TransferStatus.ENGAGEMENT_READY -> {
+                TransferStatus.QR_ENGAGEMENT_READY -> {
                     Log.d(LOG_TAG, "Engagement Ready")
                 }
                 TransferStatus.CONNECTED -> {

--- a/appholder/src/main/java/com/android/mdl/app/util/NfcDataTransferHandler.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/NfcDataTransferHandler.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.android.mdl.app.util
+
+import android.nfc.cardemulation.HostApduService
+import android.os.Bundle
+import android.util.Log
+import com.android.mdl.app.transfer.TransferManager
+
+class NfcDataTransferHandler : HostApduService() {
+
+    companion object {
+        private const val LOG_TAG = "NfcDataTransferHandler"
+
+        private val AID_FOR_MDL_DATA_TRANSFER : ByteArray = byteArrayOf(
+            0xA0.toByte(),
+            0x00.toByte(),
+            0x00.toByte(),
+            0x02.toByte(),
+            0x48.toByte(),
+            0x04.toByte(),
+            0x00.toByte())
+    }
+
+    override fun processCommandApdu(commandApdu: ByteArray, extras: Bundle?): ByteArray? {
+        Log.d(LOG_TAG, "processCommandApdu: Command-> ${FormatUtil.encodeToString(commandApdu)}")
+
+        TransferManager.getInstance(applicationContext)
+            .nfcProcessCommandApdu(this, AID_FOR_MDL_DATA_TRANSFER, commandApdu)
+
+        return null
+    }
+
+    override fun onDeactivated(reason: Int) {
+        Log.d(LOG_TAG, "onDeactivated: reason-> $reason")
+        TransferManager.getInstance(applicationContext)
+            .nfcOnDeactivated(this, AID_FOR_MDL_DATA_TRANSFER, reason)
+    }
+}

--- a/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
@@ -21,23 +21,33 @@ import android.os.Bundle
 import android.util.Log
 import com.android.mdl.app.transfer.TransferManager
 
-class NfcHandler : HostApduService() {
+class NfcEngagementHandler : HostApduService() {
 
     companion object {
-        private const val LOG_TAG = "NfcHandler"
+        private const val LOG_TAG = "NfcEngagementHandler"
+
+        private val AID_FOR_TYPE_4_TAG_NDEF_APPLICATION : ByteArray = byteArrayOf(
+            0xD2.toByte(),
+            0x76.toByte(),
+            0x00.toByte(),
+            0x00.toByte(),
+            0x85.toByte(),
+            0x01.toByte(),
+            0x01.toByte())
     }
 
     override fun processCommandApdu(commandApdu: ByteArray, extras: Bundle?): ByteArray? {
         Log.d(LOG_TAG, "processCommandApdu: Command-> ${FormatUtil.encodeToString(commandApdu)}")
 
         TransferManager.getInstance(applicationContext)
-            .nfcEngagementProcessCommandApdu(this, commandApdu)
+            .nfcProcessCommandApdu(this, AID_FOR_TYPE_4_TAG_NDEF_APPLICATION, commandApdu)
 
         return null
     }
 
     override fun onDeactivated(reason: Int) {
         Log.d(LOG_TAG, "onDeactivated: reason-> $reason")
-        TransferManager.getInstance(applicationContext).nfcEngagementOnDeactivated(this, reason)
+        TransferManager.getInstance(applicationContext)
+            .nfcOnDeactivated(this, AID_FOR_TYPE_4_TAG_NDEF_APPLICATION, reason)
     }
 }

--- a/appholder/src/main/java/com/android/mdl/app/util/TransferStatus.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/TransferStatus.kt
@@ -1,7 +1,7 @@
 package com.android.mdl.app.util
 
 enum class TransferStatus {
-    ENGAGEMENT_READY,
+    QR_ENGAGEMENT_READY,
     ENGAGEMENT_DETECTED,
     CONNECTING,
     CONNECTED,

--- a/appholder/src/main/java/com/android/mdl/app/viewmodel/ShareDocumentViewModel.kt
+++ b/appholder/src/main/java/com/android/mdl/app/viewmodel/ShareDocumentViewModel.kt
@@ -2,6 +2,7 @@ package com.android.mdl.app.viewmodel
 
 import android.app.Application
 import android.view.View
+import android.widget.Button
 import androidx.databinding.ObservableField
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
@@ -39,9 +40,11 @@ class ShareDocumentViewModel(val app: Application) :
         message.set("Presentation canceled")
     }
 
-    fun setDeviceEngagement() {
+    fun showQrCode() {
         deviceEngagementQr.set(transferManager.getDeviceEngagementQrCode())
     }
 
+    fun onShowQrCodeClicked() {
+        transferManager.startQrEngagement()
+    }
 }
-

--- a/appholder/src/main/res/layout-land/fragment_share_document.xml
+++ b/appholder/src/main/res/layout-land/fragment_share_document.xml
@@ -31,8 +31,8 @@
 
         <LinearLayout
             android:id="@+id/layout_engagement"
-            android:layout_width="300dp"
-            android:layout_height="300dp"
+            android:layout_width="200dp"
+            android:layout_height="200dp"
             android:orientation="vertical"
             app:engagementView="@{vm.deviceEngagementQr}"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -40,15 +40,36 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/txt_share_fragment" />
 
-        <Button
-            android:id="@+id/bt_cancel"
+        <LinearLayout
+            android:id="@+id/bt_layout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="24dp"
-            android:onClick="@{() -> fragment.onCancel()}"
-            android:text="@string/bt_cancel"
+            android:layout_marginTop="24dp"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/layout_engagement">
+
+            <Button
+                android:id="@+id/bt_show_qr"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:insetLeft="10dp"
+                android:insetRight="10dp"
+                android:onClick="@{() -> fragment.onShowQrCodeClicked()}"
+                android:text="@string/bt_show_qr_code" />
+
+            <Button
+                    android:id="@+id/bt_cancel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:insetLeft="10dp"
+                    android:insetRight="10dp"
+                    android:onClick="@{() -> fragment.onCancel()}"
+                    android:text="@string/bt_cancel"/>
+
+        </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/appholder/src/main/res/layout/fragment_share_document.xml
+++ b/appholder/src/main/res/layout/fragment_share_document.xml
@@ -35,22 +35,43 @@
             android:layout_height="300dp"
             android:orientation="vertical"
             app:engagementView="@{vm.deviceEngagementQr}"
-            app:layout_constraintBottom_toTopOf="@+id/bt_cancel"
+            app:layout_constraintBottom_toTopOf="@+id/bt_layout"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/txt_share_fragment" />
+            app:layout_constraintTop_toBottomOf="@+id/txt_share_fragment" >
 
-        <Button
-            android:id="@+id/bt_cancel"
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/bt_layout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:onClick="@{() -> fragment.onCancel()}"
-            android:text="@string/bt_cancel"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/layout_engagement"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+            app:layout_constraintTop_toBottomOf="@+id/layout_engagement">
+
+            <Button
+                android:id="@+id/bt_show_qr"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:insetLeft="10dp"
+                android:insetRight="10dp"
+                android:onClick="@{() -> fragment.onShowQrCodeClicked()}"
+                android:text="@string/bt_show_qr_code" />
+
+            <Button
+                android:id="@+id/bt_cancel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:insetLeft="10dp"
+                android:insetRight="10dp"
+                android:onClick="@{() -> fragment.onCancel()}"
+                android:text="@string/bt_cancel" />
+
+        </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/appholder/src/main/res/values/strings.xml
+++ b/appholder/src/main/res/values/strings.xml
@@ -1,13 +1,15 @@
 <resources>
     <string name="app_name">App Holder</string>
     <string name="bt_cancel">Cancel</string>
+    <string name="bt_show_qr_code">Show QR Code</string>
     <string name="bt_done">Done</string>
     <string name="txt_transfer_completed">Transfer Completed!</string>
     <string name="txt_list_of_documents">List of Documents:</string>
     <string name="txt_transferring">Transferring</string>
     <string name="txt_consent">Approve sending data to mDL verifier</string>
     <string name="bt_approve">Approve</string>
-    <string name="engagement_service_desc">mDL Holder NFC Engagement</string>
+    <string name="nfc_engagement_service_desc">mDL NFC Engagement</string>
+    <string name="nfc_data_transfer_service_desc">mDL NFC Data Transfer</string>
     <string name="engagement_aid_group_desc">mDL AID Group</string>
     <string name="bt_add_document">Add Document</string>
     <string name="txt_server_url">Enter the server URL</string>

--- a/appholder/src/main/res/xml/nfc_data_transfer_apdu_service.xml
+++ b/appholder/src/main/res/xml/nfc_data_transfer_apdu_service.xml
@@ -17,12 +17,12 @@
   -->
 
 <host-apdu-service xmlns:android="http://schemas.android.com/apk/res/android"
-    android:description="@string/nfc_engagement_service_desc"
+    android:description="@string/nfc_data_transfer_service_desc"
     android:requireDeviceUnlock="true">
 
     <aid-group android:description="@string/engagement_aid_group_desc" android:category="other">
-        <!-- NFC Type 4 Tag -->
-        <aid-filter android:name="D2760000850101"/>
+        <!-- Defined in ISO 18013-5:2021 clause 8.3.3.1.2 -->
+        <aid-filter android:name="A0000002480400"/>
     </aid-group>
 
 </host-apdu-service>

--- a/identity/src/androidTest/java/com/android/identity/DataTransportTcpTest.java
+++ b/identity/src/androidTest/java/com/android/identity/DataTransportTcpTest.java
@@ -77,7 +77,7 @@ public class DataTransportTcpTest {
             }
 
             @Override
-            public void onMessageReceived(@NonNull byte[] data) {
+            public void onMessageReceived() {
                 Assert.fail();
             }
 
@@ -164,7 +164,8 @@ public class DataTransportTcpTest {
             }
 
             @Override
-            public void onMessageReceived(@NonNull byte[] data) {
+            public void onMessageReceived() {
+                byte[] data = prover.getMessage();
                 messageReceivedByProver[0] = data.clone();
                 proverMessageReceivedCondVar.open();
             }
@@ -213,7 +214,8 @@ public class DataTransportTcpTest {
             }
 
             @Override
-            public void onMessageReceived(@NonNull byte[] data) {
+            public void onMessageReceived() {
+                byte[] data = verifier.getMessage();
                 messageReceivedByVerifier[0] = data.clone();
                 verifierMessageReceivedCondVar.open();
             }

--- a/identity/src/androidTest/java/com/android/identity/StoreStaticAuthenticationDataTest.java
+++ b/identity/src/androidTest/java/com/android/identity/StoreStaticAuthenticationDataTest.java
@@ -72,6 +72,7 @@ public class StoreStaticAuthenticationDataTest {
   private void checkStaticAuthData(int numAuthKeys, int staticAuthDataSizeBytes)
           throws IdentityCredentialException {
     final int usesPerKey = 3;
+    mStore.deleteCredentialByName(CREDENTIAL_NAME);
     ProvisioningTest.createCredential(mStore, CREDENTIAL_NAME);
     try {
       IdentityCredential credential = Preconditions.checkNotNull(

--- a/identity/src/main/java/com/android/identity/NfcApduRouter.java
+++ b/identity/src/main/java/com/android/identity/NfcApduRouter.java
@@ -1,0 +1,89 @@
+package com.android.identity;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.Pair;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.Executor;
+
+/**
+ * Mechanism used for interfacing with the NFC subsystem.
+ *
+ * <p>The application using the Identity Credential Library must implement this and connect
+ * it to its internal APDU routing system.
+ */
+public abstract class NfcApduRouter {
+
+    // Defined by NFC Forum
+    public static final byte[] AID_FOR_TYPE_4_TAG_NDEF_APPLICATION = Util.fromHex("D2760000850101");
+
+    // Defined by 18013-5 Section 8.3.3.1.2 Data retrieval using near field communication (NFC)
+    public static final byte[] AID_FOR_MDL_DATA_TRANSFER = Util.fromHex("A0000002480400");
+
+    private ArrayList<Pair<Listener, Executor>> mListeners = new ArrayList<>();
+
+    public void addListener(@Nullable Listener listener, @Nullable Executor executor) {
+        if (listener != null && executor == null) {
+            throw new IllegalStateException("Cannot have non-null listener with null executor");
+        }
+        mListeners.add(new Pair<>(listener, executor));
+    }
+
+    /**
+     * Remove a previously registered listener.
+     *
+     * <p>Trying to remove a listener multiple times is permitted, only the first call will
+     * have an effect.
+     *
+     * @param listener
+     * @param executor
+     */
+    public void removeListener(@Nullable Listener listener, @Nullable Executor executor) {
+        mListeners.removeIf(listenerPair -> (listenerPair.first == listener
+                && listenerPair.second == executor));
+    }
+
+    /**
+     * Sends a response APDU back to the remote device.
+     *
+     * @param responseApdu A byte-array containing the response APDU.
+     */
+    public abstract void sendResponseApdu(@NonNull byte[] responseApdu);
+
+    /**
+     * Adds a received APDU to the queue of received APDUs.
+     *
+     * <p>This will notify listeners.
+     *
+     * @param receivedApdu an APDU received
+     */
+    public void addReceivedApdu(@NonNull byte[] aid, @NonNull byte[] receivedApdu) {
+        for (Pair<Listener, Executor> listenerPair : Collections.synchronizedList(mListeners)) {
+            Listener listener = listenerPair.first;
+            Executor executor = listenerPair.second;
+            executor.execute(() -> listener.onApduReceived(aid, receivedApdu));
+        }
+    }
+
+    /**
+     * Adds a deactivated notification to the queue of received APDUs.
+     *
+     * <p>This will notify listeners.
+     *
+     * @param reason the reason for deactivation
+     */
+    public void addDeactivated(@NonNull byte[] aid, int reason) {
+        for (Pair<Listener, Executor> listenerPair : Collections.synchronizedList(mListeners)) {
+            Listener listener = listenerPair.first;
+            Executor executor = listenerPair.second;
+            executor.execute(() -> listener.onDeactivated(aid, reason));
+        }
+    }
+
+    public interface Listener {
+        void onApduReceived(@NonNull byte[] aid, @NonNull byte[] apdu);
+        void onDeactivated(@NonNull byte[] aid, int reason);
+    }
+}

--- a/identity/src/main/java/com/android/identity/NfcUtil.java
+++ b/identity/src/main/java/com/android/identity/NfcUtil.java
@@ -1,0 +1,47 @@
+package com.android.identity;
+
+import androidx.annotation.NonNull;
+
+class NfcUtil {
+
+
+    static final int COMMAND_TYPE_OTHER = 0;
+    static final int COMMAND_TYPE_SELECT_BY_AID = 1;
+    static final int COMMAND_TYPE_SELECT_FILE = 2;
+    static final int COMMAND_TYPE_READ_BINARY = 3;
+    static final int COMMAND_TYPE_UPDATE_BINARY = 4;
+    static final int COMMAND_TYPE_ENVELOPE = 5;
+    static final int COMMAND_TYPE_RESPONSE = 6;
+    static final int CAPABILITY_CONTAINER_FILE_ID = 0xe103;
+    static final int NDEF_FILE_ID = 0xe104;
+    static final byte[] STATUS_WORD_INSTRUCTION_NOT_SUPPORTED = {(byte) 0x6d, (byte) 0x00};
+    static final byte[] STATUS_WORD_OK = {(byte) 0x90, (byte) 0x00};
+    static final byte[] STATUS_WORD_FILE_NOT_FOUND = {(byte) 0x6a, (byte) 0x82};
+    static final byte[] STATUS_WORD_END_OF_FILE_REACHED = {(byte) 0x62, (byte) 0x82};
+    static final byte[] STATUS_WORD_WRONG_PARAMETERS = {(byte) 0x6b, (byte) 0x00};
+
+
+    static int nfcGetCommandType(@NonNull byte[] apdu) {
+        if (apdu.length < 3) {
+            return COMMAND_TYPE_OTHER;
+        }
+        int ins = apdu[1] & 0xff;
+        int p1 = apdu[2] & 0xff;
+        if (ins == 0xA4) {
+            if (p1 == 0x04) {
+                return COMMAND_TYPE_SELECT_BY_AID;
+            } else if (p1 == 0x00) {
+                return COMMAND_TYPE_SELECT_FILE;
+            }
+        } else if (ins == 0xb0) {
+            return COMMAND_TYPE_READ_BINARY;
+        } else if (ins == 0xd6) {
+            return COMMAND_TYPE_UPDATE_BINARY;
+        } else if (ins == 0xc0) {
+            return COMMAND_TYPE_RESPONSE;
+        } else if (ins == 0xc3) {
+            return COMMAND_TYPE_ENVELOPE;
+        }
+        return COMMAND_TYPE_OTHER;
+    }
+}

--- a/identity/src/main/java/com/android/identity/QrEngagementHelper.java
+++ b/identity/src/main/java/com/android/identity/QrEngagementHelper.java
@@ -1,0 +1,434 @@
+package com.android.identity;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.Build;
+import android.util.Base64;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.security.KeyPair;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.builder.ArrayBuilder;
+import co.nstant.in.cbor.builder.MapBuilder;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.SimpleValue;
+import co.nstant.in.cbor.model.UnsignedInteger;
+
+public class QrEngagementHelper implements NfcApduRouter.Listener {
+    private static final String TAG = "QrEngagementHelper";
+
+    private final PresentationSession mPresentationSession;
+    private final Context mContext;
+    private final KeyPair mEphemeralKeyPair;
+    private final Util.Logger mLog;
+    private final NfcApduRouter mNfcApduRouter;
+    private final DataRetrievalListenerConfiguration mDataRetrievalListenerConfiguration;
+    private int mLoggingFlags;
+    private Listener mListener;
+    private Executor mExecutor;
+    private boolean mInhibitCallbacks;
+    private ArrayList<DataTransport> mTransports = new ArrayList<>();
+    private int mNumTransportsStillSettingUp;
+    private byte[] mEncodedDeviceEngagement;
+    private byte[] mEncodedHandover;
+    private boolean mReportedDeviceConnecting;
+    private int mNumEngagementApdusReceived;
+    private int mNumDataTransferApdusReceived;
+
+    public QrEngagementHelper(@NonNull Context context,
+                              @NonNull PresentationSession presentationSession,
+                              @NonNull DataRetrievalListenerConfiguration dataRetrievalListenerConfiguration,
+                              @Nullable NfcApduRouter nfcApduRouter,
+                              @NonNull Listener listener, @NonNull Executor executor,
+                              @Constants.LoggingFlag int loggingFlags) {
+        mContext = context;
+        mPresentationSession = presentationSession;
+        mListener = listener;
+        mExecutor = executor;
+        mNfcApduRouter = nfcApduRouter;
+        if (mNfcApduRouter != null) {
+            mNfcApduRouter.addListener(this, executor);
+        }
+        mEphemeralKeyPair = mPresentationSession.getEphemeralKeyPair();
+        mLog = new Util.Logger(TAG, loggingFlags);
+        mLoggingFlags = loggingFlags;
+
+        mDataRetrievalListenerConfiguration = dataRetrievalListenerConfiguration;
+        startListening();
+    }
+
+    public void close() {
+        if (mNfcApduRouter != null) {
+            mNfcApduRouter.removeListener(this, mExecutor);
+        }
+        mInhibitCallbacks = true;
+        if (mTransports != null) {
+            for (DataTransport transport : mTransports) {
+                transport.close();
+            }
+            mTransports = null;
+        }
+    }
+
+    @Override
+    public void onApduReceived(@NonNull byte[] aid, @NonNull byte[] apdu) {
+        mLog.info(String.format(Locale.US, "onApduReceived aid=%s apdu=%s",
+                Util.toHex(aid), Util.toHex(apdu)));
+        if (Arrays.equals(aid, NfcApduRouter.AID_FOR_TYPE_4_TAG_NDEF_APPLICATION)) {
+            mNumEngagementApdusReceived += 1;
+        } else if (Arrays.equals(aid, NfcApduRouter.AID_FOR_MDL_DATA_TRANSFER)) {
+            mNumDataTransferApdusReceived += 1;
+        }
+
+        mLog.info(String.format(Locale.US,
+                        "mNumEngagementApdusReceived=%d mNumDataTransferApdusReceived=%d",
+                        mNumEngagementApdusReceived, mNumDataTransferApdusReceived));
+
+        /*
+        // This is for the case of QR engagement to NFC data transfer... we have to be
+        // careful and only react on the SELECT APPLICATION command if we received no
+        // previous APDUs for the engagement service.
+        //
+        if (mNumEngagementApdusReceived == 0 && mNumDataTransferApdusReceived == 1) {
+            switch (NfcUtil.nfcGetCommandType(apdu)) {
+                case NfcUtil.COMMAND_TYPE_SELECT_BY_AID:
+                    if (Arrays.equals(Arrays.copyOfRange(apdu, 5, 12),
+                            NfcApduRouter.AID_FOR_MDL_DATA_TRANSFER)) {
+                        for (DataTransport t : mTransports) {
+                            if (t instanceof DataTransportNfc) {
+                                mLog.info("NFC data transfer AID selected");
+                                DataTransportNfc dataTransportNfc = (DataTransportNfc) t;
+                                // Hand over the APDU router to the NFC data transport
+                                mNfcApduRouter.removeListener(this, mExecutor);
+                                dataTransportNfc.setNfcApduRouter(mNfcApduRouter, mExecutor);
+                                mNfcApduRouter.sendResponseApdu(NfcUtil.STATUS_WORD_OK);
+                            }
+                        }
+                    }
+                    break;
+            }
+        }
+
+         */
+    }
+
+    @Override
+    public void onDeactivated(@NonNull byte[] aid, int reason) {
+        mLog.info(String.format(Locale.US, "onDeactivated aid=%s reason=%d",
+                Util.toHex(aid), reason));
+        if (Arrays.equals(aid, NfcApduRouter.AID_FOR_TYPE_4_TAG_NDEF_APPLICATION)) {
+            mNumEngagementApdusReceived = 0;
+        } else if (Arrays.equals(aid, NfcApduRouter.AID_FOR_MDL_DATA_TRANSFER)) {
+            mNumDataTransferApdusReceived = 0;
+        }
+    }
+
+    /**
+     * Used by PresentationHelperTest.java.
+     */
+    void addDataTransport(@NonNull DataTransport transport) {
+        mTransports.add(transport);
+    }
+
+    /**
+     * Called by constructor and also used by PresentationHelperTest.java.
+     */
+    void startListening() {
+        // The order here matters... it will be the same order in the array in the QR code
+        // and we expect readers to pick the first one.
+        //
+        if (mDataRetrievalListenerConfiguration.isBleEnabled()) {
+            @Constants.BleDataRetrievalOption int opts =
+                    mDataRetrievalListenerConfiguration.getBleDataRetrievalOptions();
+
+            boolean useL2CAPIfAvailable = (opts & Constants.BLE_DATA_RETRIEVAL_OPTION_L2CAP) != 0;
+
+            boolean bleClearCache = (opts & Constants.BLE_DATA_RETRIEVAL_CLEAR_CACHE) != 0;
+
+            if ((opts & Constants.BLE_DATA_RETRIEVAL_OPTION_MDOC_CENTRAL_CLIENT_MODE) != 0) {
+                UUID serviceUuid = UUID.randomUUID();
+                DataTransportBleCentralClientMode bleTransport =
+                        new DataTransportBleCentralClientMode(mContext, mLoggingFlags);
+                bleTransport.setServiceUuid(serviceUuid);
+                bleTransport.setUseL2CAPIfAvailable(useL2CAPIfAvailable);
+                bleTransport.setClearCache(bleClearCache);
+                mLog.info("Adding BLE mdoc central client mode transport");
+                mTransports.add(bleTransport);
+            }
+            if ((opts & Constants.BLE_DATA_RETRIEVAL_OPTION_MDOC_PERIPHERAL_SERVER_MODE) != 0) {
+                UUID serviceUuid = UUID.randomUUID();
+                DataTransportBlePeripheralServerMode bleTransport =
+                        new DataTransportBlePeripheralServerMode(mContext, mLoggingFlags);
+                bleTransport.setServiceUuid(serviceUuid);
+                bleTransport.setUseL2CAPIfAvailable(useL2CAPIfAvailable);
+                mLog.info("Adding BLE mdoc peripheral server mode transport");
+                if (bleClearCache) {
+                    mLog.info("Ignoring bleClearCache flag since it only applies to "
+                            + "BLE mdoc central client mode when acting as a holder");
+                }
+                mTransports.add(bleTransport);
+            }
+        }
+        if (mDataRetrievalListenerConfiguration.isWifiAwareEnabled()) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                mLog.info("Adding Wifi Aware transport");
+                mTransports.add(new DataTransportWifiAware(mContext));
+            } else {
+                throw new IllegalArgumentException("Wifi Aware only available on API 29 or later");
+            }
+        }
+        if (mDataRetrievalListenerConfiguration.isNfcEnabled()) {
+            mLog.info("Adding NFC transport");
+            mTransports.add(new DataTransportNfc(mContext, mLoggingFlags));
+        }
+
+        byte[] encodedEDeviceKeyBytes = Util.cborEncode(Util.cborBuildTaggedByteString(
+                Util.cborEncode(Util.cborBuildCoseKey(mEphemeralKeyPair.getPublic()))));
+
+        for (DataTransport t : mTransports) {
+            t.setEDeviceKeyBytes(encodedEDeviceKeyBytes);
+        }
+
+        // Careful, we're using the user-provided Executor below so these callbacks might happen
+        // in another thread than we're in right now. For example this happens if using
+        // ThreadPoolExecutor.
+        //
+        // In particular, it means we need locking around `mNumTransportsStillSettingUp`. We'll
+        // use the monitor for the PresentationHelper object for to achieve that.
+        //
+        final QrEngagementHelper helper = this;
+        mNumTransportsStillSettingUp = 0;
+
+        synchronized (helper) {
+            for (DataTransport transport : mTransports) {
+                transport.setListener(new DataTransport.Listener() {
+                    @Override
+                    public void onListeningSetupCompleted(@Nullable DataRetrievalAddress address) {
+                        mLog.info("onListeningSetupCompleted for " + transport);
+                        synchronized (helper) {
+                            mNumTransportsStillSettingUp -= 1;
+                            if (mNumTransportsStillSettingUp == 0) {
+                                allTransportsAreSetup();
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void onListeningPeerConnecting() {
+                        mLog.info("onListeningPeerConnecting for " + transport);
+                        peerIsConnecting(transport);
+                    }
+
+                    @Override
+                    public void onListeningPeerConnected() {
+                        mLog.info("onListeningPeerConnected for " + transport);
+                        peerHasConnected(transport);
+                    }
+
+                    @Override
+                    public void onListeningPeerDisconnected() {
+                        mLog.info("onListeningPeerDisconnected for " + transport);
+                        transport.close();
+                    }
+
+                    @Override
+                    public void onConnectionResult(@Nullable Throwable error) {
+                        mLog.info("onConnectionResult for " + transport);
+                        if (error != null) {
+                            throw new IllegalStateException("Unexpected onConnectionResult "
+                                    + "callback from transport " + transport, error);
+                        }
+                        throw new IllegalStateException("Unexpected onConnectionResult "
+                                + "callback from transport " + transport);
+                    }
+
+                    @Override
+                    public void onConnectionDisconnected() {
+                        mLog.info("onConnectionDisconnected for " + transport);
+                        throw new IllegalStateException("Unexpected onConnectionDisconnected "
+                                + "callback from transport " + transport);
+                    }
+
+                    @Override
+                    public void onError(@NonNull Throwable error) {
+                        transport.close();
+                        reportError(error);
+                    }
+
+                    @Override
+                    public void onMessageReceived() {
+                        mLog.info("onMessageReceived for " + transport);
+                    }
+
+                    @Override
+                    public void onTransportSpecificSessionTermination() {
+                        mLog.info("Received transport-specific session termination");
+                        transport.close();
+                    }
+
+                }, mExecutor);
+                mLog.info("Listening on transport " + transport);
+                transport.listen();
+                mNumTransportsStillSettingUp += 1;
+            }
+        }
+    }
+
+    private @NonNull
+    byte[] generateDeviceEngagement(@NonNull List<DataRetrievalAddress> listeningAddresses) {
+        DataItem eDeviceKeyBytes = Util.cborBuildTaggedByteString(
+                Util.cborEncode(Util.cborBuildCoseKey(mEphemeralKeyPair.getPublic())));
+
+        DataItem securityDataItem = new CborBuilder()
+                .addArray()
+                .add(1) // cipher suite
+                .add(eDeviceKeyBytes)
+                .end()
+                .build().get(0);
+
+        DataItem deviceRetrievalMethodsDataItem = null;
+        CborBuilder deviceRetrievalMethodsBuilder = new CborBuilder();
+        ArrayBuilder<CborBuilder> arrayBuilder = deviceRetrievalMethodsBuilder.addArray();
+        for (DataRetrievalAddress address : listeningAddresses) {
+            address.addDeviceRetrievalMethodsEntry(arrayBuilder, listeningAddresses);
+        }
+        arrayBuilder.end();
+        deviceRetrievalMethodsDataItem = deviceRetrievalMethodsBuilder.build().get(0);
+
+        CborBuilder builder = new CborBuilder();
+        MapBuilder<CborBuilder> map = builder.addMap();
+        map.put(0, "1.0").put(new UnsignedInteger(1), securityDataItem);
+        if (deviceRetrievalMethodsDataItem != null) {
+            map.put(new UnsignedInteger(2), deviceRetrievalMethodsDataItem);
+        }
+        map.end();
+        return Util.cborEncode(builder.build().get(0));
+    }
+
+    // TODO: handle the case where a transport never calls onListeningSetupCompleted... that
+    //  is, set up a timeout to call this.
+    //
+    void allTransportsAreSetup() {
+        mLog.info("All transports are now set up");
+
+        // Calculate DeviceEngagement and Handover for QR code...
+        //
+        List<DataRetrievalAddress> listeningAddresses = new ArrayList<>();
+        for (DataTransport transport : mTransports) {
+            listeningAddresses.add(transport.getListeningAddress());
+        }
+        mEncodedDeviceEngagement = generateDeviceEngagement(listeningAddresses);
+        mEncodedHandover = Util.cborEncode(SimpleValue.NULL);
+        if (mLog.isEngagementEnabled()) {
+            mLog.engagement("QR DE: " + Util.toHex(mEncodedDeviceEngagement));
+            mLog.engagement("QR handover: " + Util.toHex(mEncodedHandover));
+        }
+
+        reportDeviceEngagementReady();
+    }
+
+
+    public @NonNull
+    String getDeviceEngagementUriEncoded() {
+        String base64EncodedDeviceEngagement =
+                Base64.encodeToString(mEncodedDeviceEngagement,
+                        Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP);
+        Uri uri = new Uri.Builder()
+                .scheme("mdoc")
+                .encodedOpaquePart(base64EncodedDeviceEngagement)
+                .build();
+        String uriString = uri.toString();
+        mLog.info("qrCode URI: " + uriString);
+        return uriString;
+    }
+
+    public @NonNull
+    byte[] getDeviceEngagement() {
+        return mEncodedDeviceEngagement;
+    }
+
+    public @NonNull
+    byte[] getHandover() {
+        return mEncodedHandover;
+    }
+
+    void peerIsConnecting(@NonNull DataTransport transport) {
+        if (!mReportedDeviceConnecting) {
+            mReportedDeviceConnecting = true;
+            reportDeviceConnecting();
+        }
+    }
+
+    void peerHasConnected(@NonNull DataTransport transport) {
+        // stop listening on other transports
+        //
+        mLog.info("Peer has connected on transport " + transport
+                + " - shutting down other transports");
+        for (DataTransport t : mTransports) {
+            if (t != transport) {
+                t.setListener(null, null);
+                t.close();
+            }
+        }
+        mTransports.clear();
+
+        transport.setListener(null, null);
+        reportDeviceConnected(transport);
+    }
+
+
+    // Note: The report*() methods are safe to call from any thread.
+
+    void reportDeviceEngagementReady() {
+        mLog.info("reportDeviceEngagementReady");
+        final Listener listener = mListener;
+        final Executor executor = mExecutor;
+        if (!mInhibitCallbacks && listener != null && executor != null) {
+            executor.execute(listener::onDeviceEngagementReady);
+        }
+    }
+
+    void reportDeviceConnecting() {
+        mLog.info("reportDeviceConnecting");
+        final Listener listener = mListener;
+        final Executor executor = mExecutor;
+        if (!mInhibitCallbacks && listener != null && executor != null) {
+            executor.execute(listener::onDeviceConnecting);
+        }
+    }
+
+    void reportDeviceConnected(DataTransport transport) {
+        mLog.info("reportDeviceConnected");
+        final Listener listener = mListener;
+        final Executor executor = mExecutor;
+        if (!mInhibitCallbacks && listener != null && executor != null) {
+            executor.execute(() -> listener.onDeviceConnected(transport));
+        }
+    }
+
+    void reportError(@NonNull Throwable error) {
+        mLog.info("reportError: error: ", error);
+        final Listener listener = mListener;
+        final Executor executor = mExecutor;
+        if (!mInhibitCallbacks && listener != null && executor != null) {
+            executor.execute(() -> listener.onError(error));
+        }
+    }
+
+    public interface Listener {
+        void onDeviceEngagementReady();
+        void onDeviceConnecting();
+        void onDeviceConnected(DataTransport transport);
+        void onError(@NonNull Throwable error);
+    }
+}

--- a/identity/src/main/java/com/android/identity/VerificationHelper.java
+++ b/identity/src/main/java/com/android/identity/VerificationHelper.java
@@ -476,7 +476,12 @@ public class VerificationHelper {
             }
 
             @Override
-            public void onMessageReceived(@NonNull byte[] data) {
+            public void onMessageReceived() {
+                byte[] data = mDataTransport.getMessage();
+                if (data == null) {
+                    reportError(new Error("onMessageReceived but no message"));
+                    return;
+                }
                 if (mSessionEncryptionReader == null) {
                     reportError(new IllegalStateException("Message received but no session "
                             + "establishment with the remote device."));


### PR DESCRIPTION
This introduces two new classes QrEngagementHelper and NfcEngagementHelper which implements QR engagement and NFC engagement (static handover) as per 18013-5. Introduce a new class NfcApduRouter to help facilitate the application delivering APDUs to now various distinct pieces of functionality.

Also change reference application to not show QR code by default. Implementation-wise this means that we only spin up BLE radios when either the QR code is shown or when handling NFC engagement. This helps save battery and reduce attack surface.

This is prep work for both 18013-7 mdoc:// support (upcoming ReaderEngagement{Parser, Generator}, DataTransportHttp types) and also NFC negotiated handover support.

It also lays the groundwork for alternative forms of engagement, in a future change concrete DataTransport types (for BLE, Wifi Aware, etc.) will be exposed.

Test: All unit tests pass.
Test: Manually tested using both QR and NFC engagement w/ all transports.