### PR TITLE
Add multiple documents with the same docType

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/fragment/AddSelfSignedFragment.kt
+++ b/appholder/src/main/java/com/android/mdl/app/fragment/AddSelfSignedFragment.kt
@@ -1,13 +1,17 @@
 package com.android.mdl.app.fragment
 
 import android.os.Bundle
+import android.text.Editable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import com.android.identity.IdentityCredentialStore.IMPLEMENTATION_TYPE_HARDWARE
+import com.android.identity.IdentityCredentialStore.IMPLEMENTATION_TYPE_KEYSTORE
 import com.android.mdl.app.R
 import com.android.mdl.app.databinding.FragmentAddSelfSignedBinding
 import com.android.mdl.app.util.DocumentData.MDL_DOCTYPE
@@ -47,11 +51,60 @@ class AddSelfSignedFragment : Fragment() {
             // Apply the adapter to the spinner
             binding.spDocumentType.adapter = adapter
         }
+        ArrayAdapter.createFromResource(
+            requireContext(),
+            R.array.storage_implementation,
+            android.R.layout.simple_spinner_item
+        ).also { adapter ->
+            // Specify the layout to use when the list of choices appears
+            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            // Apply the adapter to the spinner
+            binding.spStorageImplementation.adapter = adapter
+        }
+        binding.spDocumentType.onItemSelectedListener = object :
+            AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(
+                parent: AdapterView<*>?,
+                view: View?,
+                position: Int,
+                id: Long
+            ) {
+                setDocumentNameByType(position)
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>?) {
+
+            }
+
+        }
+    }
+
+    private fun setDocumentNameByType(position: Int) {
+        val value = when (position) {
+            0 -> {
+                "Driving License"
+            }
+            1 -> {
+                "Vehicle Registration"
+            }
+            2 -> {
+                "Vaccination Document"
+            }
+            else -> {
+                "New Document"
+            }
+        }
+        binding.edDocumentName.text = Editable.Factory.getInstance().newEditable(value)
     }
 
     fun onNext() {
+        if (binding.edDocumentName.text.isBlank()) {
+            setDocumentNameByType(-1)
+        }
         val provisionInfo = ProvisionInfo(
             getSelectedDocType(),
+            binding.edDocumentName.text.toString(),
+            getStorageImplementation(),
             binding.scUserAuthentication.isChecked,
             binding.totalMso.text.toString().toInt(),
             binding.totalUse.text.toString().toInt()
@@ -107,6 +160,22 @@ class AddSelfSignedFragment : Fragment() {
             }
             else -> {
                 MDL_DOCTYPE
+            }
+        }
+    }
+
+    private fun getStorageImplementation(): String {
+        // 0 Keystore-backed
+        // 1 Hardware-backed
+        return when (binding.spStorageImplementation.selectedItem) {
+            resources.getStringArray(R.array.storage_implementation)[0] -> {
+                IMPLEMENTATION_TYPE_KEYSTORE
+            }
+            resources.getStringArray(R.array.storage_implementation)[1] -> {
+                IMPLEMENTATION_TYPE_HARDWARE
+            }
+            else -> {
+                IMPLEMENTATION_TYPE_KEYSTORE
             }
         }
     }

