### PR TITLE
Add EngagementGenerator and EngagementParser.

### DIFF
--- a/identity/src/androidTest/java/com/android/identity/ConnectionMethodTest.java
+++ b/identity/src/androidTest/java/com/android/identity/ConnectionMethodTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import androidx.test.filters.SmallTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.OptionalLong;
+import java.util.UUID;
+
+public class ConnectionMethodTest {
+
+    @Test
+    @SmallTest
+    public void testConnectionMethodNfc() {
+        ConnectionMethodNfc cm = new ConnectionMethodNfc(4096, 32768);
+        ConnectionMethodNfc decoded = ConnectionMethodNfc.decode(cm.encode());
+        Assert.assertEquals(cm.getCommandDataFieldMaxLength(), decoded.getCommandDataFieldMaxLength());
+        Assert.assertEquals(cm.getResponseDataFieldMaxLength(), decoded.getResponseDataFieldMaxLength());
+        Assert.assertEquals("[\n" +
+                "  1,\n" +
+                "  1,\n" +
+                "  {\n" +
+                "    0 : 4096,\n" +
+                "    1 : 32768\n" +
+                "  }\n" +
+                "]", Util.cborPrettyPrint(cm.encode()));
+    }
+
+    @Test
+    @SmallTest
+    public void testConnectionMethodBle() {
+        UUID uuidPeripheral = new UUID(0, 1);
+        UUID uuidCentral = new UUID(123456789, 987654321);
+        ConnectionMethodBle cm = new ConnectionMethodBle(
+                true,
+                true,
+                uuidPeripheral,
+                uuidCentral);
+        ConnectionMethodBle decoded = ConnectionMethodBle.decode(cm.encode());
+        Assert.assertTrue(cm.getSupportsPeripheralServerMode());
+        Assert.assertTrue(cm.getSupportsCentralClientMode());
+        Assert.assertEquals(uuidPeripheral, cm.getPeripheralServerModeUuid());
+        Assert.assertEquals(uuidCentral, cm.getCentralClientModeUuid());
+        Assert.assertEquals("[\n" +
+                "  2,\n" +
+                "  1,\n" +
+                "  {\n" +
+                "    0 : true,\n" +
+                "    1 : true,\n" +
+                "    10 : [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01],\n" +
+                "    11 : [0x00, 0x00, 0x00, 0x00, 0x07, 0x5b, 0xcd, 0x15, 0x00, 0x00, 0x00, 0x00, 0x3a, 0xde, 0x68, 0xb1]\n" +
+                "  }\n" +
+                "]", Util.cborPrettyPrint(cm.encode()));
+    }
+
+    @Test
+    @SmallTest
+    public void testConnectionMethodBleOnlyCentralClient() {
+        UUID uuid = new UUID(123456789, 987654321);
+        ConnectionMethodBle cm = new ConnectionMethodBle(
+                false,
+                true,
+                null,
+                uuid);
+        ConnectionMethodBle decoded = ConnectionMethodBle.decode(cm.encode());
+        Assert.assertFalse(cm.getSupportsPeripheralServerMode());
+        Assert.assertTrue(cm.getSupportsCentralClientMode());
+        Assert.assertNull(cm.getPeripheralServerModeUuid());
+        Assert.assertEquals(uuid, cm.getCentralClientModeUuid());
+        Assert.assertEquals("[\n" +
+                "  2,\n" +
+                "  1,\n" +
+                "  {\n" +
+                "    0 : false,\n" +
+                "    1 : true,\n" +
+                "    11 : [0x00, 0x00, 0x00, 0x00, 0x07, 0x5b, 0xcd, 0x15, 0x00, 0x00, 0x00, 0x00, 0x3a, 0xde, 0x68, 0xb1]\n" +
+                "  }\n" +
+                "]", Util.cborPrettyPrint(cm.encode()));
+    }
+
+    @Test
+    @SmallTest
+    public void testConnectionMethodBleOnlyPeripheralServer() {
+        UUID uuid = new UUID(0, 1);
+        ConnectionMethodBle cm = new ConnectionMethodBle(
+                true,
+                false,
+                uuid,
+                null);
+        ConnectionMethodBle decoded = ConnectionMethodBle.decode(cm.encode());
+        Assert.assertTrue(cm.getSupportsPeripheralServerMode());
+        Assert.assertFalse(cm.getSupportsCentralClientMode());
+        Assert.assertEquals(uuid, cm.getPeripheralServerModeUuid());
+        Assert.assertNull(cm.getCentralClientModeUuid());
+        Assert.assertEquals("[\n" +
+                "  2,\n" +
+                "  1,\n" +
+                "  {\n" +
+                "    0 : true,\n" +
+                "    1 : false,\n" +
+                "    10 : [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]\n" +
+                "  }\n" +
+                "]", Util.cborPrettyPrint(cm.encode()));
+    }
+
+    @Test
+    @SmallTest
+    public void testConnectionMethodWifiAware() {
+        ConnectionMethodWifiAware cm = new ConnectionMethodWifiAware(
+                "foobar",
+                OptionalLong.of(42),
+                OptionalLong.of(43),
+                new byte[] {1, 2});
+        ConnectionMethodWifiAware decoded = ConnectionMethodWifiAware.decode(cm.encode());
+        Assert.assertEquals("foobar", cm.getPassphraseInfoPassphrase());
+        Assert.assertEquals(42, cm.getChannelInfoChannelNumber().getAsLong());
+        Assert.assertEquals(43, cm.getChannelInfoOperatingClass().getAsLong());
+        Assert.assertArrayEquals(new byte[] {1, 2}, cm.getBandInfoSupportedBands());
+        Assert.assertEquals("[\n" +
+                "  3,\n" +
+                "  1,\n" +
+                "  {\n" +
+                "    0 : 'foobar',\n" +
+                "    2 : 42,\n" +
+                "    1 : 43,\n" +
+                "    3 : [0x01, 0x02]\n" +
+                "  }\n" +
+                "]", Util.cborPrettyPrint(cm.encode()));
+    }
+
+    @Test
+    @SmallTest
+    public void testConnectionMethodRestApi() {
+        ConnectionMethodRestApi cm = new ConnectionMethodRestApi("www.example.com/mdocReader");
+        ConnectionMethodRestApi decoded = ConnectionMethodRestApi.decode(cm.encode());
+        Assert.assertEquals(decoded.getUriWebsite(), cm.getUriWebsite());
+        Assert.assertEquals("[\n" +
+                "  4,\n" +
+                "  1,\n" +
+                "  {\n" +
+                "    0 : 'www.example.com/mdocReader'\n" +
+                "  }\n" +
+                "]", Util.cborPrettyPrint(cm.encode()));
+    }
+}

