### PR TITLE
Fix/auth prompt cancellation and launching

### DIFF
--- a/appholder/src/main/AndroidManifest.xml
+++ b/appholder/src/main/AndroidManifest.xml
@@ -76,7 +76,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="mdoc" />
+                <data android:scheme="mdoc" android:host="*" />
             </intent-filter>
         </activity>
 

--- a/appholder/src/main/java/com/android/mdl/app/MainActivity.kt
+++ b/appholder/src/main/java/com/android/mdl/app/MainActivity.kt
@@ -10,6 +10,7 @@ import android.util.Log
 import android.view.WindowManager.LayoutParams.*
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.os.bundleOf
 import androidx.core.view.GravityCompat
 import androidx.navigation.Navigation
 import androidx.navigation.findNavController
@@ -19,6 +20,8 @@ import androidx.navigation.ui.setupWithNavController
 import com.android.identity.OriginInfo
 import com.android.identity.OriginInfoWebsite
 import com.android.mdl.app.databinding.ActivityMainBinding
+import com.android.mdl.app.fragment.TransferDocumentFragment
+import com.android.mdl.app.util.log
 import com.android.mdl.app.viewmodel.ShareDocumentViewModel
 import com.google.android.material.elevation.SurfaceColors
 
@@ -47,6 +50,7 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
         setupDrawerLayout()
         setupNfc()
