### PR TITLE
Work around broken mDL app using key 5 in DeviceEngagement 1.0.

### DIFF
--- a/identity/src/main/java/com/android/identity/EngagementParser.java
+++ b/identity/src/main/java/com/android/identity/EngagementParser.java
@@ -162,13 +162,24 @@ public class EngagementParser {
                 }
             }
 
-            if (Util.cborMapHasKey(map, 5)) {
-                List<DataItem> originInfoItems = Util.cborMapExtractArray(map, 5);
-                for (DataItem oiDataItem : originInfoItems) {
-                    OriginInfo originInfo = OriginInfo.decode(oiDataItem);
-                    if (originInfo != null) {
-                        mOriginInfos.add(originInfo);
+            if (Util.mdocVersionCompare(mVersion, "1.1") >= 0) {
+                // 18013-7 defines key 5 as having origin info
+                if (Util.cborMapHasKey(map, 5)) {
+                    List<DataItem> originInfoItems = Util.cborMapExtractArray(map, 5);
+                    for (DataItem oiDataItem : originInfoItems) {
+                        OriginInfo originInfo = OriginInfo.decode(oiDataItem);
+                        if (originInfo != null) {
+                            mOriginInfos.add(originInfo);
+                        }
                     }
+                }
+            } else {
+                if (Util.cborMapHasKey(map, 5)) {
+                    Logger.w(TAG,
+                            String.format("Ignoring key 5 in Engagement as version is set to %s. "
+                                    + "The mdoc application producing this DeviceEngagement is "
+                                    + "not compliant to ISO/IEC 18013-5:2021.",
+                                    mVersion));
                 }
             }
         }

--- a/identity/src/main/java/com/android/identity/Util.java
+++ b/identity/src/main/java/com/android/identity/Util.java
@@ -1860,4 +1860,25 @@ class Util {
         return new UUID(data.getLong(0), data.getLong(8));
     }
 
+    /**
+     * Version comparison method for mdoc versions.
+     *
+     * <p>This compares mdoc version strings and returns a negative number if the first version
+     * is considered less than the second version, 0 if they are considered equal, and positive
+     * otherwise.
+     *
+     * <p>For example, called with <code>mdocVersionCompare("1.0", "1.1")</code> will return
+     * a negative number.
+     *
+     * @param a a version string, for example "1.0"
+     * @param b another version string, for example "1.1"
+     * @return a positive number, negative number, or 0.
+     */
+    static int
+    mdocVersionCompare(@NonNull String a, @NonNull String b) {
+        // TODO: this just lexicographically compares the strings as ISO 18013-5 doesn't currently
+        //   define how to compare version strings.
+        return a.compareTo(b);
+    }
+
 }

--- a/identity/src/test/java/com/android/identity/UtilTest.java
+++ b/identity/src/test/java/com/android/identity/UtilTest.java
@@ -947,4 +947,11 @@ public class UtilTest {
         assertArrayEquals(data2, firstDataItemBytes);
         assertArrayEquals(incompleteCbor, baos.toByteArray());
     }
+
+    @Test
+    public void testMdocVersionCompare() {
+        assertTrue(Util.mdocVersionCompare("1.0", "1.0") == 0);
+        assertTrue(Util.mdocVersionCompare("1.0", "1.1") < 0);
+        assertTrue(Util.mdocVersionCompare("1.1", "1.0") > 0);
+    }
 }


### PR DESCRIPTION
There is an mDL app which sends a DeviceEngagement via QR with version set to "1.0" and includes a value for key 5 despite ISO 18013-5 section 8.2.1.1 Device engagement structure being quite clear that positive key values are RFU. The value which said mDL included in key 5 was an array with a single string set to "org.iso.18013.5.1.mDL".

This uncovered an issue with our new EngagementParser used in our mdoc reader which is looking for key 5 since it's defined in 18013-7/23220-4 to contain an array of OriginInfo. Fix the issue by making the parser only look for key 5 if version is set to "1.1" or later. Also print a warning that if an mDL / mdoc uses this key for version "1.0" that it is not compliant to the standard.

Additionally, once the DeviceEngagement problem was resolved another problem surfaced. The MTU that ended up being negotiated was 517 and as per the explanation in

  https://github.com/google/identity-credential/commit/8de93adc246e1f48c3e80615f29440aa6b460fe1

this clearly won't work. Since applications (for context the problematic mDL was running on iOS and our reader is on Android and was acting as the GATT server) generally cannot easily convey their preference for MTU assume that the max chunk size used for 18013-5 BLE data transfers is 515 even if a higher MTU has been negotiated.

In other words, interpret "shall divide the message in parts with a length of 3 bytes less than the MTU size." as "shall divide the message in parts with a length of 3 bytes less than the MTU size or 515 whichever is lower." since this is likely the language we'll end up using for ISO/IEC 18013-5:2021 Amendment 1.

Test: Manually tested.
