### PR TITLE
Use correct AAMVA namespace and add new reader option for US transportation.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/document/DocumentManager.kt
+++ b/appholder/src/main/java/com/android/mdl/app/document/DocumentManager.kt
@@ -338,7 +338,13 @@ class DocumentManager private constructor(private val context: Context) {
                 idsSelf,
                 signature
             )
-            .putEntryBoolean(DocumentData.AAMVA_NAMESPACE, "real_id", idsSelf, dData.getValueBoolean("real_id"))
+            .putEntryInteger(DocumentData.MDL_NAMESPACE, "sex", idsSelf, dData.getValueString("sex").toLong())
+            .putEntryString(DocumentData.AAMVA_NAMESPACE, "aamva_version", idsSelf, dData.getValueString("aamva_version"))
+            .putEntryString(DocumentData.AAMVA_NAMESPACE, "EDL_credential", idsSelf, dData.getValueString("aamva_EDL_credential"))
+            .putEntryString(DocumentData.AAMVA_NAMESPACE, "DHS_compliance", idsSelf, dData.getValueString("aamva_DHS_compliance"))
+            .putEntryString(DocumentData.AAMVA_NAMESPACE, "given_name_truncation", idsSelf, dData.getValueString("aamva_given_name_truncation"))
+            .putEntryString(DocumentData.AAMVA_NAMESPACE, "family_name_truncation", idsSelf, dData.getValueString("aamva_family_name_truncation"))
+            .putEntryInteger(DocumentData.AAMVA_NAMESPACE, "sex", idsSelf, dData.getValueString("aamva_sex").toLong())
 
         personalizationData.addAccessControlProfile(profileSelf)
 