--- a/appholder/src/main/java/com/android/mdl/app/fragment/ProvisioningFragment.kt
+++ b/appholder/src/main/java/com/android/mdl/app/fragment/ProvisioningFragment.kt
@@ -114,7 +114,7 @@ class ProvisioningFragment : Fragment() {
                 )
                 mDocType = docType
                 try {
-                    wc = documentManager.createCredential(credentialName, docType)
+                    wc = documentManager.createCredential(document, credentialName, docType)
                     val certificateChain =
                         wc?.getCredentialKeyCertificateChain(challenge)
                     Log.d(LOG_TAG, "sendMessageSetCertificateChain")

--- a/appholder/src/main/java/com/android/mdl/app/util/DocumentData.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/DocumentData.kt
@@ -1,9 +1,6 @@
 package com.android.mdl.app.util
 
 object DocumentData {
-    const val DUMMY_CREDENTIAL_NAME = "dummyCredential"
-    const val DUMMY_MVR_CREDENTIAL_NAME = "dummyCredentialMVR"
-    const val DUMMY_MICOV_CREDENTIAL_NAME = "dummyCredentialMICOV"
     const val MDL_DOCTYPE = "org.iso.18013.5.1.mDL"
     const val MDL_NAMESPACE = "org.iso.18013.5.1"
     const val MVR_DOCTYPE = "nl.rdw.mekb.1"

--- a/appholder/src/main/java/com/android/mdl/app/util/SelfSignedDocumentData.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/SelfSignedDocumentData.kt
@@ -32,6 +32,8 @@ data class SelfSignedDocumentData(
 @Parcelize
 data class ProvisionInfo(
     val docType: String,
+    var docName: String,
+    val storageImplementationType: String,
     val userAuthentication: Boolean,
     val numberMso: Int,
     val maxUseMso: Int

--- a/appholder/src/main/java/com/android/mdl/app/viewmodel/SelfSignedViewModel.kt
+++ b/appholder/src/main/java/com/android/mdl/app/viewmodel/SelfSignedViewModel.kt
@@ -37,7 +37,6 @@ class SelfSignedViewModel(val app: Application) :
         var id = 1
 
         // Pre fill default values for MDL document
-        fieldsMdl.add(Field(id++, "Document Name", "document_name", FieldType.STRING, "Driving License"))
         val bitmap = BitmapFactory.decodeResource(
             app.resources,
             R.drawable.img_erika_portrait
@@ -70,7 +69,6 @@ class SelfSignedViewModel(val app: Application) :
 
         // Pre fill default values for MRV document
         id = 1
-        fieldsMvr.add(Field(id++, "Document Name", "document_name", FieldType.STRING, "Vehicle Registration"))
         fieldsMvr.add(Field(id++, "Issuing Country", "issuingCountry", FieldType.STRING, "UT"))
         fieldsMvr.add(Field(id++, "Competent Authority", "competentAuthority", FieldType.STRING, "RDW"))
         fieldsMvr.add(Field(id++, "Registration Number", "registrationNumber", FieldType.STRING, "E-01-23"))
@@ -89,7 +87,6 @@ class SelfSignedViewModel(val app: Application) :
 
         // Pre fill default values for MICOV document
         id = 1
-        fieldsMicov.add(Field(id++, "Document Name", "document_name", FieldType.STRING, "Vaccination Document"))
         fieldsMicov.add(Field(id++, "Family name initial", "fni", FieldType.STRING, "M"))
         fieldsMicov.add(Field(id++, "Family name", "fn", FieldType.STRING, "Mustermann"))
         fieldsMicov.add(Field(id++, "Given name initial", "gni", FieldType.STRING, "E"))

--- a/appholder/src/main/java/com/android/mdl/app/viewmodel/TransferDocumentViewModel.kt
+++ b/appholder/src/main/java/com/android/mdl/app/viewmodel/TransferDocumentViewModel.kt
@@ -8,19 +8,16 @@ import androidx.databinding.ObservableInt
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.viewModelScope
 import com.android.identity.Constants.DEVICE_RESPONSE_STATUS_OK
 import com.android.identity.DeviceRequestParser
 import com.android.identity.DeviceResponseGenerator
 import com.android.mdl.app.R
 import com.android.mdl.app.authconfirmation.RequestedDocumentData
 import com.android.mdl.app.authconfirmation.SignedPropertiesCollection
+import com.android.mdl.app.document.Document
 import com.android.mdl.app.document.DocumentManager
 import com.android.mdl.app.transfer.TransferManager
 import com.android.mdl.app.util.TransferStatus
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
 
@@ -33,6 +30,7 @@ class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
     private val signedProperties = SignedPropertiesCollection()
     private val requestedProperties = mutableListOf<RequestedDocumentData>()
     private val closeConnectionMutableLiveData = MutableLiveData<Boolean>()
+    private val selectedDocuments = mutableListOf<Document>()
 
     var inProgress = ObservableInt(View.GONE)
     var documentsSent = ObservableField<String>()
@@ -44,6 +42,8 @@ class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
         transferManager.getDeviceRequest().documentRequests
 
     fun getDocuments() = documentManager.getDocuments()
+
+    fun getSelectedDocuments() = selectedDocuments
 
     fun getCryptoObject() = transferManager.getCryptoObject()
 
@@ -63,7 +63,7 @@ class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
     }
 
     fun createSelectedItemsList() {
-        val ownDocuments = getDocuments()
+        val ownDocuments = getSelectedDocuments()
         val requestedDocuments = getRequestedDocuments()
         val result = mutableListOf<RequestedDocumentData>()
         requestedDocuments.forEach { requestedDocument ->
@@ -141,5 +141,6 @@ class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
     private fun cleanUp() {
         requestedProperties.clear()
         signedProperties.clear()
+        selectedDocuments.clear()
     }
 }

--- a/appholder/src/main/res/layout/fragment_add_self_signed.xml
+++ b/appholder/src/main/res/layout/fragment_add_self_signed.xml
@@ -29,6 +29,36 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="16dp" />
 
+        <TextView
+            android:id="@+id/tv_document_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:layout_marginTop="16dp"
+            android:labelFor="@id/ed_document_name"
+            android:text="@string/txt_document_name" />
+
+        <EditText
+            android:id="@+id/ed_document_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp" />
+
+        <TextView
+            android:id="@+id/tv_storage_implementation"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:layout_marginTop="16dp"
+            android:labelFor="@id/sp_storage_implementation"
+            android:text="@string/txt_storage_implementation" />
+
+        <Spinner
+            android:id="@+id/sp_storage_implementation"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp" />
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content">

--- a/appholder/src/main/res/values/arrays.xml
+++ b/appholder/src/main/res/values/arrays.xml
@@ -5,4 +5,8 @@
         <item>mVR</item>
         <item>micov</item>
     </string-array>
+    <string-array name="storage_implementation">
+        <item>Keystore-backed</item>
+        <item>Hardware-backed</item>
+    </string-array>
 </resources>

--- a/appholder/src/main/res/values/strings.xml
+++ b/appholder/src/main/res/values/strings.xml
@@ -107,7 +107,9 @@
 
     <string name="item_settings">Settings</string>
     <string name="bt_close_connection">Close Connection</string>
-    <string name="txt_document_type">Document type:</string>
+    <string name="txt_document_type">Document type</string>
+    <string name="txt_document_name">Document name</string>
+    <string name="txt_storage_implementation">Storage implementation</string>
     <string name="txt_user_authentication">Use user authentication</string>
     <string name="txt_number_mso">Number of MSOs</string>
     <string name="txt_max_use_mso">Max use of MSO</string>


### PR DESCRIPTION
- No documents are automatically created once we install the app.
- It is possible to add more than one document for the same docType
- It is possible to provision documents using different store implementation
- User can choose which document to transfer if there are multiples for the same docType
- Document transfer can only transfer documents provisioned in Keystore implementation

* Needs to be fixed transfer multiple documents from multiple store implementations

> It's a good idea to open an issue first for discussion.

- [X] Tests pass
- [X] Appropriate changes to README are included in PR