### PR TITLE
Fix canonicalization problems.

### DIFF
--- a/identity/src/main/java/com/android/identity/CredentialData.java
+++ b/identity/src/main/java/com/android/identity/CredentialData.java
@@ -155,9 +155,9 @@ class CredentialData {
 
             MapBuilder<ArrayBuilder<CborBuilder>> entryMapBuilder = entryArrayBuilder.addMap();
             entryMapBuilder.put("name", entryName);
+            entryMapBuilder.put(new UnicodeString("value"), Util.cborDecode(entryValue));
             entryMapBuilder.put(new UnicodeString("accessControlProfiles"),
                     accessControlProfileIdsBuilder.build().get(0));
-            entryMapBuilder.put(new UnicodeString("value"), Util.cborDecode(entryValue));
         }
         return entryBuilder.build().get(0);
     }
@@ -189,7 +189,7 @@ class CredentialData {
             }
 
             DataItem cborValue = map.get(new UnicodeString("value"));
-            byte[] data = Util.cborEncode(cborValue);
+            byte[] data = Util.cborEncodeWithoutCanonicalizing(cborValue);
             builder.putEntry(namespaceName, name, accessControlProfileIds, data);
         }
 
@@ -709,7 +709,7 @@ class CredentialData {
 
     private byte[] saveToDiskEncode(CborBuilder map) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        CborEncoder encoder = new CborEncoder(baos);
+        CborEncoder encoder = new CborEncoder(baos).nonCanonical();
         try {
             encoder.encode(map.build());
         } catch (CborException e) {

--- a/identity/src/main/java/com/android/identity/DeviceResponseGenerator.java
+++ b/identity/src/main/java/com/android/identity/DeviceResponseGenerator.java
@@ -204,6 +204,6 @@ public final class DeviceResponseGenerator {
         mapBuilder.put("status", mStatusCode);
         mapBuilder.end();
 
-        return Util.cborEncode(deviceResponseBuilder.build().get(0));
+        return Util.cborEncodeWithoutCanonicalizing(deviceResponseBuilder.build().get(0));
     }
 }

--- a/identity/src/main/java/com/android/identity/DeviceResponseParser.java
+++ b/identity/src/main/java/com/android/identity/DeviceResponseParser.java
@@ -265,7 +265,8 @@ public final class DeviceResponseParser {
                                 + digestId + " in namespace " + nameSpace);
                     }
                     boolean digestMatch = Arrays.equals(expectedDigest, digest);
-                    builder.addIssuerEntry(nameSpace, elementName, Util.cborEncode(elementValue),
+                    builder.addIssuerEntry(nameSpace, elementName,
+                            Util.cborEncodeWithoutCanonicalizing(elementValue),
                             digestMatch);
                 }
             }

--- a/identity/src/main/java/com/android/identity/KeystoreWritableIdentityCredential.java
+++ b/identity/src/main/java/com/android/identity/KeystoreWritableIdentityCredential.java
@@ -190,7 +190,7 @@ class KeystoreWritableIdentityCredential extends WritableIdentityCredential {
         DataItem signature;
         try {
             ByteArrayOutputStream dtsBaos = new ByteArrayOutputStream();
-            CborEncoder dtsEncoder = new CborEncoder(dtsBaos);
+            CborEncoder dtsEncoder = new CborEncoder(dtsBaos).nonCanonical();
             dtsEncoder.encode(signedDataBuilder.build().get(0));
             byte[] dataToSign = dtsBaos.toByteArray();
 

--- a/identity/src/main/java/com/android/identity/Utility.java
+++ b/identity/src/main/java/com/android/identity/Utility.java
@@ -253,9 +253,11 @@ public class Utility {
      * @param personalizationData         the data to put in the document, organized by namespace.
      * @param numAuthKeys                 number of authentication keys to create.
      * @param maxUsesPerKey               number of uses for each authentication key.
+     * @return bytes of a COSE_Sign1 for proof of provisioning
      */
     @SuppressWarnings("deprecation")
-    public static void provisionSelfSignedCredential(
+    public static
+    @NonNull byte[] provisionSelfSignedCredential(
             @NonNull IdentityCredentialStore store,
             @NonNull String credentialName,
             @NonNull PrivateKey issuingAuthorityKey,
@@ -282,7 +284,7 @@ public class Utility {
                 e.printStackTrace();
             }
         }
-        wc.personalize(personalizationData);
+        byte[] signedPop = wc.personalize(personalizationData);
 
         IdentityCredential c = store.getCredentialByName(credentialName,
                 IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
@@ -411,6 +413,7 @@ public class Utility {
 
         } // for each authkey
 
+        return signedPop;
     }
 
 

--- a/identity/src/test/java/com/android/identity/DeviceResponseParserTest.java
+++ b/identity/src/test/java/com/android/identity/DeviceResponseParserTest.java
@@ -107,14 +107,14 @@ public class DeviceResponseParserTest {
                         "expiry_date")));
         Assert.assertEquals("[\n"
                         + "  {\n"
+                        + "    'vehicle_category_code' : 'A',\n"
                         + "    'issue_date' : tag 1004 '2018-08-09',\n"
-                        + "    'expiry_date' : tag 1004 '2024-10-20',\n"
-                        + "    'vehicle_category_code' : 'A'\n"
+                        + "    'expiry_date' : tag 1004 '2024-10-20'\n"
                         + "  },\n"
                         + "  {\n"
+                        + "    'vehicle_category_code' : 'B',\n"
                         + "    'issue_date' : tag 1004 '2017-02-23',\n"
-                        + "    'expiry_date' : tag 1004 '2024-10-20',\n"
-                        + "    'vehicle_category_code' : 'B'\n"
+                        + "    'expiry_date' : tag 1004 '2024-10-20'\n"
                         + "  }\n"
                         + "]",
                 Util.cborPrettyPrint(d.getIssuerEntryData(MDL_NAMESPACE,


### PR DESCRIPTION
In a couple of places we were reencoding CBOR and canonicalizing it leading to digest mismatch problems at presentation time when a canonicalized version was sent to the mdoc reader. This only affected data element values with non-trivial CBOR encodings for example driving_privileges from the mDL namespace.

Fix this by adding unit tests in all places where we return data elements including credential storage, proof of provisioning, and response generation / parsing.

Test: All unit tests pass (both with Keystore and IC APIs)
Test: Manually tested