+        onNewIntent(intent)
     }
 
     private fun setupNfc() {
@@ -117,7 +121,10 @@ class MainActivity : AppCompatActivity() {
         originInfos.add(OriginInfoWebsite(1, mdocReferrerUri))
         viewModel.startPresentationReverseEngagement(mdocUri, originInfos)
         val navController = findNavController(R.id.nav_host_fragment)
-        navController.navigate(R.id.transferDocumentFragment)
+        navController.navigate(
+            R.id.transferDocumentFragment,
+            bundleOf(TransferDocumentFragment.CLOSE_AFTER_SERVING_KEY to true)
+        )
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/appholder/src/main/java/com/android/mdl/app/authconfirmation/AuthConfirmationFragment.kt
+++ b/appholder/src/main/java/com/android/mdl/app/authconfirmation/AuthConfirmationFragment.kt
@@ -1,5 +1,6 @@
 package com.android.mdl.app.authconfirmation
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -49,11 +50,22 @@ class AuthConfirmationFragment : BottomSheetDialogFragment() {
                             viewModel.toggleSignedProperty(namespace, property)
                         },
                         onConfirm = { sendResponse() },
-                        onCancel = { dismiss() }
+                        onCancel = {
+                            dismiss()
+                            cancelAuthorization()
+                        }
                     )
                 }
             }
         }
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        cancelAuthorization()
+    }
+
+    private fun cancelAuthorization() {
+        viewModel.onAuthenticationCancelled()
     }
 
     private fun mapToConfirmationSheetData(

--- a/appholder/src/main/java/com/android/mdl/app/fragment/TransferDocumentFragment.kt
+++ b/appholder/src/main/java/com/android/mdl/app/fragment/TransferDocumentFragment.kt
@@ -24,6 +24,7 @@ import com.android.mdl.app.viewmodel.TransferDocumentViewModel
 class TransferDocumentFragment : Fragment() {
 
     companion object {
+        const val CLOSE_AFTER_SERVING_KEY = "closeAfterServing"
         private const val LOG_TAG = "TransferDocumentFragment"
     }
 
@@ -31,6 +32,7 @@ class TransferDocumentFragment : Fragment() {
     private val binding get() = _binding!!
 
     private val viewModel: TransferDocumentViewModel by activityViewModels()
+    private val closeAfterServing by lazy { arguments?.getBoolean("closeAfterServing", false) ?: false }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -167,6 +169,9 @@ class TransferDocumentFragment : Fragment() {
         Log.d(LOG_TAG, "Disconnected")
         hideButtons()
         TransferManager.getInstance(requireContext()).disconnect()
+        if (closeAfterServing) {
+            requireActivity().finish()
+        }
     }
 
     private fun onTransferError() {

--- a/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
@@ -53,7 +53,10 @@ class NfcEngagementHandler : HostApduService() {
         override fun onDeviceConnecting() {
             log("Engagement Listener: Device Connecting. Launching Transfer Screen")
             val launchAppIntent = Intent(applicationContext, MainActivity::class.java)
+            launchAppIntent.action = Intent.ACTION_VIEW
             launchAppIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+            launchAppIntent.addCategory(Intent.CATEGORY_DEFAULT)
+            launchAppIntent.addCategory(Intent.CATEGORY_BROWSABLE)
             applicationContext.startActivity(launchAppIntent)
 
             val pendingIntent = NavDeepLinkBuilder(applicationContext)

--- a/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
@@ -16,6 +16,7 @@
 
 package com.android.mdl.app.util
 
+import android.content.Intent
 import android.nfc.cardemulation.HostApduService
 import android.os.Bundle
 import androidx.navigation.NavDeepLinkBuilder
@@ -24,12 +25,14 @@ import com.android.identity.NfcApduRouter
 import com.android.identity.NfcEngagementHelper
 import com.android.identity.PresentationHelper
 import com.android.identity.PresentationSession
+import com.android.mdl.app.MainActivity
 import com.android.mdl.app.R
 import com.android.mdl.app.transfer.Communication
 import com.android.mdl.app.transfer.ConnectionSetup
 import com.android.mdl.app.transfer.CredentialStore
 import com.android.mdl.app.transfer.SessionSetup
 import com.android.mdl.app.transfer.TransferManager
+
 
 class NfcEngagementHandler : HostApduService() {
 
@@ -49,9 +52,14 @@ class NfcEngagementHandler : HostApduService() {
 
         override fun onDeviceConnecting() {
             log("Engagement Listener: Device Connecting. Launching Transfer Screen")
+            val launchAppIntent = Intent(applicationContext, MainActivity::class.java)
+            launchAppIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+            applicationContext.startActivity(launchAppIntent)
+
             val pendingIntent = NavDeepLinkBuilder(applicationContext)
                 .setGraph(R.navigation.navigation_graph)
                 .setDestination(R.id.transferDocumentFragment)
+                .setComponentName(MainActivity::class.java)
                 .createPendingIntent()
             pendingIntent.send(applicationContext, 0, null)
             transferManager.updateStatus(TransferStatus.CONNECTING)

--- a/appholder/src/main/java/com/android/mdl/app/viewmodel/TransferDocumentViewModel.kt
+++ b/appholder/src/main/java/com/android/mdl/app/viewmodel/TransferDocumentViewModel.kt
@@ -36,6 +36,17 @@ class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
     var documentsSent = ObservableField<String>()
     val connectionClosedLiveData: LiveData<Boolean> = closeConnectionMutableLiveData
 
+    private val mutableConfirmationState = MutableLiveData<Boolean?>()
+    val authConfirmationState: LiveData<Boolean?> = mutableConfirmationState
+
+    fun onAuthenticationCancelled() {
+        mutableConfirmationState.value = true
+    }
+
+    fun onAuthenticationCancellationConsumed() {
+        mutableConfirmationState.value = null
+    }
+
     fun getTransferStatus(): LiveData<TransferStatus> =
         transferManager.getTransferStatus()
 


### PR DESCRIPTION
This PR fixes 2 issues
 - The cancellation of the auth confirmation: clicking the `Cancel` button or manually dismissing the bottom sheet will cancel the transfer and bring the user back to the main screen
 - NFC tap will launch the holder regardless if the user currently has opened another app. This works if the holder was previously closed. If minimized there is still an issue - for some reason the app doesn't get back in front. I'll keep investigating why