### PR TITLE
Don't require user confirmation when using BiometricPrompt.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/authprompt/UserAuthPromptBuilder.kt
+++ b/appholder/src/main/java/com/android/mdl/app/authprompt/UserAuthPromptBuilder.kt
@@ -83,6 +83,7 @@ class UserAuthPromptBuilder private constructor(private val fragment: Fragment) 
             .setTitle(title)
             .setSubtitle(subtitle)
             .setDescription(description)
+            .setConfirmationRequired(false)
 
         if (forceLskf) {
             // TODO: this works only on Android 11 or later but for now this is fine


### PR DESCRIPTION
This is unnecessary because we already have a consent dialog which requires the user to press a button to send the data. As a result, the consent dialog looks a lot more delightful in this mode, see https://www.youtube.com/watch?v=hziY3kp2YE4 for a quick video.

Test: Manually tested on Pixel 4 XL
