### PR TITLE
Don't set session transcript when viewing data elements.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/transfer/TransferManager.kt
+++ b/appholder/src/main/java/com/android/mdl/app/transfer/TransferManager.kt
@@ -513,12 +513,6 @@ class TransferManager private constructor(private val context: Context) {
                 .setIssuerSignedEntriesToRequest(entriesToRequest)
                 .build()
 
-            try {
-                mSession.setSessionTranscript(byteArrayOf(0))
-            } catch (e: IllegalStateException) {
-                Log.i(LOG_TAG, "Ignoring session transcript already set ${e.message}")
-            }
-
             // It can display data if user consent is not required
             val credentialData =
                 mSession.getCredentialData(document.identityCredentialName, credentialRequest)

--- a/identity/src/main/java/com/android/identity/KeystorePresentationSession.java
+++ b/identity/src/main/java/com/android/identity/KeystorePresentationSession.java
@@ -127,7 +127,9 @@ class KeystorePresentationSession extends PresentationSession {
                 credential.setAllowUsingExhaustedKeys(request.isAllowUsingExhaustedKeys());
                 credential.setAllowUsingExpiredKeys(request.isAllowUsingExpiredKeys());
                 credential.setIncrementKeyUsageCount(request.isIncrementUseCount());
-                credential.setSessionTranscript(mSessionTranscript);
+                if (mSessionTranscript != null) {
+                    credential.setSessionTranscript(mSessionTranscript);
+                }
             }
 
             ResultData deviceSignedResult = credential.getEntries(


### PR DESCRIPTION
This is not needed and setting an empty session transcript won't work with the HW-backed Identity Credential. This was here because KS-Backed PresentationSession didn't work with an unset SessionTranscript. Fix that.
