### PR TITLE
Use HTTP transport for reverse engagement in mdoc reader.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/transfer/TransferManager.kt
+++ b/appholder/src/main/java/com/android/mdl/app/transfer/TransferManager.kt
@@ -19,6 +19,7 @@ import androidx.core.util.component2
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.android.identity.*
+import com.android.identity.DataTransport.ROLE_MDOC
 import com.android.identity.DeviceRequestParser.DeviceRequest
 import com.android.mdl.app.util.FormatUtil
 import com.android.mdl.app.util.PreferencesHelper
@@ -125,7 +126,9 @@ class TransferManager private constructor(private val context: Context) {
         val connectionMethod = engagement.connectionMethods[0]
         Log.d(LOG_TAG, "Using connection method " + connectionMethod)
 
-        val transport = connectionMethod.createDataTransport(context, getConnectionOptions())
+        val transport = connectionMethod.createDataTransport(context,
+            ROLE_MDOC,
+            getConnectionOptions())
 
         val builder = PresentationHelper.Builder(context,
             presentationListener,

--- a/appverifier/src/main/AndroidManifest.xml
+++ b/appverifier/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:name="android.hardware.nfc"
         android:required="true" />
 
+    <uses-permission android:name="android.permission.INTERNET" />
     <!-- As of API 31 BLE doesn't need location permission, but WiFi aware still requires it. -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />

--- a/appverifier/src/main/java/com/android/mdl/appreader/transfer/TransferManager.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/transfer/TransferManager.kt
@@ -10,11 +10,11 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.android.identity.ConnectionMethod
-import com.android.identity.ConnectionMethodBle
+import com.android.identity.ConnectionMethodHttp
 import com.android.identity.DataTransportOptions
+import com.android.identity.VerificationHelper
 import com.android.identity.DeviceRequestGenerator
 import com.android.identity.DeviceResponseParser
-import com.android.identity.VerificationHelper
 import com.android.mdl.appreader.document.RequestDocumentList
 import com.android.mdl.appreader.readercertgen.ReaderCertificateGenerator
 import com.android.mdl.appreader.readercertgen.SupportedCurves.*
@@ -85,12 +85,11 @@ class TransferManager private constructor(private val context: Context) {
             .build()
         builder.setDataTransportOptions(options)
         val methods = ArrayList<ConnectionMethod>()
-        // For now use BLE - in the future use ConnectionMethodHttp
-        methods.add(ConnectionMethodBle(
-            false,
-            true,
-            null,
-            UUID.randomUUID()))
+        // Passing the empty URI in means that DataTransportHttp will use local IP as host
+        // and the dynamically allocated TCP port as port. So the resulting ConnectionMethodHttp
+        // which will be included in ReaderEngagement CBOR will contain an URI of the
+        // form http://192.168.1.2:18013/mdocreader
+        methods.add(ConnectionMethodHttp(""));
         builder.setUseReverseEngagement(methods)
         verification = builder.build()
         usingReverseEngagement = true

--- a/identity/src/androidTest/java/com/android/identity/PresentationHelperTest.java
+++ b/identity/src/androidTest/java/com/android/identity/PresentationHelperTest.java
@@ -143,15 +143,16 @@ public class PresentationHelperTest {
         PresentationSession session = store.createPresentationSession(
                 IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
 
-        ConditionVariable condVarDeviceConnecting = new ConditionVariable();
         ConditionVariable condVarDeviceConnected = new ConditionVariable();
         ConditionVariable condVarDeviceDisconnected = new ConditionVariable();
         ConditionVariable condVarDeviceEngagementReady = new ConditionVariable();
 
         // TODO: use loopback instead of TCP transport
         DataTransportTcp proverTransport = new DataTransportTcp(context,
+                DataTransport.ROLE_MDOC,
                 new DataTransportOptions.Builder().build());
         DataTransportTcp verifierTransport = new DataTransportTcp(context,
+                DataTransport.ROLE_MDOC_READER,
                 new DataTransportOptions.Builder().build());
 
         Executor executor = Executors.newSingleThreadExecutor();
@@ -165,7 +166,6 @@ public class PresentationHelperTest {
 
                     @Override
                     public void onDeviceConnecting() {
-                        condVarDeviceConnecting.open();
                     }
 
                     @Override
@@ -223,27 +223,19 @@ public class PresentationHelperTest {
                 OptionalInt.empty());
         verifierTransport.setListener(new DataTransport.Listener() {
             @Override
-            public void onListeningSetupCompleted() {
+            public void onConnectionMethodReady() {
             }
 
             @Override
-            public void onListeningPeerConnecting() {
+            public void onConnecting() {
             }
 
             @Override
-            public void onListeningPeerConnected() {
+            public void onConnected() {
             }
 
             @Override
-            public void onListeningPeerDisconnected() {
-            }
-
-            @Override
-            public void onConnectionResult(@Nullable Throwable error) {
-            }
-
-            @Override
-            public void onConnectionDisconnected() {
+            public void onDisconnected() {
             }
 
             @Override
@@ -292,7 +284,6 @@ public class PresentationHelperTest {
 
         verifierTransport.setHostAndPort(proverTransport.getHost(), proverTransport.getPort());
         verifierTransport.connect();
-        Assert.assertTrue(condVarDeviceConnecting.block(5000));
         Assert.assertTrue(condVarDeviceConnected.block(5000));
 
         final PresentationHelper[] presentation = {null};
@@ -404,7 +395,6 @@ public class PresentationHelperTest {
 
         Executor executor = Executors.newSingleThreadExecutor();
 
-        ConditionVariable condVarDeviceConnecting = new ConditionVariable();
         ConditionVariable condVarDeviceConnected = new ConditionVariable();
         ConditionVariable condVarDeviceRequestReceived = new ConditionVariable();
         ConditionVariable condVarOnError = new ConditionVariable();
@@ -412,8 +402,10 @@ public class PresentationHelperTest {
 
         // TODO: use loopback transport
         DataTransportTcp proverTransport = new DataTransportTcp(context,
+                DataTransport.ROLE_MDOC,
                 new DataTransportOptions.Builder().build());
         DataTransportTcp verifierTransport = new DataTransportTcp(context,
+                DataTransport.ROLE_MDOC_READER,
                 new DataTransportOptions.Builder().build());
         QrEngagementHelper.Listener qrHelperListener = new QrEngagementHelper.Listener() {
                     @Override
@@ -423,7 +415,6 @@ public class PresentationHelperTest {
 
                     @Override
                     public void onDeviceConnecting() {
-                        condVarDeviceConnecting.open();
                     }
 
                     @Override
@@ -474,27 +465,19 @@ public class PresentationHelperTest {
                 OptionalInt.empty());
         verifierTransport.setListener(new DataTransport.Listener() {
             @Override
-            public void onListeningSetupCompleted() {
+            public void onConnectionMethodReady() {
             }
 
             @Override
-            public void onListeningPeerConnecting() {
+            public void onConnecting() {
             }
 
             @Override
-            public void onListeningPeerConnected() {
+            public void onConnected() {
             }
 
             @Override
-            public void onListeningPeerDisconnected() {
-            }
-
-            @Override
-            public void onConnectionResult(@Nullable Throwable error) {
-            }
-
-            @Override
-            public void onConnectionDisconnected() {
+            public void onDisconnected() {
             }
 
             @Override
@@ -515,7 +498,6 @@ public class PresentationHelperTest {
 
         verifierTransport.setHostAndPort(proverTransport.getHost(), proverTransport.getPort());
         verifierTransport.connect();
-        Assert.assertTrue(condVarDeviceConnecting.block(5000));
         Assert.assertTrue(condVarDeviceConnected.block(5000));
 
         PresentationHelper.Listener listener =

--- a/identity/src/main/java/com/android/identity/ConnectionMethod.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethod.java
@@ -147,10 +147,13 @@ public abstract class ConnectionMethod {
      * of {@link ConnectionMethod}.
      *
      * @param context application context.
+     * @param role whether the transport will be used by the mdoc or mdoc reader.
      * @param options options for configuring the created instance.
      * @return A {@link DataTransport}-derived instance configured with the given options.
      * @throws IllegalArgumentException if the connection-method has invalid options specified.
      */
     public abstract @NonNull
-    DataTransport createDataTransport(@NonNull Context context, @NonNull DataTransportOptions options);
+    DataTransport createDataTransport(@NonNull Context context,
+                                      @DataTransport.Role int role,
+                                      @NonNull DataTransportOptions options);
 }

--- a/identity/src/main/java/com/android/identity/ConnectionMethodBle.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethodBle.java
@@ -102,6 +102,7 @@ public class ConnectionMethodBle extends ConnectionMethod {
     public @Override
     @NonNull
     DataTransport createDataTransport(@NonNull Context context,
+                                      @DataTransport.Role int role,
                                       @NonNull DataTransportOptions options) {
         if (mSupportsCentralClientMode && mSupportsPeripheralServerMode) {
             throw new IllegalArgumentException(
@@ -109,12 +110,12 @@ public class ConnectionMethodBle extends ConnectionMethod {
                             + "before picking one.");
         }
         if (mSupportsCentralClientMode) {
-            DataTransportBle t = new DataTransportBleCentralClientMode(context, options);
+            DataTransportBle t = new DataTransportBleCentralClientMode(context, role, this, options);
             t.setServiceUuid(mCentralClientModeUuid);
             return t;
         }
         if (mSupportsPeripheralServerMode) {
-            DataTransportBle t = new DataTransportBlePeripheralServerMode(context, options);
+            DataTransportBle t = new DataTransportBlePeripheralServerMode(context, role, this, options);
             t.setServiceUuid(mPeripheralServerModeUuid);
             return t;
         }

--- a/identity/src/main/java/com/android/identity/ConnectionMethodNfc.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethodNfc.java
@@ -70,8 +70,9 @@ public class ConnectionMethodNfc extends ConnectionMethod {
     public @Override
     @NonNull
     DataTransport createDataTransport(@NonNull Context context,
+                                      @DataTransport.Role int role,
                                       @NonNull DataTransportOptions options) {
-        DataTransportNfc t = new DataTransportNfc(context, options);
+        DataTransportNfc t = new DataTransportNfc(context, role, this, options);
         // TODO: set mCommandDataFieldMaxLength and mResponseDataFieldMaxLength
         return t;
     }

--- a/identity/src/main/java/com/android/identity/ConnectionMethodWifiAware.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethodWifiAware.java
@@ -100,11 +100,12 @@ public class ConnectionMethodWifiAware extends ConnectionMethod {
     public @Override
     @NonNull
     DataTransport createDataTransport(@NonNull Context context,
+                                      @DataTransport.Role int role,
                                       @NonNull DataTransportOptions options) {
         if (!(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)) {
             throw new IllegalStateException("Wifi Aware is not supported");
         }
-        DataTransportWifiAware t = new DataTransportWifiAware(context, options);
+        DataTransportWifiAware t = new DataTransportWifiAware(context, role, this, options);
         if (mPassphraseInfoPassphrase != null) {
             t.setPassphrase(mPassphraseInfoPassphrase);
         }

--- a/identity/src/main/java/com/android/identity/DataTransportBle.java
+++ b/identity/src/main/java/com/android/identity/DataTransportBle.java
@@ -16,28 +16,11 @@
 
 package com.android.identity;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import android.content.Context;
-import android.nfc.NdefRecord;
-import android.util.Log;
-import android.util.Pair;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
-import java.io.ByteArrayOutputStream;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
 import java.util.UUID;
-
-import co.nstant.in.cbor.CborBuilder;
-import co.nstant.in.cbor.builder.ArrayBuilder;
-import co.nstant.in.cbor.model.DataItem;
-import co.nstant.in.cbor.model.Map;
 
 /**
  * BLE data transport
@@ -48,13 +31,23 @@ abstract class DataTransportBle extends DataTransport {
     // The size of buffer for read() calls when using L2CAP sockets.
     static final int L2CAP_BUF_SIZE = 4096;
     protected UUID mServiceUuid;
+    protected ConnectionMethodBle mConnectionMethod;
 
     public DataTransportBle(@NonNull Context context,
+                            @Role int role,
+                            @NonNull ConnectionMethodBle connectionMethod,
                             @NonNull DataTransportOptions options) {
-        super(context, options);
+        super(context, role, options);
+        mConnectionMethod = connectionMethod;
     }
 
     void setServiceUuid(@NonNull UUID serviceUuid) {
         mServiceUuid = serviceUuid;
     }
+
+    @Override
+    public @NonNull ConnectionMethod getConnectionMethod() {
+        return mConnectionMethod;
+    }
+
 }

--- a/identity/src/main/java/com/android/identity/GattClient.java
+++ b/identity/src/main/java/com/android/identity/GattClient.java
@@ -292,11 +292,11 @@ class GattClient extends BluetoothGattCallback {
             if (Logger.isDebugEnabled()) {
                 Logger.d(TAG, "Received identValue: " + Util.toHex(identValue));
             }
-            // TODO: maybe comment out or change to warning since it's optional... several readers
-            //  send the wrong value (others send the right one though)
+            // TODO: Don't even request IDENT since it cannot work w/ reverse engagement (there's
+            //   no way the mdoc reader knows EDeviceKeyBytes at this point) and it's also optional.
             if (!Arrays.equals(identValue, mIdentValue)) {
-                reportError(new Error("Received ident does not match expected ident"));
-                return;
+                Logger.w(TAG, "Received ident '" + Util.toHex(identValue)
+                        + "' does not match expected ident '" + Util.toHex(mIdentValue) + "'");
             }
 
             afterIdentObtained(gatt);

--- a/identity/src/main/java/com/android/identity/QrEngagementHelper.java
+++ b/identity/src/main/java/com/android/identity/QrEngagementHelper.java
@@ -149,7 +149,7 @@ public class QrEngagementHelper implements NfcApduRouter.Listener {
         // if both BLE modes are available at the same time.
         List<ConnectionMethod> disambiguatedMethods = ConnectionMethod.disambiguate(mConnectionMethods);
         for (ConnectionMethod cm : disambiguatedMethods) {
-            DataTransport transport = cm.createDataTransport(mContext, mOptions);
+            DataTransport transport = cm.createDataTransport(mContext, DataTransport.ROLE_MDOC, mOptions);
             transport.setEDeviceKeyBytes(encodedEDeviceKeyBytes);
             mTransports.add(transport);
             Logger.d(TAG, "Added transport for " + cm);
@@ -169,8 +169,8 @@ public class QrEngagementHelper implements NfcApduRouter.Listener {
             for (DataTransport transport : mTransports) {
                 transport.setListener(new DataTransport.Listener() {
                     @Override
-                    public void onListeningSetupCompleted() {
-                        Logger.d(TAG, "onListeningSetupCompleted for " + transport);
+                    public void onConnectionMethodReady() {
+                        Logger.d(TAG, "onConnectionMethodReady for " + transport);
                         synchronized (helper) {
                             mNumTransportsStillSettingUp -= 1;
                             if (mNumTransportsStillSettingUp == 0) {
@@ -180,39 +180,21 @@ public class QrEngagementHelper implements NfcApduRouter.Listener {
                     }
 
                     @Override
-                    public void onListeningPeerConnecting() {
-                        Logger.d(TAG, "onListeningPeerConnecting for " + transport);
+                    public void onConnecting() {
+                        Logger.d(TAG, "onConnecting for " + transport);
                         peerIsConnecting(transport);
                     }
 
                     @Override
-                    public void onListeningPeerConnected() {
-                        Logger.d(TAG, "onListeningPeerConnected for " + transport);
+                    public void onConnected() {
+                        Logger.d(TAG, "onConnected for " + transport);
                         peerHasConnected(transport);
                     }
 
                     @Override
-                    public void onListeningPeerDisconnected() {
-                        Logger.d(TAG, "onListeningPeerDisconnected for " + transport);
+                    public void onDisconnected() {
+                        Logger.d(TAG, "onDisconnected for " + transport);
                         transport.close();
-                    }
-
-                    @Override
-                    public void onConnectionResult(@Nullable Throwable error) {
-                        Logger.d(TAG, "onConnectionResult for " + transport);
-                        if (error != null) {
-                            throw new IllegalStateException("Unexpected onConnectionResult "
-                                    + "callback from transport " + transport, error);
-                        }
-                        throw new IllegalStateException("Unexpected onConnectionResult "
-                                + "callback from transport " + transport);
-                    }
-
-                    @Override
-                    public void onConnectionDisconnected() {
-                        Logger.d(TAG, "onConnectionDisconnected for " + transport);
-                        throw new IllegalStateException("Unexpected onConnectionDisconnected "
-                                + "callback from transport " + transport);
                     }
 
                     @Override
@@ -233,14 +215,14 @@ public class QrEngagementHelper implements NfcApduRouter.Listener {
                     }
 
                 }, mExecutor);
-                Logger.d(TAG, "Listening on transport " + transport);
-                transport.listen();
+                Logger.d(TAG, "Connecting to transport " + transport);
+                transport.connect();
                 mNumTransportsStillSettingUp += 1;
             }
         }
     }
 
-    // TODO: handle the case where a transport never calls onListeningSetupCompleted... that
+    // TODO: handle the case where a transport never calls onConnectionMethodReady... that
     //  is, set up a timeout to call this.
     //
     void allTransportsAreSetup() {

--- a/identity/src/test/java/com/android/identity/ConnectionMethodTest.java
+++ b/identity/src/test/java/com/android/identity/ConnectionMethodTest.java
@@ -150,7 +150,7 @@ public class ConnectionMethodTest {
     public void testConnectionMethodRestApi() {
         ConnectionMethodHttp cm = new ConnectionMethodHttp("https://www.example.com/mdocReader");
         ConnectionMethodHttp decoded = ConnectionMethodHttp.fromDeviceEngagement(cm.toDeviceEngagement());
-        Assert.assertEquals(decoded.getUriWebsite(), cm.getUriWebsite());
+        Assert.assertEquals(decoded.getUri(), cm.getUri());
         Assert.assertEquals("[\n" +
                 "  4,\n" +
                 "  1,\n" +

--- a/identity/src/test/java/com/android/identity/EngagementGeneratorTest.java
+++ b/identity/src/test/java/com/android/identity/EngagementGeneratorTest.java
@@ -64,8 +64,8 @@ public class EngagementGeneratorTest {
 
         EngagementGenerator eg = new EngagementGenerator(eSenderKey.getPublic(),
                 ENGAGEMENT_VERSION_1_1);
-        eg.addConnectionMethod(new ConnectionMethodHttp("www.example.com/verifier/123"));
-        eg.addOriginInfo(new OriginInfoWebsite(OriginInfo.CAT_DELIVERY, "www.example.com/verifier"));
+        eg.addConnectionMethod(new ConnectionMethodHttp("http://www.example.com/verifier/123"));
+        eg.addOriginInfo(new OriginInfoWebsite(OriginInfo.CAT_DELIVERY, "http://www.example.com/verifier"));
         byte[] encodedEngagement = eg.generate();
 
         EngagementParser parser = new EngagementParser(encodedEngagement);
@@ -75,10 +75,10 @@ public class EngagementGeneratorTest {
         Assert.assertEquals(ENGAGEMENT_VERSION_1_1, engagement.getVersion());
         Assert.assertEquals(1, engagement.getConnectionMethods().size());
         ConnectionMethodHttp cm = (ConnectionMethodHttp) engagement.getConnectionMethods().get(0);
-        Assert.assertEquals("www.example.com/verifier/123", cm.getUriWebsite());
+        Assert.assertEquals("http://www.example.com/verifier/123", cm.getUri());
         Assert.assertEquals(1, engagement.getOriginInfos().size());
         OriginInfoWebsite oi = (OriginInfoWebsite) engagement.getOriginInfos().get(0);
-        Assert.assertEquals("www.example.com/verifier", oi.getBaseUrl());
+        Assert.assertEquals("http://www.example.com/verifier", oi.getBaseUrl());
     }
 
     @Test


### PR DESCRIPTION
This required a slight refactor of DataTransport such that listening/connecting transports use the same API and the role is just passed in at construction time (ROLE_MDOC and ROLE_MDOC_READER).

Specifically for DataTransportHttp when used on the mdoc reader side it'll return URIs of the form http://<ip>:<port>/mdocreader where <ip> is the local IP address and <port> is the dynamically chosen TCP port number returned by the kernel when the listening socket was created.

Test: All unit tests pass.
Test: Manually tested both forward and reverse engagement.
Bug: None