--- a/identity/src/androidTest/java/com/android/identity/EngagementGeneratorTest.java
+++ b/identity/src/androidTest/java/com/android/identity/EngagementGeneratorTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import static com.android.identity.EngagementGenerator.ENGAGEMENT_VERSION_1_0;
+import static com.android.identity.EngagementGenerator.ENGAGEMENT_VERSION_1_1;
+
+import android.security.keystore.KeyProperties;
+
+import androidx.test.filters.SmallTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.ECGenParameterSpec;
+import java.util.UUID;
+
+public class EngagementGeneratorTest {
+
+    @Test
+    @SmallTest
+    public void testNoConnectionMethodsOrOriginInfos() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_EC);
+        ECGenParameterSpec ecSpec = new ECGenParameterSpec("prime256v1");
+        kpg.initialize(ecSpec);
+        KeyPair eSenderKey = kpg.generateKeyPair();
+
+        EngagementGenerator eg = new EngagementGenerator(eSenderKey.getPublic(),
+                ENGAGEMENT_VERSION_1_0);
+        byte[] encodedEngagement = eg.generate();
+
+        EngagementParser parser = new EngagementParser(encodedEngagement);
+        EngagementParser.Engagement engagement = parser.parse();
+
+        Assert.assertEquals(engagement.getESenderKey(), eSenderKey.getPublic());
+        Assert.assertEquals(ENGAGEMENT_VERSION_1_0, engagement.getVersion());
+        Assert.assertEquals(0, engagement.getConnectionMethods().size());
+        Assert.assertEquals(0, engagement.getOriginInfos().size());
+    }
+
+    @Test
+    @SmallTest
+    public void testWebsiteEngagement() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_EC);
+        ECGenParameterSpec ecSpec = new ECGenParameterSpec("prime256v1");
+        kpg.initialize(ecSpec);
+        KeyPair eSenderKey = kpg.generateKeyPair();
+
+        EngagementGenerator eg = new EngagementGenerator(eSenderKey.getPublic(),
+                ENGAGEMENT_VERSION_1_1);
+        eg.addConnectionMethod(new ConnectionMethodRestApi("www.example.com/verifier/123"));
+        eg.addOriginInfo(new OriginInfoWebsite(OriginInfo.CAT_DELIVERY, "www.example.com/verifier"));
+        byte[] encodedEngagement = eg.generate();
+
+        EngagementParser parser = new EngagementParser(encodedEngagement);
+        EngagementParser.Engagement engagement = parser.parse();
+
+        Assert.assertEquals(engagement.getESenderKey(), eSenderKey.getPublic());
+        Assert.assertEquals(ENGAGEMENT_VERSION_1_1, engagement.getVersion());
+        Assert.assertEquals(1, engagement.getConnectionMethods().size());
+        ConnectionMethodRestApi cm = (ConnectionMethodRestApi) engagement.getConnectionMethods().get(0);
+        Assert.assertEquals("www.example.com/verifier/123", cm.getUriWebsite());
+        Assert.assertEquals(1, engagement.getOriginInfos().size());
+        OriginInfoWebsite oi = (OriginInfoWebsite) engagement.getOriginInfos().get(0);
+        Assert.assertEquals("www.example.com/verifier", oi.getBaseUrl());
+    }
+
+    @Test
+    @SmallTest
+    public void testDeviceEngagementQrBleCentralClientMode() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_EC);
+        ECGenParameterSpec ecSpec = new ECGenParameterSpec("prime256v1");
+        kpg.initialize(ecSpec);
+        KeyPair eSenderKey = kpg.generateKeyPair();
+
+        UUID uuid = UUID.randomUUID();
+        EngagementGenerator eg = new EngagementGenerator(eSenderKey.getPublic(),
+                ENGAGEMENT_VERSION_1_0);
+        eg.addConnectionMethod(new ConnectionMethodBle(
+                false,
+                true,
+                null,
+                uuid));
+        byte[] encodedEngagement = eg.generate();
+
+        EngagementParser parser = new EngagementParser(encodedEngagement);
+        EngagementParser.Engagement engagement = parser.parse();
+
+        Assert.assertEquals(engagement.getESenderKey(), eSenderKey.getPublic());
+        Assert.assertEquals(ENGAGEMENT_VERSION_1_0, engagement.getVersion());
+
+        Assert.assertEquals(1, engagement.getConnectionMethods().size());
+        ConnectionMethodBle cm = (ConnectionMethodBle) engagement.getConnectionMethods().get(0);
+        Assert.assertFalse(cm.getSupportsPeripheralServerMode());
+        Assert.assertTrue(cm.getSupportsCentralClientMode());
+        Assert.assertNull(cm.getPeripheralServerModeUuid());
+        Assert.assertEquals(uuid, cm.getCentralClientModeUuid());
+
+        Assert.assertEquals(0, engagement.getOriginInfos().size());
+    }
+}

--- a/identity/src/androidTest/java/com/android/identity/EngagementParserTest.java
+++ b/identity/src/androidTest/java/com/android/identity/EngagementParserTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import androidx.test.filters.SmallTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class EngagementParserTest {
+    @Test
+    @SmallTest
+    public void testDeviceRequestEngagementWithVectors() {
+        byte[] deviceEngagement = Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_ENGAGEMENT);
+        EngagementParser parser = new EngagementParser(deviceEngagement);
+        EngagementParser.Engagement engagement = parser.parse();
+        Assert.assertEquals("1.0", engagement.getVersion());
+
+        List<ConnectionMethod> connectionMethods = engagement.getConnectionMethods();
+        Assert.assertEquals(1, connectionMethods.size());
+        Assert.assertTrue(connectionMethods.get(0) instanceof ConnectionMethodBle);
+        ConnectionMethodBle cmBle = (ConnectionMethodBle) connectionMethods.get(0);
+        Assert.assertFalse(cmBle.getSupportsPeripheralServerMode());
+        Assert.assertTrue(cmBle.getSupportsCentralClientMode());
+        Assert.assertNull(cmBle.getPeripheralServerModeUuid());
+        Assert.assertEquals("45efef74-2b2c-4837-a9a3-b0e1d05a6917",
+                cmBle.getCentralClientModeUuid().toString());
+    }
+}

--- a/identity/src/androidTest/java/com/android/identity/OriginInfoTest.java
+++ b/identity/src/androidTest/java/com/android/identity/OriginInfoTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import androidx.test.filters.SmallTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OriginInfoTest {
+    @Test
+    @SmallTest
+    public void testOriginInfoQr() {
+        OriginInfoQr info = new OriginInfoQr(OriginInfo.CAT_RECEIVE);
+        OriginInfoQr decoded = info.decode(info.encode());
+        Assert.assertEquals(OriginInfo.CAT_RECEIVE, decoded.getCat());
+        Assert.assertEquals("[1, 2, null]", Util.cborPrettyPrint(info.encode()));
+    }
+
+    @Test
+    @SmallTest
+    public void testOriginInfoQrDelivery() {
+        OriginInfoQr info = new OriginInfoQr(OriginInfo.CAT_DELIVERY);
+        OriginInfoQr decoded = info.decode(info.encode());
+        Assert.assertEquals(OriginInfo.CAT_DELIVERY, decoded.getCat());
+        Assert.assertEquals("[0, 2, null]", Util.cborPrettyPrint(info.encode()));
+    }
+
+    @Test
+    @SmallTest
+    public void testOriginInfoNfc() {
+        OriginInfoNfc info = new OriginInfoNfc(OriginInfo.CAT_RECEIVE);
+        OriginInfoNfc decoded = info.decode(info.encode());
+        Assert.assertEquals(OriginInfo.CAT_RECEIVE, decoded.getCat());
+        Assert.assertEquals("[1, 3, null]", Util.cborPrettyPrint(info.encode()));
+    }
+
+    @Test
+    @SmallTest
+    public void testOriginInfoNfcDelivery() {
+        OriginInfoNfc info = new OriginInfoNfc(OriginInfo.CAT_DELIVERY);
+        OriginInfoNfc decoded = info.decode(info.encode());
+        Assert.assertEquals(OriginInfo.CAT_DELIVERY, decoded.getCat());
+        Assert.assertEquals("[0, 3, null]", Util.cborPrettyPrint(info.encode()));
+    }
+
+    @Test
+    @SmallTest
+    public void testOriginInfoWebsite() {
+        OriginInfoWebsite info = new OriginInfoWebsite(OriginInfo.CAT_RECEIVE, "foo.com/bar");
+        OriginInfoWebsite decoded = info.decode(info.encode());
+        Assert.assertEquals(OriginInfo.CAT_RECEIVE, decoded.getCat());
+        Assert.assertEquals("foo.com/bar", decoded.getBaseUrl());
+        Assert.assertEquals("[\n" +
+                "  1,\n" +
+                "  1,\n" +
+                "  {\n" +
+                "    'baseUrl' : 'foo.com/bar'\n" +
+                "  }\n" +
+                "]", Util.cborPrettyPrint(info.encode()));
+    }
+
+    @Test
+    @SmallTest
+    public void testOriginInfoWebsiteDelivery() {
+        OriginInfoWebsite info = new OriginInfoWebsite(OriginInfo.CAT_DELIVERY, "foo.com/baz");
+        OriginInfoWebsite decoded = info.decode(info.encode());
+        Assert.assertEquals(OriginInfo.CAT_DELIVERY, decoded.getCat());
+        Assert.assertEquals("foo.com/baz", decoded.getBaseUrl());
+        Assert.assertEquals("[\n" +
+                "  0,\n" +
+                "  1,\n" +
+                "  {\n" +
+                "    'baseUrl' : 'foo.com/baz'\n" +
+                "  }\n" +
+                "]", Util.cborPrettyPrint(info.encode()));
+    }
+
+}