--- a/appholder/src/main/java/com/android/mdl/app/util/DocumentData.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/DocumentData.kt
@@ -8,7 +8,7 @@ object DocumentData {
     const val MICOV_DOCTYPE = "org.micov.1"
     const val MICOV_VTR_NAMESPACE = "org.micov.vtr.1"
     const val MICOV_ATT_NAMESPACE = "org.micov.attestation.1"
-    const val AAMVA_NAMESPACE = "org.aamva.18013.5.1"
+    const val AAMVA_NAMESPACE = "org.iso.18013.5.1.aamva"
 
     enum class ErikaStaticData(val identifier: String, val value: String) {
         VISIBLE_NAME("visible_name", "Driving License"),

--- a/appholder/src/main/java/com/android/mdl/app/viewmodel/SelfSignedViewModel.kt
+++ b/appholder/src/main/java/com/android/mdl/app/viewmodel/SelfSignedViewModel.kt
@@ -58,6 +58,7 @@ class SelfSignedViewModel(val app: Application) :
         fieldsMdl.add(Field(id++, "UN Distinguishing Sign", "un_distinguishing_sign", FieldType.STRING, "UT"))
         fieldsMdl.add(Field(id++, "Age Over 18", "age_over_18", FieldType.BOOLEAN, "true"))
         fieldsMdl.add(Field(id++, "Age Over 21", "age_over_21", FieldType.BOOLEAN, "true"))
+        fieldsMdl.add(Field(id++, "Sex", "sex", FieldType.STRING, "2"))
         // TODO: Add driving_privileges dynamically
         fieldsMdl.add(Field(id++, "vehicle Category Code 1", "vehicle_category_code_1", FieldType.STRING, "A"))
         fieldsMdl.add(Field(id++, "Issue Date 1", "issue_date_1", FieldType.DATE, "2018-08-09"))
@@ -65,7 +66,12 @@ class SelfSignedViewModel(val app: Application) :
         fieldsMdl.add(Field(id++, "vehicle Category Code 2", "vehicle_category_code_2", FieldType.STRING, "B"))
         fieldsMdl.add(Field(id++, "Issue Date 2", "issue_date_2", FieldType.DATE, "2017-02-23"))
         fieldsMdl.add(Field(id++, "Expiry Date 2", "expiry_date_2", FieldType.DATE, "2024-10-20"))
-        fieldsMdl.add(Field(id, "Real Id", "real_id", FieldType.BOOLEAN, "true"))
+        fieldsMdl.add(Field(id++, "AAMVA version", "aamva_version", FieldType.STRING, "2"))
+        fieldsMdl.add(Field(id++, "AAMVA DHS Compliance (Real ID)", "aamva_DHS_compliance", FieldType.STRING, "F"))
+        fieldsMdl.add(Field(id++, "AAMVA EDL Credential", "aamva_EDL_credential", FieldType.STRING, "1"))
+        fieldsMdl.add(Field(id++, "AAMVA Given Name Truncation", "aamva_given_name_truncation", FieldType.STRING, "N"))
+        fieldsMdl.add(Field(id++, "AAMVA Family Name Truncation", "aamva_family_name_truncation", FieldType.STRING, "N"))
+        fieldsMdl.add(Field(id++, "AAMVA Sex", "aamva_sex", FieldType.STRING, "2"))
 
         // Pre fill default values for MRV document
         id = 1

--- a/appverifier/src/main/java/com/android/mdl/appreader/document/RequestMdlUsTransportation.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/document/RequestMdlUsTransportation.kt
@@ -1,0 +1,41 @@
+package com.android.mdl.appreader.document
+
+import com.android.mdl.appreader.R
+
+object RequestMdlUsTransportation : RequestDocument() {
+    override val docType = "org.iso.18013.5.1.mDL"
+    override val nameSpace = "org.iso.18013.5.1"
+    private val nameSpaceAamva = "org.iso.18013.5.1.aamva"
+    override val dataItems = DataItems.values().asList()
+
+    override fun getItemsToRequest(): Map<String, Map<String, Boolean>> {
+        return mapOf(
+            Pair(nameSpace,
+                mapOf(Pair("sex", false),
+                      Pair("portrait", false),
+                      Pair("given_name", false),
+                      Pair("issue_date", false),
+                      Pair("expiry_date", false),
+                      Pair("family_name", false),
+                      Pair("document_number", false),
+                      Pair("issuing_authority", false))),
+            Pair(nameSpaceAamva,
+                mapOf(Pair("DHS_compliance", false),
+                      Pair("EDL_credential", false)))
+        )
+    }
+
+    enum class DataItems(override val identifier: String, override val stringResourceId: Int) :
+        RequestDataItem {
+        SEX("", R.string.sex),
+        PORTRAIT("portrait", R.string.portrait),
+        GIVEN_NAME("given_name", R.string.given_name),
+        BIRTH_DATE("birth_date", R.string.birth_date),
+        ISSUE_DATE("issue_date", R.string.issue_date),
+        EXPIRY_DATE("expiry_date", R.string.expiry_date),
+        FAMILY_NAME("family_name", R.string.family_name),
+        DOCUMENT_NUMBER("document_number", R.string.document_number),
+        ISSUING_AUTHORITY("issuing_authority", R.string.issuing_authority),
+        DHS_COMPLIANCE("DHS_compliance", R.string.dhs_compliance),
+    }
+}

--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/RequestOptionsFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/RequestOptionsFragment.kt
@@ -52,6 +52,7 @@ class RequestOptionsFragment : Fragment() {
             binding.cbRequestMdlOlder21.isEnabled = binding.cbRequestMdl.isChecked
             binding.cbRequestMdlMandatory.isEnabled = binding.cbRequestMdl.isChecked
             binding.cbRequestMdlFull.isEnabled = binding.cbRequestMdl.isChecked
+            binding.cbRequestMdlUsTransportation.isEnabled =  binding.cbRequestMdl.isChecked
             binding.cbRequestMdlCustom.isEnabled = binding.cbRequestMdl.isChecked
         }
 
@@ -60,6 +61,7 @@ class RequestOptionsFragment : Fragment() {
             binding.cbRequestMdlOlder21.isChecked = false
             binding.cbRequestMdlMandatory.isChecked = false
             binding.cbRequestMdlFull.isChecked = false
+            binding.cbRequestMdlUsTransportation.isChecked = false
             binding.cbRequestMdlCustom.isChecked = false
         }
         binding.cbRequestMdlOlder21.setOnClickListener {
@@ -67,6 +69,7 @@ class RequestOptionsFragment : Fragment() {
             binding.cbRequestMdlOlder21.isChecked = true
             binding.cbRequestMdlMandatory.isChecked = false
             binding.cbRequestMdlFull.isChecked = false
+            binding.cbRequestMdlUsTransportation.isChecked = false
             binding.cbRequestMdlCustom.isChecked = false
         }
         binding.cbRequestMdlMandatory.setOnClickListener {
@@ -74,6 +77,7 @@ class RequestOptionsFragment : Fragment() {
             binding.cbRequestMdlOlder21.isChecked = false
             binding.cbRequestMdlMandatory.isChecked = true
             binding.cbRequestMdlFull.isChecked = false
+            binding.cbRequestMdlUsTransportation.isChecked = false
             binding.cbRequestMdlCustom.isChecked = false
         }
         binding.cbRequestMdlFull.setOnClickListener {
@@ -81,14 +85,23 @@ class RequestOptionsFragment : Fragment() {
             binding.cbRequestMdlOlder21.isChecked = false
             binding.cbRequestMdlMandatory.isChecked = false
             binding.cbRequestMdlFull.isChecked = true
+            binding.cbRequestMdlUsTransportation.isChecked = false
             binding.cbRequestMdlCustom.isChecked = false
-
+        }
+        binding.cbRequestMdlUsTransportation.setOnClickListener {
+            binding.cbRequestMdlOlder18.isChecked = false
+            binding.cbRequestMdlOlder21.isChecked = false
+            binding.cbRequestMdlMandatory.isChecked = false
+            binding.cbRequestMdlFull.isChecked = false
+            binding.cbRequestMdlUsTransportation.isChecked = true
+            binding.cbRequestMdlCustom.isChecked = false
         }
         binding.cbRequestMdlCustom.setOnClickListener {
             binding.cbRequestMdlOlder18.isChecked = false
             binding.cbRequestMdlOlder21.isChecked = false
             binding.cbRequestMdlMandatory.isChecked = false
             binding.cbRequestMdlFull.isChecked = false
+            binding.cbRequestMdlUsTransportation.isChecked = false
             binding.cbRequestMdlCustom.isChecked = true
         }
 
@@ -134,18 +147,22 @@ class RequestOptionsFragment : Fragment() {
 
         val requestDocumentList = RequestDocumentList()
         if (binding.cbRequestMdl.isChecked) {
-            val mdl = RequestMdl
-            when {
-                binding.cbRequestMdlOlder18.isChecked ->
-                    mdl.setSelectedDataItems(getSelectRequestMdlOlder18(intentToRetain))
-                binding.cbRequestMdlOlder21.isChecked ->
-                    mdl.setSelectedDataItems(getSelectRequestMdlOlder21(intentToRetain))
-                binding.cbRequestMdlMandatory.isChecked ->
-                    mdl.setSelectedDataItems(getSelectRequestMdlMandatory(intentToRetain))
-                binding.cbRequestMdlFull.isChecked ->
-                    mdl.setSelectedDataItems(getSelectRequestFull(mdl, intentToRetain))
+            if (binding.cbRequestMdlUsTransportation.isChecked) {
+                requestDocumentList.addRequestDocument(RequestMdlUsTransportation)
+            } else {
+                val mdl = RequestMdl
+                when {
+                    binding.cbRequestMdlOlder18.isChecked ->
+                        mdl.setSelectedDataItems(getSelectRequestMdlOlder18(intentToRetain))
+                    binding.cbRequestMdlOlder21.isChecked ->
+                        mdl.setSelectedDataItems(getSelectRequestMdlOlder21(intentToRetain))
+                    binding.cbRequestMdlMandatory.isChecked ->
+                        mdl.setSelectedDataItems(getSelectRequestMdlMandatory(intentToRetain))
+                    binding.cbRequestMdlFull.isChecked ->
+                        mdl.setSelectedDataItems(getSelectRequestFull(mdl, intentToRetain))
+                }
+                requestDocumentList.addRequestDocument(mdl)
             }
-            requestDocumentList.addRequestDocument(mdl)
         }
         if (binding.cbRequestMvr.isChecked) {
             val doc = RequestMvr

--- a/appverifier/src/main/res/layout/fragment_request_options.xml
+++ b/appverifier/src/main/res/layout/fragment_request_options.xml
@@ -64,13 +64,22 @@
         app:layout_constraintTop_toBottomOf="@+id/cb_request_mdl_mandatory" />
 
     <CheckBox
+        android:id="@+id/cb_request_mdl_us_transportation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="56dp"
+        android:text="mDL for US transportation"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/cb_request_mdl_full" />
+
+    <CheckBox
         android:id="@+id/cb_request_mdl_custom"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="56dp"
         android:text="Custom..."
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/cb_request_mdl_full" />
+        app:layout_constraintTop_toBottomOf="@+id/cb_request_mdl_us_transportation" />
 
 
     <CheckBox

--- a/appverifier/src/main/res/values/strings.xml
+++ b/appverifier/src/main/res/values/strings.xml
@@ -74,5 +74,6 @@
     <string name="item_settings">Settings</string>
     <string name="show_qr_code_instructions">Scan QR code with mdoc application.\n\nNOTE: This is not supported for ISO 18013-7, only 23220-4.</string>
     <string name="show_qr">Show QR Code for\nReverse Engagement</string>
+    <string name="dhs_compliance">DHS Compliance</string>
 
 </resources>


### PR DESCRIPTION
Also add a couple of mandatory AAMVA data elements in the default self-signed mDL. The new reader option is called "mDL for US transportion" and will request an asssorted set of data elements in both the org.iso.18013.5.1 and org.iso.18013.5.1.aamva namespace.

This actually uncovered a bug in our holder app insofar that two documents are included in the response, one for each namespace. A subsequent change will fix this to be just one document.

Test: Manually tested.