--- a/identity/src/androidTest/java/com/android/identity/ReaderAuthTest.java
+++ b/identity/src/androidTest/java/com/android/identity/ReaderAuthTest.java
@@ -202,6 +202,8 @@ public class ReaderAuthTest {
                         .putEntry(mdlNs, "Accessible to C", idsReaderAuthC,
                                 Util.cborEncodeString("bat"))
                         .build();
+        Collection<X509Certificate> credentialKeyCertificateChain =
+                wc.getCredentialKeyCertificateChain(new byte[] {1, 2});  // Don't care about this.
         byte[] proofOfProvisioningSignature = wc.personalize(personalizationData);
         byte[] proofOfProvisioning =
                 Util.coseSign1GetData(Util.cborDecode(proofOfProvisioningSignature));

--- a/identity/src/androidTest/java/com/android/identity/TestVectors.java
+++ b/identity/src/androidTest/java/com/android/identity/TestVectors.java
@@ -17,6 +17,11 @@
 package com.android.identity;
 
 public class TestVectors {
+    static final String ISO_18013_5_ANNEX_D_DEVICE_ENGAGEMENT =
+            "a30063312e30018201d818584ba4010220012158205a88d182bce5f42efa59943f33359d2"
+            + "e8a968ff289d93e5fa444b624343167fe225820b16e8cf858ddc7690407ba61d4c338237a"
+            + "8cfcf3de6aa672fc60a557aa32fc670281830201a300f401f50b5045efef742b2c4837a9a"
+            + "3b0e1d05a6917";
 
     static final String ISO_18013_5_ANNEX_D_DEVICE_RESPONSE =
             "a36776657273696f6e63312e3069646f63756d656e747381a367646f6354797065756f72672e69736"

--- a/identity/src/main/java/com/android/identity/ConnectionMethod.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethod.java
@@ -1,0 +1,55 @@
+package com.android.identity;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Number;
+
+/**
+ * A class representing the ConnectionMethod structure exchanged between mdoc and mdoc reader.
+ *
+ * <p>This is an abstract class - applications are expected to interact with concrete
+ * implementations, for example {@link ConnectionMethodBle} or {@link ConnectionMethodNfc}.
+ */
+public abstract class ConnectionMethod {
+    private static final String TAG = "ConnectionMethod";
+
+    abstract @NonNull
+    DataItem encode();
+
+    static @Nullable
+    ConnectionMethod decode(@NonNull DataItem cmDataItem) {
+        if (!(cmDataItem instanceof co.nstant.in.cbor.model.Array)) {
+            throw new IllegalArgumentException("Top-level CBOR is not an array");
+        }
+        List<DataItem> items = ((Array) cmDataItem).getDataItems();
+        if (items.size() != 3) {
+            throw new IllegalArgumentException("Expected array with 3 elements, got " + items.size());
+        }
+        if (!(items.get(0) instanceof Number) || !(items.get(1) instanceof Number)) {
+            throw new IllegalArgumentException("First two items are not numbers");
+        }
+        long type = ((Number) items.get(0)).getValue().longValue();
+        if (!(items.get(2) instanceof co.nstant.in.cbor.model.Map)) {
+            throw new IllegalArgumentException("Third item is not a map");
+        }
+        switch ((int) type) {
+            case ConnectionMethodNfc.METHOD_TYPE:
+                return ConnectionMethodNfc.decode(cmDataItem);
+            case ConnectionMethodBle.METHOD_TYPE:
+                return ConnectionMethodBle.decode(cmDataItem);
+            case ConnectionMethodWifiAware.METHOD_TYPE:
+                return ConnectionMethodWifiAware.decode(cmDataItem);
+            case ConnectionMethodRestApi.METHOD_TYPE:
+                return ConnectionMethodRestApi.decode(cmDataItem);
+        }
+        Log.w(TAG, "Unsupported type " + type);
+        return null;
+    }
+}

--- a/identity/src/main/java/com/android/identity/ConnectionMethodBle.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethodBle.java
@@ -1,0 +1,161 @@
+package com.android.identity;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+import java.util.UUID;
+
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.builder.MapBuilder;
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Map;
+import co.nstant.in.cbor.model.Number;
+
+/**
+ * Connection method for BLE.
+ */
+public class ConnectionMethodBle extends ConnectionMethod {
+    private static final String TAG = "ConnectionOptionsBle";
+    private boolean mSupportsPeripheralServerMode;
+    private boolean mSupportsCentralClientMode;
+    private UUID mPeripheralServerModeUuid;
+    private UUID mCentralClientModeUuid;
+
+    static final int METHOD_TYPE = 2;
+    static final int METHOD_MAX_VERSION = 1;
+    private static final int OPTION_KEY_SUPPORTS_PERIPHERAL_SERVER_MODE = 0;
+    private static final int OPTION_KEY_SUPPORTS_CENTRAL_CLIENT_MODE = 1;
+    private static final int OPTION_KEY_PERIPHERAL_SERVER_MODE_UUID = 10;
+    private static final int OPTION_KEY_CENTRAL_CLIENT_MODE_UUID = 11;
+    private static final int OPTION_KEY_PERIPHERAL_SERVER_MODE_BLE_DEVICE_ADDRESS = 20;
+
+    /**
+     * Creates a new connection method for BLE.
+     *
+     * @param supportsPeripheralServerMode whether mdoc peripheral mode is supported.
+     * @param supportsCentralClientMode whether mdoc central client mode is supported.
+     * @param peripheralServerModeUuid the UUID to use for mdoc peripheral server mode.
+     * @param centralClientModeUuid the UUID to use for mdoc central client mode.
+     */
+    public ConnectionMethodBle(boolean supportsPeripheralServerMode,
+                               boolean supportsCentralClientMode,
+                               @Nullable UUID peripheralServerModeUuid,
+                               @Nullable UUID centralClientModeUuid) {
+        mSupportsPeripheralServerMode = supportsPeripheralServerMode;
+        mSupportsCentralClientMode = supportsCentralClientMode;
+        mPeripheralServerModeUuid = peripheralServerModeUuid;
+        mCentralClientModeUuid = centralClientModeUuid;
+    }
+
+    /**
+     * Gets whether the connection method indicates that mdoc peripheral server mode is enabled.
+     *
+     * @return the value.
+     */
+    public boolean getSupportsPeripheralServerMode() {
+        return mSupportsPeripheralServerMode;
+    }
+
+    /**
+     * Gets whether the connection method indicates that mdoc central client mode is enabled.
+     *
+     * @return the value.
+     */
+    public boolean getSupportsCentralClientMode() {
+        return mSupportsCentralClientMode;
+    }
+
+    /**
+     * Gets the UUID used for mdoc peripheral server mode, if any.
+     *
+     * @return the value or {@code null}.
+     */
+    public @Nullable UUID getPeripheralServerModeUuid() {
+        return mPeripheralServerModeUuid;
+    }
+
+    /**
+     * Gets the UUID used for mdoc central client mode, if any.
+     *
+     * @return the value or {@code null}.
+     */
+    public @Nullable UUID getCentralClientModeUuid() {
+        return mCentralClientModeUuid;
+    }
+
+    @NonNull
+    @Override
+    DataItem encode() {
+        MapBuilder<CborBuilder> builder = new CborBuilder().addMap();
+        builder.put(OPTION_KEY_SUPPORTS_PERIPHERAL_SERVER_MODE, mSupportsPeripheralServerMode);
+        builder.put(OPTION_KEY_SUPPORTS_CENTRAL_CLIENT_MODE, mSupportsCentralClientMode);
+        if (mPeripheralServerModeUuid != null) {
+            builder.put(OPTION_KEY_PERIPHERAL_SERVER_MODE_UUID, Util.uuidToBytes(mPeripheralServerModeUuid));
+        }
+        if (mCentralClientModeUuid != null) {
+            builder.put(OPTION_KEY_CENTRAL_CLIENT_MODE_UUID, Util.uuidToBytes(mCentralClientModeUuid));
+        }
+        // TODO: add support for OPTION_KEY_PERIPHERAL_SERVER_MODE_BLE_DEVICE_ADDRESS
+        return new CborBuilder()
+                .addArray()
+                .add(METHOD_TYPE)
+                .add(METHOD_MAX_VERSION)
+                .add(builder.end().build().get(0))
+                .end()
+                .build().get(0);
+    }
+
+    @Nullable
+    static ConnectionMethodBle decode(@NonNull DataItem cmDataItem) {
+        if (!(cmDataItem instanceof co.nstant.in.cbor.model.Array)) {
+            throw new IllegalArgumentException("Top-level CBOR is not an array");
+        }
+        List<DataItem> items = ((Array) cmDataItem).getDataItems();
+        if (items.size() != 3) {
+            throw new IllegalArgumentException("Expected array with 3 elements, got " + items.size());
+        }
+        if (!(items.get(0) instanceof Number) || !(items.get(1) instanceof Number)) {
+            throw new IllegalArgumentException("First two items are not numbers");
+        }
+        long type = ((Number) items.get(0)).getValue().longValue();
+        long version = ((Number) items.get(1)).getValue().longValue();
+        if (!(items.get(2) instanceof co.nstant.in.cbor.model.Map)) {
+            throw new IllegalArgumentException("Third item is not a map");
+        }
+        DataItem options = (Map) items.get(2);
+        if (type != METHOD_TYPE) {
+            Log.w(TAG, "Unexpected method type " + type);
+            return null;
+        }
+        if (version > METHOD_MAX_VERSION) {
+            Log.w(TAG, "Unsupported options version " + version);
+            return null;
+        }
+        boolean supportsPeripheralServerMode =
+                Util.cborMapExtractBoolean(options, OPTION_KEY_SUPPORTS_PERIPHERAL_SERVER_MODE);
+        boolean supportsCentralClientMode =
+                Util.cborMapExtractBoolean(options, OPTION_KEY_SUPPORTS_CENTRAL_CLIENT_MODE);
+        UUID peripheralServerModeUuid = null;
+        if (Util.cborMapHasKey(options, OPTION_KEY_PERIPHERAL_SERVER_MODE_UUID)) {
+            peripheralServerModeUuid =
+                    Util.uuidFromBytes(Util.cborMapExtractByteString(options,
+                            OPTION_KEY_PERIPHERAL_SERVER_MODE_UUID));
+        }
+        UUID centralClientModeUuid = null;
+        if (Util.cborMapHasKey(options, OPTION_KEY_CENTRAL_CLIENT_MODE_UUID)) {
+            centralClientModeUuid =
+                    Util.uuidFromBytes(Util.cborMapExtractByteString(options,
+                            OPTION_KEY_CENTRAL_CLIENT_MODE_UUID));
+        }
+
+        return new ConnectionMethodBle(
+                supportsPeripheralServerMode,
+                supportsCentralClientMode,
+                peripheralServerModeUuid,
+                centralClientModeUuid);
+    }
+}

--- a/identity/src/main/java/com/android/identity/ConnectionMethodNfc.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethodNfc.java
@@ -1,0 +1,105 @@
+package com.android.identity;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.builder.MapBuilder;
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Map;
+import co.nstant.in.cbor.model.Number;
+
+/**
+ * Connection method for NFC.
+ */
+public class ConnectionMethodNfc extends ConnectionMethod {
+    private static final String TAG = "ConnectionMethodNfc";
+    private final long mCommandDataFieldMaxLength;
+    private final long mResponseDataFieldMaxLength;
+
+    static final int METHOD_TYPE = 1;
+    static final int METHOD_MAX_VERSION = 1;
+    private static final int OPTION_KEY_COMMAND_DATA_FIELD_MAX_LENGTH = 0;
+    private static final int OPTION_KEY_RESPONSE_DATA_FIELD_MAX_LENGTH = 1;
+
+    /**
+     * Creates a new connection method for NFC.
+     *
+     * @param commandDataFieldMaxLength the maximum length for the command data field.
+     * @param responseDataFieldMaxLength the maximum length of the response data field.
+     */
+    public ConnectionMethodNfc(long commandDataFieldMaxLength,
+                               long responseDataFieldMaxLength) {
+        mCommandDataFieldMaxLength = commandDataFieldMaxLength;
+        mResponseDataFieldMaxLength = responseDataFieldMaxLength;
+    }
+
+    /**
+     * Gets the maximum length for the command data field.
+     *
+     * @return the value.
+     */
+    public long getCommandDataFieldMaxLength() {
+        return mCommandDataFieldMaxLength;
+    }
+
+    /**
+     * Gets the maximum length for the response data field.
+     *
+     * @return the value.
+     */
+    public long getResponseDataFieldMaxLength() {
+        return mResponseDataFieldMaxLength;
+    }
+
+    @NonNull
+    @Override
+    DataItem encode() {
+        MapBuilder<CborBuilder> builder = new CborBuilder().addMap();
+        builder.put(OPTION_KEY_COMMAND_DATA_FIELD_MAX_LENGTH, mCommandDataFieldMaxLength);
+        builder.put(OPTION_KEY_RESPONSE_DATA_FIELD_MAX_LENGTH, mResponseDataFieldMaxLength);
+        return new CborBuilder()
+                .addArray()
+                .add(METHOD_TYPE)
+                .add(METHOD_MAX_VERSION)
+                .add(builder.end().build().get(0))
+                .end()
+                .build().get(0);
+    }
+
+    @Nullable
+    static ConnectionMethodNfc decode(@NonNull DataItem cmDataItem) {
+        if (!(cmDataItem instanceof co.nstant.in.cbor.model.Array)) {
+            throw new IllegalArgumentException("Top-level CBOR is not an array");
+        }
+        List<DataItem> items = ((Array) cmDataItem).getDataItems();
+        if (items.size() != 3) {
+            throw new IllegalArgumentException("Expected array with 3 elements, got " + items.size());
+        }
+        if (!(items.get(0) instanceof Number) || !(items.get(1) instanceof Number)) {
+            throw new IllegalArgumentException("First two items are not numbers");
+        }
+        long type = ((Number) items.get(0)).getValue().longValue();
+        long version = ((Number) items.get(1)).getValue().longValue();
+        if (!(items.get(2) instanceof co.nstant.in.cbor.model.Map)) {
+            throw new IllegalArgumentException("Third item is not a map");
+        }
+        DataItem options = (Map) items.get(2);
+        if (type != METHOD_TYPE) {
+            Log.w(TAG, "Unexpected method type " + type);
+            return null;
+        }
+        if (version > METHOD_MAX_VERSION) {
+            Log.w(TAG, "Unsupported options version " + version);
+            return null;
+        }
+        return new ConnectionMethodNfc(
+                Util.cborMapExtractNumber(options, OPTION_KEY_COMMAND_DATA_FIELD_MAX_LENGTH),
+                Util.cborMapExtractNumber(options, OPTION_KEY_RESPONSE_DATA_FIELD_MAX_LENGTH));
+    }
+}

--- a/identity/src/main/java/com/android/identity/ConnectionMethodRestApi.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethodRestApi.java
@@ -1,0 +1,89 @@
+package com.android.identity;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.builder.MapBuilder;
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Map;
+import co.nstant.in.cbor.model.Number;
+
+/**
+ * Connection method for REST API.
+ */
+public class ConnectionMethodRestApi extends ConnectionMethod {
+    private static final String TAG = "ConnectionOptionsRestApi";
+    private String mUriWebsite;
+
+    static final int METHOD_TYPE = 4;
+    static final int METHOD_MAX_VERSION = 1;
+    private static final int OPTION_KEY_URI_WEBSITE = 0;
+
+    /**
+     * Creates a new connection method for REST API.
+     *
+     * @param uriWebsite the URL for the website.
+     */
+    public ConnectionMethodRestApi(@NonNull String uriWebsite) {
+        mUriWebsite = uriWebsite;
+    }
+
+    /**
+     * Gets the URL for the website.
+     *
+     * @return the website URL.
+     */
+    public @NonNull String getUriWebsite() {
+        return mUriWebsite;
+    }
+
+    @NonNull
+    @Override
+    DataItem encode() {
+        MapBuilder<CborBuilder> builder = new CborBuilder().addMap();
+        builder.put(OPTION_KEY_URI_WEBSITE, mUriWebsite);
+        return new CborBuilder()
+                .addArray()
+                .add(METHOD_TYPE)
+                .add(METHOD_MAX_VERSION)
+                .add(builder.end().build().get(0))
+                .end()
+                .build().get(0);
+    }
+
+    @Nullable
+    static ConnectionMethodRestApi decode(@NonNull DataItem cmDataItem) {
+        if (!(cmDataItem instanceof co.nstant.in.cbor.model.Array)) {
+            throw new IllegalArgumentException("Top-level CBOR is not an array");
+        }
+        List<DataItem> items = ((Array) cmDataItem).getDataItems();
+        if (items.size() != 3) {
+            throw new IllegalArgumentException("Expected array with 3 elements, got " + items.size());
+        }
+        if (!(items.get(0) instanceof Number) || !(items.get(1) instanceof Number)) {
+            throw new IllegalArgumentException("First two items are not numbers");
+        }
+        long type = ((Number) items.get(0)).getValue().longValue();
+        long version = ((Number) items.get(1)).getValue().longValue();
+        if (!(items.get(2) instanceof co.nstant.in.cbor.model.Map)) {
+            throw new IllegalArgumentException("Third item is not a map");
+        }
+        DataItem options = (Map) items.get(2);
+        if (type != METHOD_TYPE) {
+            Log.w(TAG, "Unexpected method type " + type);
+            return null;
+        }
+        if (version > METHOD_MAX_VERSION) {
+            Log.w(TAG, "Unsupported options version " + version);
+            return null;
+        }
+        return new ConnectionMethodRestApi(
+                Util.cborMapExtractString(options, OPTION_KEY_URI_WEBSITE));
+    }
+}

--- a/identity/src/main/java/com/android/identity/ConnectionMethodWifiAware.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethodWifiAware.java
@@ -1,0 +1,168 @@
+package com.android.identity;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+import java.util.OptionalLong;
+
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.builder.MapBuilder;
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Map;
+import co.nstant.in.cbor.model.Number;
+
+/**
+ * Connection method for Wifi Aware.
+ */
+public class ConnectionMethodWifiAware extends ConnectionMethod {
+    private static final String TAG = "ConnectionMethodWifiAware";
+    private final String mPassphraseInfoPassphrase;
+    private final OptionalLong mChannelInfoChannelNumber;
+    private final OptionalLong mChannelInfoOperatingClass;
+    private final byte[] mBandInfoSupportedBands;
+
+    static final int METHOD_TYPE = 3;
+    static final int METHOD_MAX_VERSION = 1;
+    private static final int OPTION_KEY_PASSPHRASE_INFO_PASSPHRASE = 0;
+    private static final int OPTION_KEY_CHANNEL_INFO_OPERATING_CLASS = 1;
+    private static final int OPTION_KEY_CHANNEL_INFO_CHANNEL_NUMBER = 2;
+    private static final int OPTION_KEY_BAND_INFO_SUPPORTED_BANDS = 3;
+
+    /**
+     * Creates a new connection method for Wifi Aware.
+     *
+     * @param passphraseInfoPassphrase the passphrase or {@code null}.
+     * @param channelInfoChannelNumber the channel number or unset.
+     * @param channelInfoOperatingClass the operating class or unset.
+     * @param bandInfoSupportedBands the supported bands or {@code null}.
+     */
+    public ConnectionMethodWifiAware(@Nullable String passphraseInfoPassphrase,
+                                     OptionalLong channelInfoChannelNumber,
+                                     OptionalLong channelInfoOperatingClass,
+                                     @Nullable byte[] bandInfoSupportedBands) {
+        mPassphraseInfoPassphrase = passphraseInfoPassphrase;
+        mChannelInfoChannelNumber = channelInfoChannelNumber;
+        mChannelInfoOperatingClass = channelInfoOperatingClass;
+        mBandInfoSupportedBands = bandInfoSupportedBands;
+    }
+
+    /**
+     *
+     * @return the value or {@code null}.
+     */
+    public @Nullable String getPassphraseInfoPassphrase() {
+        return mPassphraseInfoPassphrase;
+    }
+
+    /**
+     * Gets the channel number, if set.
+     *
+     * @return the value, if any.
+     */
+    public OptionalLong getChannelInfoChannelNumber() {
+        return mChannelInfoChannelNumber;
+    }
+
+    /**
+     * Gets the operating class, if set.
+     *
+     * @return the value, if any.
+     */
+    public OptionalLong getChannelInfoOperatingClass() {
+        return mChannelInfoOperatingClass;
+    }
+
+    /**
+     *
+     * @return the value or {@code null}.
+     */
+    public @Nullable byte[] getBandInfoSupportedBands() {
+        return mBandInfoSupportedBands;
+    }
+
+    @NonNull
+    @Override
+    DataItem encode() {
+        MapBuilder<CborBuilder> builder = new CborBuilder().addMap();
+        if (mPassphraseInfoPassphrase != null) {
+            builder.put(OPTION_KEY_PASSPHRASE_INFO_PASSPHRASE, mPassphraseInfoPassphrase);
+        }
+        if (mChannelInfoChannelNumber.isPresent()) {
+            builder.put(OPTION_KEY_CHANNEL_INFO_CHANNEL_NUMBER,
+                    mChannelInfoChannelNumber.getAsLong());
+        }
+        if (mChannelInfoOperatingClass.isPresent()) {
+            builder.put(OPTION_KEY_CHANNEL_INFO_OPERATING_CLASS,
+                    mChannelInfoOperatingClass.getAsLong());
+        }
+        if (mBandInfoSupportedBands != null) {
+            builder.put(OPTION_KEY_BAND_INFO_SUPPORTED_BANDS,
+                    mBandInfoSupportedBands);
+        }
+        return new CborBuilder()
+                .addArray()
+                .add(METHOD_TYPE)
+                .add(METHOD_MAX_VERSION)
+                .add(builder.end().build().get(0))
+                .end()
+                .build().get(0);
+    }
+
+    @Nullable
+    static ConnectionMethodWifiAware decode(@NonNull DataItem cmDataItem) {
+        if (!(cmDataItem instanceof co.nstant.in.cbor.model.Array)) {
+            throw new IllegalArgumentException("Top-level CBOR is not an array");
+        }
+        List<DataItem> items = ((Array) cmDataItem).getDataItems();
+        if (items.size() != 3) {
+            throw new IllegalArgumentException("Expected array with 3 elements, got " + items.size());
+        }
+        if (!(items.get(0) instanceof Number) || !(items.get(1) instanceof Number)) {
+            throw new IllegalArgumentException("First two items are not numbers");
+        }
+        long type = ((Number) items.get(0)).getValue().longValue();
+        long version = ((Number) items.get(1)).getValue().longValue();
+        if (!(items.get(2) instanceof co.nstant.in.cbor.model.Map)) {
+            throw new IllegalArgumentException("Third item is not a map");
+        }
+        DataItem options = (Map) items.get(2);
+        if (type != METHOD_TYPE) {
+            Log.w(TAG, "Unexpected method type " + type);
+            return null;
+        }
+        if (version > METHOD_MAX_VERSION) {
+            Log.w(TAG, "Unsupported options version " + version);
+            return null;
+        }
+        String passphraseInfoPassphrase = null;
+        if (Util.cborMapHasKey(options, OPTION_KEY_PASSPHRASE_INFO_PASSPHRASE)) {
+            passphraseInfoPassphrase =
+                    Util.cborMapExtractString(options, OPTION_KEY_PASSPHRASE_INFO_PASSPHRASE);
+        }
+        OptionalLong channelInfoChannelNumber = OptionalLong.empty();
+        if (Util.cborMapHasKey(options, OPTION_KEY_CHANNEL_INFO_CHANNEL_NUMBER)) {
+            channelInfoChannelNumber = OptionalLong.of(
+                    Util.cborMapExtractNumber(options, OPTION_KEY_CHANNEL_INFO_CHANNEL_NUMBER));
+
+        }
+        OptionalLong channelInfoOperatingClass = OptionalLong.empty();
+        if (Util.cborMapHasKey(options, OPTION_KEY_CHANNEL_INFO_OPERATING_CLASS)) {
+            channelInfoOperatingClass = OptionalLong.of(
+                    Util.cborMapExtractNumber(options, OPTION_KEY_CHANNEL_INFO_OPERATING_CLASS));
+        }
+        byte[] bandInfoSupportedBands = null;
+        if (Util.cborMapHasKey(options, OPTION_KEY_BAND_INFO_SUPPORTED_BANDS)) {
+            bandInfoSupportedBands = Util.cborMapExtractByteString(options,
+                    OPTION_KEY_BAND_INFO_SUPPORTED_BANDS);
+        }
+        return new ConnectionMethodWifiAware(
+                passphraseInfoPassphrase,
+                channelInfoChannelNumber,
+                channelInfoOperatingClass,
+                bandInfoSupportedBands);
+    }
+}

--- a/identity/src/main/java/com/android/identity/DataTransportBle.java
+++ b/identity/src/main/java/com/android/identity/DataTransportBle.java
@@ -68,25 +68,6 @@ abstract class DataTransportBle extends DataTransport {
         mLoggingFlags = loggingFlags;
     }
 
-    protected static @NonNull
-    byte[] uuidToBytes(@NonNull UUID uuid) {
-        ByteBuffer data = ByteBuffer.allocate(16);
-        data.order(ByteOrder.BIG_ENDIAN);
-        data.putLong(uuid.getMostSignificantBits());
-        data.putLong(uuid.getLeastSignificantBits());
-        return data.array();
-    }
-
-    protected static @NonNull
-    UUID uuidFromBytes(@NonNull byte[] bytes) {
-        if (bytes.length != 16) {
-            throw new IllegalStateException("Expected 16 bytes, found " + bytes.length);
-        }
-        ByteBuffer data = ByteBuffer.wrap(bytes, 0, 16);
-        data.order(ByteOrder.BIG_ENDIAN);
-        return new UUID(data.getLong(0), data.getLong(8));
-    }
-
     public static @Nullable
     List<DataRetrievalAddress> parseNdefRecord(@NonNull NdefRecord record) {
         boolean centralClient = false;
@@ -178,7 +159,7 @@ abstract class DataTransportBle extends DataTransport {
                 byte[] uuidBytes = Util.cborMapExtractByteString(options,
                         RETRIEVAL_OPTION_KEY_CENTRAL_CLIENT_MODE_UUID);
                 addresses.add(
-                        new DataRetrievalAddressBleCentralClientMode(uuidFromBytes(uuidBytes)));
+                        new DataRetrievalAddressBleCentralClientMode(Util.uuidFromBytes(uuidBytes)));
             } else {
                 Log.w(TAG, "No UUID field for mdoc central client mode");
             }
@@ -191,7 +172,7 @@ abstract class DataTransportBle extends DataTransport {
                 byte[] uuidBytes = Util.cborMapExtractByteString(options,
                         RETRIEVAL_OPTION_KEY_PERIPHERAL_SERVER_MODE_UUID);
                 addresses.add(
-                        new DataRetrievalAddressBlePeripheralServerMode(uuidFromBytes(uuidBytes)));
+                        new DataRetrievalAddressBlePeripheralServerMode(Util.uuidFromBytes(uuidBytes)));
             } else {
                 Log.w(TAG, "No UUID field for mdoc peripheral server mode");
             }
@@ -441,9 +422,9 @@ abstract class DataTransportBle extends DataTransport {
                         .put(RETRIEVAL_OPTION_KEY_SUPPORTS_PERIPHERAL_SERVER_MODE, true)
                         .put(RETRIEVAL_OPTION_KEY_SUPPORTS_CENTRAL_CLIENT_MODE, true)
                         .put(RETRIEVAL_OPTION_KEY_PERIPHERAL_SERVER_MODE_UUID,
-                                uuidToBytes(((DataRetrievalAddressBlePeripheralServerMode)
+                                Util.uuidToBytes(((DataRetrievalAddressBlePeripheralServerMode)
                                         otherAddress).uuid))
-                        .put(RETRIEVAL_OPTION_KEY_CENTRAL_CLIENT_MODE_UUID, uuidToBytes(uuid))
+                        .put(RETRIEVAL_OPTION_KEY_CENTRAL_CLIENT_MODE_UUID, Util.uuidToBytes(uuid))
                         .end()
                         .end();
             } else {
@@ -453,7 +434,7 @@ abstract class DataTransportBle extends DataTransport {
                         .addMap()
                         .put(RETRIEVAL_OPTION_KEY_SUPPORTS_PERIPHERAL_SERVER_MODE, false)
                         .put(RETRIEVAL_OPTION_KEY_SUPPORTS_CENTRAL_CLIENT_MODE, true)
-                        .put(RETRIEVAL_OPTION_KEY_CENTRAL_CLIENT_MODE_UUID, uuidToBytes(uuid))
+                        .put(RETRIEVAL_OPTION_KEY_CENTRAL_CLIENT_MODE_UUID, Util.uuidToBytes(uuid))
                         .end()
                         .end();
             }
@@ -494,9 +475,9 @@ abstract class DataTransportBle extends DataTransport {
                         .addMap()
                         .put(RETRIEVAL_OPTION_KEY_SUPPORTS_PERIPHERAL_SERVER_MODE, true)
                         .put(RETRIEVAL_OPTION_KEY_SUPPORTS_CENTRAL_CLIENT_MODE, true)
-                        .put(RETRIEVAL_OPTION_KEY_PERIPHERAL_SERVER_MODE_UUID, uuidToBytes(uuid))
+                        .put(RETRIEVAL_OPTION_KEY_PERIPHERAL_SERVER_MODE_UUID, Util.uuidToBytes(uuid))
                         .put(RETRIEVAL_OPTION_KEY_CENTRAL_CLIENT_MODE_UUID,
-                                uuidToBytes(((DataRetrievalAddressBleCentralClientMode)
+                                Util.uuidToBytes(((DataRetrievalAddressBleCentralClientMode)
                                         otherAddress).uuid))
                         .end()
                         .end();
@@ -507,7 +488,7 @@ abstract class DataTransportBle extends DataTransport {
                         .addMap()
                         .put(RETRIEVAL_OPTION_KEY_SUPPORTS_PERIPHERAL_SERVER_MODE, true)
                         .put(RETRIEVAL_OPTION_KEY_SUPPORTS_CENTRAL_CLIENT_MODE, false)
-                        .put(RETRIEVAL_OPTION_KEY_PERIPHERAL_SERVER_MODE_UUID, uuidToBytes(uuid))
+                        .put(RETRIEVAL_OPTION_KEY_PERIPHERAL_SERVER_MODE_UUID, Util.uuidToBytes(uuid))
                         .end()
                         .end();
             }

--- a/identity/src/main/java/com/android/identity/EngagementGenerator.java
+++ b/identity/src/main/java/com/android/identity/EngagementGenerator.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.security.PublicKey;
+
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.builder.ArrayBuilder;
+import co.nstant.in.cbor.builder.MapBuilder;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnsignedInteger;
+
+/**
+ * Helper to generate <code>DeviceEngagement</code> or <code>ReaderEngagement</code> CBOR.
+ */
+public final class EngagementGenerator {
+    private static final String TAG = "EngagementGenerator";
+    private final String mVersion;
+    private PublicKey mESenderKey;
+    private ArrayBuilder<CborBuilder> mConnectionMethodsArrayBuilder;
+    private ArrayBuilder<CborBuilder> mOriginInfoArrayBuilder;
+    private int mNumConnectionMethods = 0;
+    private int mNumOriginInfos = 0;
+
+    public static final String ENGAGEMENT_VERSION_1_0 = "1.0";
+    public static final String ENGAGEMENT_VERSION_1_1 = "1.1";
+
+    /** @hidden */
+    @Retention(RetentionPolicy.SOURCE)
+    @StringDef(value = {ENGAGEMENT_VERSION_1_0, ENGAGEMENT_VERSION_1_1})
+    public @interface EngagementVersion {
+    }
+
+    /**
+     * Helper class for building Engagement structures.
+     *
+     * @param ESenderKey The ephemeral key used by the device (when generating
+     *                   <code>DeviceEngagement</code>) or the reader (when generating
+     *                   <code>ReaderEngagement</code>).
+     * @param version the version to use.
+     */
+    public EngagementGenerator(@NonNull PublicKey ESenderKey,
+                               @EngagementVersion @NonNull String version) {
+        mESenderKey = ESenderKey;
+        mVersion = version;
+
+        mConnectionMethodsArrayBuilder = new CborBuilder().addArray();
+        mOriginInfoArrayBuilder = new CborBuilder().addArray();
+    }
+
+    /**
+     * Adds a connection method to the engagement.
+     *
+     * @param connectionMethod An instance of a type derived from {@link ConnectionMethod}.
+     * @return the generator.
+     */
+    public @NonNull
+    EngagementGenerator addConnectionMethod(@NonNull ConnectionMethod connectionMethod) {
+        mConnectionMethodsArrayBuilder.add(connectionMethod.encode());
+        mNumConnectionMethods++;
+        return this;
+    }
+
+    /**
+     * Adds origin info to the engagement.
+     *
+     * @param originInfo An instance of a type derived from {@link OriginInfo}.
+     * @return the generator.
+     */
+    public @NonNull
+    EngagementGenerator addOriginInfo(@NonNull OriginInfo originInfo) {
+        mOriginInfoArrayBuilder.add(originInfo.encode());
+        mNumOriginInfos++;
+        return this;
+    }
+
+    /**
+     * Generates the binary Engagement structure.
+     *
+     * @return the bytes of the <code>Engagement</code> structure.
+     */
+    public @NonNull
+    byte[] generate() {
+        DataItem eDeviceKeyBytes = Util.cborBuildTaggedByteString(
+                Util.cborEncode(Util.cborBuildCoseKey(mESenderKey)));
+
+        DataItem securityDataItem = new CborBuilder()
+                .addArray()
+                .add(1) // cipher suite
+                .add(eDeviceKeyBytes)
+                .end()
+                .build().get(0);
+
+        CborBuilder builder = new CborBuilder();
+        MapBuilder<CborBuilder> map = builder.addMap();
+        // TODO: support other versions...
+        map.put(0, mVersion);
+        map.put(new UnsignedInteger(1), securityDataItem);
+        if (mNumConnectionMethods > 0) {
+            map.put(new UnsignedInteger(2), mConnectionMethodsArrayBuilder.end().build().get(0));
+        }
+        if (mNumOriginInfos > 0) {
+            map.put(new UnsignedInteger(5), mOriginInfoArrayBuilder.end().build().get(0));
+        }
+        map.end();
+        return Util.cborEncode(builder.build().get(0));
+    }
+
+}

--- a/identity/src/main/java/com/android/identity/EngagementParser.java
+++ b/identity/src/main/java/com/android/identity/EngagementParser.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import androidx.annotation.NonNull;
+
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.List;
+
+import co.nstant.in.cbor.model.ByteString;
+import co.nstant.in.cbor.model.DataItem;
+
+/**
+ * Helper for parsing <code>DeviceEngagement</code> or <code>ReaderEngagement</code> CBOR.
+ */
+public class EngagementParser {
+    private static final String TAG = "EngagementParser";
+
+    private final byte[] mEncodedEngagement;
+
+    /**
+     * Constructs a new parser.
+     *
+     * @param encodedEngagement the bytes of the <code>Engagement</code> structure.
+     */
+    public EngagementParser(@NonNull byte[] encodedEngagement) {
+        mEncodedEngagement = encodedEngagement;
+    }
+
+    /**
+     * Parses the given <code>Engagement</code> structure.
+     *
+     * @return A {@link Engagement} object with the parsed data.
+     */
+    @NonNull public Engagement parse() {
+        EngagementParser.Engagement engagement = new EngagementParser.Engagement();
+        engagement.parse(mEncodedEngagement);
+        return engagement;
+    }
+
+    /**
+     * An object used to represent data extract from an <code>Engagement</code> structure.
+     */
+    public class Engagement {
+        private static final String TAG = "Engagement";
+        private String mVersion;
+        private PublicKey mESenderKey;
+        private List<ConnectionMethod> mConnectionMethods = new ArrayList<>();
+        private List<OriginInfo> mOriginInfos = new ArrayList<>();
+
+        Engagement() {
+        }
+
+        /**
+         * Gets the version string set in the <code>Engagement</code> CBOR.
+         *
+         * @return the version string in the engagement e.g. "1.0" or "1.1".
+         */
+        @NonNull
+        public String getVersion() {
+            return mVersion;
+        }
+
+        /**
+         * Gets the ephemeral key used by the other side.
+         *
+         * @return The ephemeral key used by the device (when parsing <code>DeviceEngagement</code>)
+         *     or the reader (when generating <code>ReaderEngagement</code>).
+         */
+        @NonNull
+        public PublicKey getESenderKey() {
+            return mESenderKey;
+        }
+
+        /**
+         * Gets the connection methods listed in the engagement.
+         *
+         * @return a list of {@link ConnectionMethod}-derived instances.
+         */
+        @NonNull
+        public List<ConnectionMethod> getConnectionMethods() {
+            return mConnectionMethods;
+        }
+
+        /**
+         * Gets the origin infos listed in the engagement.
+         *
+         * @return A list of {@link OriginInfo}-derived instances.
+         */
+        @NonNull
+        public List<OriginInfo> getOriginInfos() {
+            return mOriginInfos;
+        }
+
+        void parse(@NonNull byte[] encodedEngagement) {
+            DataItem map = Util.cborDecode(encodedEngagement);
+            if (!(map instanceof co.nstant.in.cbor.model.Map)) {
+                throw new IllegalArgumentException("Top-level Engagement CBOR is not a map");
+            }
+
+            mVersion = Util.cborMapExtractString(map, 0);
+
+            List<DataItem> securityItems = Util.cborMapExtractArray(map, 1);
+            if (securityItems.size() < 2) {
+                throw new IllegalArgumentException("Expected at least two items in Security array");
+            }
+            if (!(securityItems.get(0) instanceof co.nstant.in.cbor.model.UnsignedInteger)) {
+                throw new IllegalArgumentException("First item in Security array is not a number");
+            }
+            int cipherSuite = ((co.nstant.in.cbor.model.UnsignedInteger) securityItems.get(0)).getValue().intValue();
+            if (cipherSuite != 1) {
+                throw new IllegalArgumentException("Expected cipher suite 1, got " + cipherSuite);
+            }
+            if (!(securityItems.get(1) instanceof co.nstant.in.cbor.model.ByteString) ||
+                    securityItems.get(1).getTag().getValue() != 24) {
+                throw new IllegalArgumentException("Second item in Security array is not a tagged bstr");
+            }
+            byte[] encodedCoseKey = ((ByteString) securityItems.get(1)).getBytes();
+            DataItem coseKey = Util.cborDecode(encodedCoseKey);
+            mESenderKey = Util.coseKeyDecode(coseKey);
+
+            if (Util.cborMapHasKey(map, 2)) {
+                List<DataItem> connectionMethodItems = Util.cborMapExtractArray(map, 2);
+                for (DataItem cmDataItem : connectionMethodItems) {
+                    ConnectionMethod connectionMethod = ConnectionMethod.decode(cmDataItem);
+                    if (connectionMethod != null) {
+                        mConnectionMethods.add(connectionMethod);
+                    }
+                }
+            }
+
+            if (Util.cborMapHasKey(map, 5)) {
+                List<DataItem> originInfoItems = Util.cborMapExtractArray(map, 5);
+                for (DataItem oiDataItem : originInfoItems) {
+                    OriginInfo originInfo = OriginInfo.decode(oiDataItem);
+                    if (originInfo != null) {
+                        mOriginInfos.add(originInfo);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/identity/src/main/java/com/android/identity/OriginInfo.java
+++ b/identity/src/main/java/com/android/identity/OriginInfo.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Number;
+
+/**
+ * A class representing the OriginInfo structure exchanged by the mdoc and the mdoc reader.
+ */
+public abstract class OriginInfo {
+    private static final String TAG = "OriginInfo";
+
+    /**
+     * The constant used to specify how the current engagement structure is delivered.
+     */
+    public static final long CAT_DELIVERY = 0;
+
+    /**
+     * The constant used to specify how the other party engagement structure has been received.
+     */
+    public static final long CAT_RECEIVE = 1;
+
+    /**
+     * Specifies whether the OriginInfoOptions are about this engagement or the one
+     * received previously
+     *
+     * @return one of {@link #CAT_DELIVERY} or {@link #CAT_RECEIVE}.
+     */
+    public abstract long getCat();
+
+    abstract @NonNull
+    DataItem encode();
+
+    static @Nullable
+    OriginInfo decode(@NonNull DataItem oiDataItem) {
+        if (!(oiDataItem instanceof co.nstant.in.cbor.model.Array)) {
+            throw new IllegalArgumentException("Top-level CBOR is not an array");
+        }
+        List<DataItem> items = ((Array) oiDataItem).getDataItems();
+        if (items.size() != 3) {
+            throw new IllegalArgumentException("Expected array with 3 elements, got " + items.size());
+        }
+        if (!(items.get(0) instanceof Number) || !(items.get(1) instanceof Number)) {
+            throw new IllegalArgumentException("First two items are not numbers");
+        }
+        long cat = ((Number) items.get(0)).getValue().longValue();
+        long type = ((Number) items.get(1)).getValue().longValue();
+        switch ((int) type) {
+            case OriginInfoQr.TYPE:
+                return OriginInfoQr.decode(oiDataItem);
+            case OriginInfoNfc.TYPE:
+                return OriginInfoNfc.decode(oiDataItem);
+            case OriginInfoWebsite.TYPE:
+                return OriginInfoWebsite.decode(oiDataItem);
+        }
+        Log.w(TAG, "Unsupported type " + type);
+        return null;
+    }
+}

--- a/identity/src/main/java/com/android/identity/OriginInfoNfc.java
+++ b/identity/src/main/java/com/android/identity/OriginInfoNfc.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Number;
+import co.nstant.in.cbor.model.SimpleValue;
+import co.nstant.in.cbor.model.SimpleValueType;
+
+public class OriginInfoNfc extends OriginInfo {
+    private static final String TAG = "OriginInfoNfc";
+
+    static final int TYPE = 3;
+    private final long mCat;
+
+    public OriginInfoNfc(long cat) {
+        mCat = cat;
+    }
+
+    /**
+     * Specifies whether the OriginInfoOptions are about this engagement or the one
+     * received previously
+     *
+     * @return one of {@link #CAT_DELIVERY} or {@link #CAT_RECEIVE}.
+     */
+    @Override
+    public long getCat() {
+        return mCat;
+    }
+
+    @NonNull
+    @Override
+    DataItem encode() {
+        return new CborBuilder()
+                .addArray()
+                .add(mCat)
+                .add(TYPE)
+                .add(SimpleValue.NULL)
+                .end()
+                .build().get(0);
+    }
+
+    @Nullable
+    static OriginInfoNfc decode(@NonNull DataItem oiDataItem) {
+        if (!(oiDataItem instanceof co.nstant.in.cbor.model.Array)) {
+            throw new IllegalArgumentException("Top-level CBOR is not an array");
+        }
+        List<DataItem> items = ((Array) oiDataItem).getDataItems();
+        if (items.size() != 3) {
+            throw new IllegalArgumentException("Expected array with 3 elements, got " + items.size());
+        }
+        if (!(items.get(0) instanceof Number) || !(items.get(1) instanceof Number)) {
+            throw new IllegalArgumentException("First two items are not numbers");
+        }
+        if (!(items.get(2) instanceof SimpleValue) ||
+                ((SimpleValue) items.get(2)).getSimpleValueType() != SimpleValueType.NULL) {
+            throw new IllegalArgumentException("Details is not a NULL value");
+        }
+        long cat = ((Number) items.get(0)).getValue().longValue();
+        long type = ((Number) items.get(1)).getValue().longValue();
+        if (type != TYPE) {
+            Log.w(TAG, "Unexpected type " + type);
+            return null;
+        }
+        return new OriginInfoNfc(cat);
+    }
+}

--- a/identity/src/main/java/com/android/identity/OriginInfoQr.java
+++ b/identity/src/main/java/com/android/identity/OriginInfoQr.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Number;
+import co.nstant.in.cbor.model.SimpleValue;
+import co.nstant.in.cbor.model.SimpleValueType;
+
+public class OriginInfoQr extends OriginInfo {
+    private static final String TAG = "OriginInfoQr";
+
+    static final int TYPE = 2;
+    private final long mCat;
+
+    public OriginInfoQr(long cat) {
+        mCat = cat;
+    }
+
+    /**
+     * Specifies whether the OriginInfoOptions are about this engagement or the one
+     * received previously
+     *
+     * @return one of {@link #CAT_DELIVERY} or {@link #CAT_RECEIVE}.
+     */
+    @Override
+    public long getCat() {
+        return mCat;
+    }
+
+    @NonNull
+    @Override
+    DataItem encode() {
+        return new CborBuilder()
+                .addArray()
+                .add(mCat)
+                .add(TYPE)
+                .add(SimpleValue.NULL)
+                .end()
+                .build().get(0);
+    }
+
+    @Nullable
+    static OriginInfoQr decode(@NonNull DataItem oiDataItem) {
+        if (!(oiDataItem instanceof co.nstant.in.cbor.model.Array)) {
+            throw new IllegalArgumentException("Top-level CBOR is not an array");
+        }
+        List<DataItem> items = ((Array) oiDataItem).getDataItems();
+        if (items.size() != 3) {
+            throw new IllegalArgumentException("Expected array with 3 elements, got " + items.size());
+        }
+        if (!(items.get(0) instanceof Number) || !(items.get(1) instanceof Number)) {
+            throw new IllegalArgumentException("First two items are not numbers");
+        }
+        if (!(items.get(2) instanceof SimpleValue) ||
+                ((SimpleValue) items.get(2)).getSimpleValueType() != SimpleValueType.NULL) {
+            throw new IllegalArgumentException("Details is not a NULL value");
+        }
+        long cat = ((Number) items.get(0)).getValue().longValue();
+        long type = ((Number) items.get(1)).getValue().longValue();
+        if (type != TYPE) {
+            Log.w(TAG, "Unexpected type " + type);
+            return null;
+        }
+        return new OriginInfoQr(cat);
+    }
+}

--- a/identity/src/main/java/com/android/identity/OriginInfoWebsite.java
+++ b/identity/src/main/java/com/android/identity/OriginInfoWebsite.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Map;
+import co.nstant.in.cbor.model.Number;
+
+public class OriginInfoWebsite extends OriginInfo {
+    private static final String TAG = "OriginInfoWebsite";
+
+    static final int TYPE = 1;
+    private final long mCat;
+    private final String mBaseUrl;
+
+    public OriginInfoWebsite(long cat, String baseUrl) {
+        mCat = cat;
+        mBaseUrl = baseUrl;
+    }
+
+    /**
+     * Specifies whether the OriginInfoOptions are about this engagement or the one
+     * received previously
+     *
+     * @return one of {@link #CAT_DELIVERY} or {@link #CAT_RECEIVE}.
+     */
+    @Override
+    public long getCat() {
+        return mCat;
+    }
+
+    public String getBaseUrl() {
+        return mBaseUrl;
+    }
+
+    @NonNull
+    @Override
+    DataItem encode() {
+        return new CborBuilder()
+                .addArray()
+                .add(mCat)
+                .add(TYPE)
+                .addMap()
+                .put("baseUrl", mBaseUrl)
+                .end()
+                .end()
+                .build().get(0);
+    }
+
+    @Nullable
+    static OriginInfoWebsite decode(@NonNull DataItem oiDataItem) {
+        if (!(oiDataItem instanceof co.nstant.in.cbor.model.Array)) {
+            throw new IllegalArgumentException("Top-level CBOR is not an array");
+        }
+        List<DataItem> items = ((Array) oiDataItem).getDataItems();
+        if (items.size() != 3) {
+            throw new IllegalArgumentException("Expected array with 3 elements, got " + items.size());
+        }
+        if (!(items.get(0) instanceof Number) || !(items.get(1) instanceof Number)) {
+            throw new IllegalArgumentException("First two items are not numbers");
+        }
+        if (!(items.get(2) instanceof Map)) {
+            throw new IllegalArgumentException("Details is not a map");
+        }
+        Map details = (Map) items.get(2);
+        long cat = ((Number) items.get(0)).getValue().longValue();
+        long type = ((Number) items.get(1)).getValue().longValue();
+        String baseUrl = Util.cborMapExtractString(details, "baseUrl");
+        if (type != TYPE) {
+            Log.w(TAG, "Unexpected type " + type);
+            return null;
+        }
+        return new OriginInfoWebsite(cat, baseUrl);
+    }
+}

--- a/identity/src/main/java/com/android/identity/Util.java
+++ b/identity/src/main/java/com/android/identity/Util.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -78,6 +79,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Queue;
 import java.util.TimeZone;
+import java.util.UUID;
 
 import javax.crypto.KeyAgreement;
 import javax.crypto.Mac;
@@ -1837,6 +1839,25 @@ class Util {
         pendingDataBaos.reset();
         pendingDataBaos.write(pendingData, dataItemLength, pendingData.length - dataItemLength);
         return dataItemBytes;
+    }
+
+    static @NonNull
+    byte[] uuidToBytes(@NonNull UUID uuid) {
+        ByteBuffer data = ByteBuffer.allocate(16);
+        data.order(ByteOrder.BIG_ENDIAN);
+        data.putLong(uuid.getMostSignificantBits());
+        data.putLong(uuid.getLeastSignificantBits());
+        return data.array();
+    }
+
+    static @NonNull
+    UUID uuidFromBytes(@NonNull byte[] bytes) {
+        if (bytes.length != 16) {
+            throw new IllegalStateException("Expected 16 bytes, found " + bytes.length);
+        }
+        ByteBuffer data = ByteBuffer.wrap(bytes, 0, 16);
+        data.order(ByteOrder.BIG_ENDIAN);
+        return new UUID(data.getLong(0), data.getLong(8));
     }
 
     /**


### PR DESCRIPTION
This is mostly just refactoring existing code into Engagement{Parser, Genenerator} except for newly added support for OriginInfo which is used in upcoming ISO 18013-7 and ISO 23220-4 standards. This work will be used in mdoc:// support for over-the-Internet mdoc presentations according to 18013-7.

Existing QrEngagementHelper and NfcEngagementHelper haven't been wired up to use this yet as that will include migrating DataRetrievalAddress classes to the new ConnectionMethod classes. This will happen in an upcoming change.

Test: New unit tests and all unit tests pass
Bug: None