### PR TITLE
Implement NFC Negotiated Handover and add unit test for NFC engagement.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
@@ -119,21 +119,23 @@ class NfcEngagementHandler : HostApduService() {
     }
 
     override fun onCreate() {
+        log("onCreate:")
         super.onCreate()
         session = SessionSetup(CredentialStore(applicationContext)).createSession()
         communication = Communication.getInstance(applicationContext)
         transferManager = TransferManager.getInstance(applicationContext)
         transferManager.setCommunication(session, communication)
         val connectionSetup = ConnectionSetup(applicationContext)
-        engagementHelper = NfcEngagementHelper(
+        val builder = NfcEngagementHelper.Builder(
             applicationContext,
             session,
-            connectionSetup.getConnectionMethods(),
             connectionSetup.getConnectionOptions(),
             nfcApduRouter,
             nfcEngagementListener,
-            applicationContext.mainExecutor()
-        )
+            applicationContext.mainExecutor())
+        builder.useStaticHandover(connectionSetup.getConnectionMethods())
+        //builder.useNegotiatedHandover()
+        engagementHelper = builder.build()
     }
 
     override fun processCommandApdu(commandApdu: ByteArray, extras: Bundle?): ByteArray? {

--- a/appverifier/src/main/java/com/android/mdl/appreader/transfer/TransferManager.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/transfer/TransferManager.kt
@@ -102,7 +102,8 @@ class TransferManager private constructor(private val context: Context) {
     fun setNdefDeviceEngagement(adapter: NfcAdapter, activity: Activity) {
         adapter.enableReaderMode(
             activity, readerModeListener,
-            NfcAdapter.FLAG_READER_NFC_A + NfcAdapter.FLAG_READER_NFC_B,
+            NfcAdapter.FLAG_READER_NFC_A + NfcAdapter.FLAG_READER_NFC_B
+                    + NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK,
             null)
     }
 

--- a/identity/src/androidTest/java/com/android/identity/NfcEnagementHelperTest.java
+++ b/identity/src/androidTest/java/com/android/identity/NfcEnagementHelperTest.java
@@ -1,0 +1,433 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import static org.junit.Assume.assumeTrue;
+
+import android.content.Context;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.model.SimpleValue;
+
+@SuppressWarnings("deprecation")
+@RunWith(AndroidJUnit4.class)
+public class NfcEnagementHelperTest {
+    private static final String TAG = "NfcEnagementHelperTest";
+
+    @Test
+    @SmallTest
+    public void testStaticHandover() throws Exception {
+        NfcEngagementHelper helper = null;
+        Context context = InstrumentationRegistry.getTargetContext();
+        IdentityCredentialStore store = Util.getIdentityCredentialStore(context);
+        assumeTrue(store.getFeatureVersion() >= IdentityCredentialStore.FEATURE_VERSION_202201);
+
+        PresentationSession session = store.createPresentationSession(
+                IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
+
+        NfcEngagementHelper.Listener listener = new NfcEngagementHelper.Listener() {
+            @Override
+            public void onDeviceConnecting() {
+
+            }
+
+            @Override
+            public void onDeviceConnected(DataTransport transport) {
+            }
+
+            @Override
+            public void onError(@NonNull Throwable error) {
+
+            }
+        };
+
+        BlockingQueue<byte[]> apdusSentByHelper = new ArrayBlockingQueue<byte[]>(100);
+        NfcApduRouter apduRouter = new NfcApduRouter() {
+            @Override
+            public void sendResponseApdu(@NonNull byte[] responseApdu) {
+                Log.w(TAG, "apdu: " + Util.toHex(responseApdu));
+                apdusSentByHelper.add(responseApdu);
+            }
+        };
+
+        Executor executor = Executors.newSingleThreadExecutor();
+        NfcEngagementHelper.Builder builder = new NfcEngagementHelper.Builder(
+                context,
+                session,
+                new DataTransportOptions.Builder().build(),
+                apduRouter,
+                listener,
+                executor);
+
+        // Include all ConnectionMethods that can exist in OOB data
+        List<ConnectionMethod> connectionMethods = new ArrayList<>();
+        UUID bleUuid = UUID.randomUUID();
+        connectionMethods.add(new ConnectionMethodBle(
+                true,
+                true,
+                bleUuid,
+                bleUuid));
+        connectionMethods.add(new ConnectionMethodNfc(
+                0xffff,
+                0xffff));
+        connectionMethods.add(new ConnectionMethodWifiAware(
+                null,
+                OptionalLong.empty(),
+                OptionalLong.empty(),
+                null));
+        builder.useStaticHandover(connectionMethods);
+        helper = builder.build();
+        helper.testingDoNotStartTransports();
+
+        // Select Type 4 Tag NDEF app
+        byte[] ndefAppId = NfcApduRouter.AID_FOR_TYPE_4_TAG_NDEF_APPLICATION;
+        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduApplicationSelect(ndefAppId));
+        byte[] responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        Assert.assertArrayEquals(NfcUtil.STATUS_WORD_OK, responseApdu);
+
+        // Select CC file
+        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduSelectFile(NfcUtil.CAPABILITY_CONTAINER_FILE_ID));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        Assert.assertArrayEquals(NfcUtil.STATUS_WORD_OK, responseApdu);
+
+        // Get length of CC file
+        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduReadBinary(0, 2));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        // The response contains the length as 2 bytes followed by STATUS_WORD_OK
+        Assert.assertArrayEquals(Util.fromHex("000f9000"), responseApdu);
+
+        // Get CC file
+        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduReadBinary(0, 15));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        // The response is the CC file followed by STATUS_WORD_OK. Keep in sync with
+        // NfcEngagementHelper.handleSelectFile() for the contents.
+        Assert.assertEquals("000f207fff7fff0406e1047fff00ff9000", Util.toHex(responseApdu));
+
+        // Select NDEF file
+        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduSelectFile(NfcUtil.NDEF_FILE_ID));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        Assert.assertArrayEquals(NfcUtil.STATUS_WORD_OK, responseApdu);
+
+        // Get length of Initial NDEF message
+        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduReadBinary(0, 2));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        // The response contains the length as 2 bytes followed by STATUS_WORD_OK. Assume we
+        // don't know the length.
+        Assert.assertEquals(4, responseApdu.length);
+        Assert.assertEquals(0x90, responseApdu[2] & 0xff);
+        Assert.assertEquals(0x00, responseApdu[3] & 0xff);
+        int initialNdefMessageSize = (((int) responseApdu[0]) & 0xff) * 0x0100
+                + (((int) responseApdu[1]) & 0xff);
+
+        // Read Initial NDEF message
+        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduReadBinary(2, initialNdefMessageSize));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        // The response contains the length as 2 bytes followed by STATUS_WORD_OK. Assume we
+        // don't know the length.
+        Assert.assertEquals(initialNdefMessageSize + 2, responseApdu.length);
+        Assert.assertEquals(0x90, responseApdu[initialNdefMessageSize] & 0xff);
+        Assert.assertEquals(0x00, responseApdu[initialNdefMessageSize + 1] & 0xff);
+        byte[] initialNdefMessage = Arrays.copyOf(responseApdu, responseApdu.length - 2);
+
+        // The Initial NDEF message should contain Handover Select. Check this.
+        NfcUtil.ParsedHandoverSelectMessage hs = NfcUtil.parseHandoverSelectMessage(initialNdefMessage);
+        Assert.assertNotNull(hs);
+        EngagementParser parser = new EngagementParser(hs.encodedDeviceEngagement);
+        // Check the returned DeviceEngagement
+        EngagementParser.Engagement e = parser.parse();
+        Assert.assertEquals("1.0", e.getVersion());
+        Assert.assertEquals(0, e.getOriginInfos().size());
+        Assert.assertEquals(session.getEphemeralKeyPair().getPublic(), e.getESenderKey());
+        Assert.assertEquals(0, e.getConnectionMethods().size());
+        // Check the synthesized ConnectionMethod (from returned OOB data in HS)
+        Assert.assertEquals(connectionMethods.size(), hs.connectionMethods.size());
+        for (int n = 0; n < connectionMethods.size(); n++) {
+            Assert.assertEquals(connectionMethods.get(n).toString(),
+                    hs.connectionMethods.get(n).toString());
+        }
+
+        // Checks that the helper returns the correct DE and Handover
+        byte[] expectedHandover = Util.cborEncode(new CborBuilder()
+                .addArray()
+                .add(initialNdefMessage)   // Handover Select message
+                .add(SimpleValue.NULL)     // Handover Request message
+                .end()
+                .build().get(0));
+        Assert.assertArrayEquals(expectedHandover, helper.getHandover());
+        Assert.assertArrayEquals(hs.encodedDeviceEngagement, helper.getDeviceEngagement());
+
+        helper.close();
+    }
+
+    @Test
+    @SmallTest
+    public void testNegotiatedHandover() throws Exception {
+        NfcEngagementHelper helper = null;
+        Context context = InstrumentationRegistry.getTargetContext();
+        IdentityCredentialStore store = Util.getIdentityCredentialStore(context);
+        assumeTrue(store.getFeatureVersion() >= IdentityCredentialStore.FEATURE_VERSION_202201);
+
+        PresentationSession session = store.createPresentationSession(
+                IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
+
+        NfcEngagementHelper.Listener listener = new NfcEngagementHelper.Listener() {
+            @Override
+            public void onDeviceConnecting() {
+
+            }
+
+            @Override
+            public void onDeviceConnected(DataTransport transport) {
+            }
+
+            @Override
+            public void onError(@NonNull Throwable error) {
+            }
+        };
+
+        BlockingQueue<byte[]> apdusSentByHelper = new ArrayBlockingQueue<byte[]>(100);
+        NfcApduRouter apduRouter = new NfcApduRouter() {
+            @Override
+            public void sendResponseApdu(@NonNull byte[] responseApdu) {
+                Log.w(TAG, "apdu: " + Util.toHex(responseApdu));
+                apdusSentByHelper.add(responseApdu);
+            }
+        };
+
+        Executor executor = Executors.newSingleThreadExecutor();
+        NfcEngagementHelper.Builder builder = new NfcEngagementHelper.Builder(
+                context,
+                session,
+                new DataTransportOptions.Builder().build(),
+                apduRouter,
+                listener,
+                executor);
+
+        // Include all ConnectionMethods that can exist in OOB data
+        List<ConnectionMethod> connectionMethods = new ArrayList<>();
+        UUID bleUuid = UUID.randomUUID();
+        connectionMethods.add(new ConnectionMethodBle(
+                true,
+                true,
+                bleUuid,
+                bleUuid));
+        connectionMethods.add(new ConnectionMethodNfc(
+                0xffff,
+                0xffff));
+        connectionMethods.add(new ConnectionMethodWifiAware(
+                null,
+                OptionalLong.empty(),
+                OptionalLong.empty(),
+                null));
+        builder.useNegotiatedHandover();
+        helper = builder.build();
+        helper.testingDoNotStartTransports();
+
+        // Select Type 4 Tag NDEF app
+        byte[] ndefAppId = NfcApduRouter.AID_FOR_TYPE_4_TAG_NDEF_APPLICATION;
+        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduApplicationSelect(ndefAppId));
+        byte[] responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        Assert.assertArrayEquals(NfcUtil.STATUS_WORD_OK, responseApdu);
+
+        // Select CC file
+        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduSelectFile(NfcUtil.CAPABILITY_CONTAINER_FILE_ID));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        Assert.assertArrayEquals(NfcUtil.STATUS_WORD_OK, responseApdu);
+
+        // Get length of CC file
+        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduReadBinary(0, 2));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        // The response contains the length as 2 bytes followed by STATUS_WORD_OK
+        Assert.assertArrayEquals(Util.fromHex("000f9000"), responseApdu);
+
+        // Get CC file
+        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduReadBinary(0, 15));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        // The response is the CC file followed by STATUS_WORD_OK. Keep in sync with
+        // NfcEngagementHelper.handleSelectFile() for the contents.
+        Assert.assertEquals("000f207fff7fff0406e1047fff00009000", Util.toHex(responseApdu));
+
+        // Select NDEF file
+        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduSelectFile(NfcUtil.NDEF_FILE_ID));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        Assert.assertArrayEquals(NfcUtil.STATUS_WORD_OK, responseApdu);
+
+        // Get length of Initial NDEF message
+        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduReadBinary(0, 2));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        // The response contains the length as 2 bytes followed by STATUS_WORD_OK. Assume we
+        // don't know the length.
+        Assert.assertEquals(4, responseApdu.length);
+        Assert.assertEquals(0x90, responseApdu[2] & 0xff);
+        Assert.assertEquals(0x00, responseApdu[3] & 0xff);
+        int initialNdefMessageSize = (((int) responseApdu[0]) & 0xff) * 0x0100
+                + (((int) responseApdu[1]) & 0xff);
+
+        // Read Initial NDEF message
+        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduReadBinary(2, initialNdefMessageSize));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        // The response contains the length as 2 bytes followed by STATUS_WORD_OK. Assume we
+        // don't know the length.
+        Assert.assertEquals(initialNdefMessageSize + 2, responseApdu.length);
+        Assert.assertEquals(0x90, responseApdu[initialNdefMessageSize] & 0xff);
+        Assert.assertEquals(0x00, responseApdu[initialNdefMessageSize + 1] & 0xff);
+        byte[] initialNdefMessage = Arrays.copyOf(responseApdu, responseApdu.length - 2);
+
+        // The Initial NDEF message should contain a Service Parameter record for the
+        // urn:nfc:sn:handover service
+        Assert.assertTrue(NfcUtil.ndefMessageContainsServiceParameterRecord(initialNdefMessage,
+                "urn:nfc:sn:handover"));
+
+        // Keep the following code in sync with verificationHelper.startNegotiatedHandover()
+
+        // Select the service, the resulting NDEF message is specified in
+        // in Tag NDEF Exchange Protocol Technical Specification Version 1.0
+        // section 4.3 TNEP Status Message
+        byte[] serviceSelectResponse = ndefTransact(apduRouter, apdusSentByHelper,
+                NfcUtil.createNdefMessageServiceSelect("urn:nfc:sn:handover"));
+        Assert.assertEquals("d10201546500", Util.toHex(serviceSelectResponse));
+
+        // Now send Handover Request, the resulting NDEF message is Handover Response..
+        byte[] hrMessage = NfcUtil.createNdefMessageHandoverRequest(
+                connectionMethods,
+                null); // TODO: pass ReaderEngagement message
+        byte[] hsMessage = ndefTransact(apduRouter, apdusSentByHelper, hrMessage);
+
+        NfcUtil.ParsedHandoverSelectMessage hs = NfcUtil.parseHandoverSelectMessage(hsMessage);
+        Assert.assertNotNull(hs);
+        EngagementParser parser = new EngagementParser(hs.encodedDeviceEngagement);
+        // Check the returned DeviceEngagement
+        EngagementParser.Engagement e = parser.parse();
+        Assert.assertEquals("1.0", e.getVersion());
+        Assert.assertEquals(0, e.getOriginInfos().size());
+        Assert.assertEquals(session.getEphemeralKeyPair().getPublic(), e.getESenderKey());
+        Assert.assertEquals(0, e.getConnectionMethods().size());
+
+        // Check the synthesized ConnectionMethod (from returned OOB data in HS)... we expect
+        // only one to be returned and we expect it to be the BLE one and only the Central
+        // Client mode.
+        Assert.assertEquals(1, hs.connectionMethods.size());
+        ConnectionMethodBle cm = (ConnectionMethodBle) hs.connectionMethods.get(0);
+        Assert.assertFalse(cm.getSupportsPeripheralServerMode());
+        Assert.assertTrue(cm.getSupportsCentralClientMode());
+        Assert.assertNull(cm.getPeripheralServerModeUuid());
+        Assert.assertEquals(cm.getCentralClientModeUuid(), bleUuid);
+
+        // Checks that the helper returns the correct DE and Handover
+        byte[] expectedHandover = Util.cborEncode(new CborBuilder()
+                .addArray()
+                .add(hsMessage)      // Handover Select message
+                .add(hrMessage)      // Handover Request message
+                .end()
+                .build().get(0));
+        Assert.assertArrayEquals(expectedHandover, helper.getHandover());
+        Assert.assertArrayEquals(hs.encodedDeviceEngagement, helper.getDeviceEngagement());
+
+        helper.close();
+    }
+
+    static byte[] ndefTransact(NfcApduRouter apduRouter,
+                               BlockingQueue<byte[]> apdusSentByHelper,
+                               byte[] ndefMessage) throws InterruptedException {
+        byte[] responseApdu;
+
+        // First command is UPDATE_BINARY to reset length
+        apduRouter.addReceivedApdu(NfcApduRouter.AID_FOR_TYPE_4_TAG_NDEF_APPLICATION,
+                NfcUtil.createApduUpdateBinary(0, new byte[] {0x00, 0x00}));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        Assert.assertEquals(NfcUtil.STATUS_WORD_OK, responseApdu);
+
+        // Second command is UPDATE_BINARY with payload, starting at offset 2.
+        apduRouter.addReceivedApdu(NfcApduRouter.AID_FOR_TYPE_4_TAG_NDEF_APPLICATION,
+                NfcUtil.createApduUpdateBinary(2, ndefMessage));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        Assert.assertEquals(NfcUtil.STATUS_WORD_OK, responseApdu);
+
+        // Third command is UPDATE_BINARY to write the length
+        byte[] encodedLength = new byte[] {
+                (byte) ((ndefMessage.length / 0x100) & 0xff),
+                (byte) (ndefMessage.length & 0xff)};
+        apduRouter.addReceivedApdu(NfcApduRouter.AID_FOR_TYPE_4_TAG_NDEF_APPLICATION,
+                NfcUtil.createApduUpdateBinary(0, encodedLength));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        Assert.assertEquals(NfcUtil.STATUS_WORD_OK, responseApdu);
+
+        // Finally, read the NDEF response message.. first get the length
+        apduRouter.addReceivedApdu(NfcApduRouter.AID_FOR_TYPE_4_TAG_NDEF_APPLICATION,
+                NfcUtil.createApduReadBinary(0, 2));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        // The response contains the length as 2 bytes followed by STATUS_WORD_OK. Assume we
+        // don't know the length.
+        Assert.assertEquals(4, responseApdu.length);
+        Assert.assertEquals(0x90, responseApdu[2] & 0xff);
+        Assert.assertEquals(0x00, responseApdu[3] & 0xff);
+        int ndefMessageSize = (((int) responseApdu[0]) & 0xff) * 0x0100
+                + (((int) responseApdu[1]) & 0xff);
+
+        // Read NDEF message
+        apduRouter.addReceivedApdu(NfcApduRouter.AID_FOR_TYPE_4_TAG_NDEF_APPLICATION,
+                NfcUtil.createApduReadBinary(2, ndefMessageSize));
+        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
+        Assert.assertNotNull(responseApdu);
+        // The response contains the length as 2 bytes followed by STATUS_WORD_OK. Assume we
+        // don't know the length.
+        Assert.assertEquals(ndefMessageSize + 2, responseApdu.length);
+        Assert.assertEquals(0x90, responseApdu[ndefMessageSize] & 0xff);
+        Assert.assertEquals(0x00, responseApdu[ndefMessageSize + 1] & 0xff);
+        return Arrays.copyOf(responseApdu, responseApdu.length - 2);
+    }
+
+}

--- a/identity/src/main/java/com/android/identity/ConnectionMethod.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethod.java
@@ -61,8 +61,17 @@ public abstract class ConnectionMethod {
         return null;
     }
 
-    abstract @NonNull
-    Pair<NdefRecord, byte[]> toNdefRecord();
+    /**
+     * Creates Carrier Reference and Auxiliary Data Reference records.
+     *
+     * <p>If this is to be included in a Handover Select method, pass <code>{"mdoc"}</code>
+     * for <code>auxilliaryReferences</code>.
+     *
+     * @param auxiliaryReferences A list of references to include in the Alternative Carrier Record
+     * @return
+     */
+    abstract @Nullable
+    Pair<NdefRecord, byte[]> toNdefRecord(@NonNull List<String> auxiliaryReferences);
 
     static @Nullable
     ConnectionMethod fromNdefRecord(@NonNull NdefRecord record) {

--- a/identity/src/main/java/com/android/identity/ConnectionMethodHttp.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethodHttp.java
@@ -146,8 +146,8 @@ public class ConnectionMethodHttp extends ConnectionMethod {
                 .build().get(0);
     }
 
-    @Override @NonNull
-    Pair<NdefRecord, byte[]> toNdefRecord() {
-        throw new IllegalStateException("NDEF records for this connection method is not defined");
+    @Override @Nullable
+    Pair<NdefRecord, byte[]> toNdefRecord(@NonNull List<String> auxiliaryReferences) {
+        return null;
     }
 }

--- a/identity/src/main/java/com/android/identity/ConnectionMethodNfc.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethodNfc.java
@@ -195,8 +195,8 @@ public class ConnectionMethodNfc extends ConnectionMethod {
         }
     }
 
-    @Override @NonNull
-    Pair<NdefRecord, byte[]> toNdefRecord() {
+    @Override @Nullable
+    Pair<NdefRecord, byte[]> toNdefRecord(@NonNull List<String> auxiliaryReferences) {
         byte[] carrierDataReference = "nfc".getBytes(UTF_8);
 
         // This is defined by ISO 18013-5 8.2.2.2 Alternative Carrier Record for device
@@ -223,10 +223,14 @@ public class ConnectionMethodNfc extends ConnectionMethod {
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
-        baos.write(0x01); // Number of auxiliary references
-        byte[] auxReference = "mdoc".getBytes(UTF_8);
-        baos.write(auxReference.length);  // Length of auxiliary reference 0 data
-        baos.write(auxReference, 0, auxReference.length);
+        baos.write(auxiliaryReferences.size()); // Number of auxiliary references
+        for (String auxRef : auxiliaryReferences) {
+            // Each auxiliary reference consists of a single byte for the length and then as
+            // many bytes for the reference itself.
+            byte[] auxRefUtf8 = auxRef.getBytes(UTF_8);
+            baos.write(auxRefUtf8.length);
+            baos.write(auxRefUtf8, 0, auxRefUtf8.length);
+        }
         byte[] acRecordPayload = baos.toByteArray();
 
         return new Pair<>(record, acRecordPayload);

--- a/identity/src/main/java/com/android/identity/ConnectionMethodWifiAware.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethodWifiAware.java
@@ -252,9 +252,8 @@ public class ConnectionMethodWifiAware extends ConnectionMethod {
                 .build().get(0);
     }
 
-    @Override
-    @NonNull
-    Pair<NdefRecord, byte[]> toNdefRecord() {
+    @Override @Nullable
+    Pair<NdefRecord, byte[]> toNdefRecord(@NonNull List<String> auxiliaryReferences) {
         // The NdefRecord and its OOB data is defined in "Wi-Fi Aware Specification", table 142.
         //
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -331,10 +330,13 @@ public class ConnectionMethodWifiAware extends ConnectionMethod {
         baos.write(0x01); // CPS: active
         baos.write(0x01); // Length of carrier data reference ("0")
         baos.write('W');  // Carrier data reference
-        baos.write(0x01); // Number of auxiliary references
-        byte[] auxReference = "mdoc".getBytes(UTF_8);
-        baos.write(auxReference.length);
-        baos.write(auxReference, 0, auxReference.length);
+        for (String auxRef : auxiliaryReferences) {
+            // Each auxiliary reference consists of a single byte for the length and then as
+            // many bytes for the reference itself.
+            byte[] auxRefUtf8 = auxRef.getBytes(UTF_8);
+            baos.write(auxRefUtf8.length);
+            baos.write(auxRefUtf8, 0, auxRefUtf8.length);
+        }
         byte[] acRecordPayload = baos.toByteArray();
 
         return new Pair<>(record, acRecordPayload);

--- a/identity/src/main/java/com/android/identity/NfcUtil.java
+++ b/identity/src/main/java/com/android/identity/NfcUtil.java
@@ -1,9 +1,23 @@
 package com.android.identity;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import android.nfc.FormatException;
+import android.nfc.NdefMessage;
+import android.nfc.NdefRecord;
+import android.util.Pair;
+
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 class NfcUtil {
-
+    private static final String TAG = "NfcUtil";
 
     static final int COMMAND_TYPE_OTHER = 0;
     static final int COMMAND_TYPE_SELECT_BY_AID = 1;
@@ -44,4 +58,290 @@ class NfcUtil {
         }
         return COMMAND_TYPE_OTHER;
     }
+
+    static @NonNull byte[] createApduApplicationSelect(@NonNull byte[] aid) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(0x00);
+        baos.write(0xa4);
+        baos.write(0x04);
+        baos.write(0x00);
+        baos.write(0x07);
+        try {
+            baos.write(aid);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        return baos.toByteArray();
+    }
+
+    static @NonNull byte[] createApduSelectFile(int fileId) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(0x00);
+        baos.write(0xa4);
+        baos.write(0x00);
+        baos.write(0x0c);
+        baos.write(0x02);
+        baos.write(fileId / 0x100);
+        baos.write(fileId & 0xff);
+        return baos.toByteArray();
+    }
+
+    static @NonNull byte[] createApduReadBinary(int offset, int length) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(0x00);
+        baos.write(0xb0);
+        baos.write(offset / 0x100);
+        baos.write(offset & 0xff);
+        if (length < 0x100) {
+            baos.write(length & 0xff);
+        } else {
+            baos.write(0x00);
+            baos.write(length / 0x100);
+            baos.write(length & 0xff);
+        }
+        return baos.toByteArray();
+    }
+
+    static @NonNull byte[] createApduUpdateBinary(int offset, byte[] data) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(0x00);
+        baos.write(0xd6);
+        baos.write(offset / 0x100);
+        baos.write(offset & 0xff);
+        if (data.length >= 0x100) {
+            throw new IllegalArgumentException("Data must be shorter than 0x010 bytes");
+        }
+        baos.write(data.length & 0xff);
+        try {
+            baos.write(data);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+        return baos.toByteArray();
+    }
+
+    static byte[] createNdefMessageServiceSelect(String serviceName) {
+        // [TNEP] section 4.2.2 Service Select Record
+        byte[] payload = (" " + serviceName).getBytes(UTF_8);
+        payload[0] = (byte) (payload.length - 1);
+        NdefRecord record = new NdefRecord(NdefRecord.TNF_WELL_KNOWN,
+                "Ts".getBytes(UTF_8),
+                null,
+                payload);
+        return new NdefMessage(new NdefRecord[] {record}).toByteArray();
+    }
+
+    private static @NonNull
+    byte[] calculateHandoverSelectPayload(@NonNull List<byte[]> alternativeCarrierRecords) {
+        // 6.2 Handover Select Record
+        //
+        // The NDEF payload of the Handover Select Record SHALL consist of a single octet that
+        // contains the MAJOR_VERSION and MINOR_VERSION numbers, optionally followed by an embedded
+        // NDEF message.
+        //
+        // If present, the NDEF message SHALL consist of one of the following options:
+        // - One or more ALTERNATIVE_CARRIER_RECORDs
+        // - One or more ALTERNATIVE_CARRIER_RECORDs followed by an ERROR_RECORD
+        // - An ERROR_RECORD.
+        //
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(0x15);  // version 1.5
+        NdefRecord[] acRecords = new NdefRecord[alternativeCarrierRecords.size()];
+        for (int n = 0; n < alternativeCarrierRecords.size(); n++) {
+            byte[] acRecordPayload = alternativeCarrierRecords.get(n);
+            acRecords[n] = new NdefRecord((short) 0x01,
+                    "ac".getBytes(UTF_8),
+                    null,
+                    acRecordPayload);
+        }
+        NdefMessage hsMessage = new NdefMessage(acRecords);
+        baos.write(hsMessage.toByteArray(), 0, hsMessage.getByteArrayLength());
+        return baos.toByteArray();
+    }
+
+
+    private static @NonNull
+    byte[] createNdefMessageHandoverSelectOrRequest(
+            @NonNull List<ConnectionMethod> methods,
+            @Nullable byte[] encodedDeviceEngagement,
+            @Nullable byte[] encodedReaderEngagement) {
+        boolean isHandoverSelect = false;
+        if (encodedDeviceEngagement != null) {
+            isHandoverSelect = true;
+            if (encodedReaderEngagement != null) {
+                throw new IllegalArgumentException("Cannot have readerEngagement in Handover Select");
+            }
+        }
+
+        List<String> auxiliaryReferences = new ArrayList<>();
+        if (isHandoverSelect) {
+            auxiliaryReferences.add("mdoc");
+        }
+
+        List<NdefRecord> carrierConfigurationRecords = new ArrayList<>();
+        List<byte[]> alternativeCarrierRecords = new ArrayList<>();
+
+        // TODO: we actually need to do the reverse disambiguation to e.g. merge two
+        //  disambiguated BLE ConnectionMethods...
+        for (ConnectionMethod cm : methods) {
+            Pair<NdefRecord, byte[]> records = cm.toNdefRecord(auxiliaryReferences);
+            if (records != null) {
+                if (Logger.isDebugEnabled()) {
+                    Logger.d(TAG, "ConnectionMethod " + cm + ": alternativeCarrierRecord: "
+                            + Util.toHex(records.second) + " carrierConfigurationRecord: "
+                            + Util.toHex(records.first.getPayload()));
+                }
+                alternativeCarrierRecords.add(records.second);
+                carrierConfigurationRecords.add(records.first);
+            } else {
+                Logger.d(TAG, "Ignoring address " + cm + " which yielded no NDEF records");
+            }
+        }
+
+        List<NdefRecord> records = new ArrayList<>();
+        byte[] hsPayload = calculateHandoverSelectPayload(alternativeCarrierRecords);
+        records.add(new NdefRecord(
+                NdefRecord.TNF_WELL_KNOWN,
+                (isHandoverSelect ? "Hs" : "Hr").getBytes(UTF_8),
+                null,
+                hsPayload));
+
+        if (encodedDeviceEngagement != null) {
+            records.add(new NdefRecord(
+                    NdefRecord.TNF_EXTERNAL_TYPE,
+                    "iso.org:18013:deviceengagement".getBytes(UTF_8),
+                    "mdoc".getBytes(UTF_8),
+                    encodedDeviceEngagement));
+        }
+
+        if (encodedReaderEngagement != null) {
+            records.add(new NdefRecord(
+                    NdefRecord.TNF_EXTERNAL_TYPE,
+                    "iso.org:18013:readerengagement".getBytes(UTF_8),
+                    "mdocreader".getBytes(UTF_8),
+                    encodedReaderEngagement));
+        }
+
+        for (NdefRecord record : carrierConfigurationRecords) {
+            records.add(record);
+        }
+
+        NdefMessage message = new NdefMessage(records.toArray(new NdefRecord[0]));
+        return message.toByteArray();
+    }
+
+    static @NonNull
+    byte[] createNdefMessageHandoverSelect(
+            @NonNull List<ConnectionMethod> methods,
+            @NonNull byte[] encodedDeviceEngagement) {
+        return createNdefMessageHandoverSelectOrRequest(methods, encodedDeviceEngagement, null);
+    }
+
+    static @NonNull
+    byte[] createNdefMessageHandoverRequest(
+            @NonNull List<ConnectionMethod> methods,
+            @Nullable byte[] encodedReaderEngagement) {
+        return createNdefMessageHandoverSelectOrRequest(methods, null, encodedReaderEngagement);
+    }
+
+    // TODO: return other fields in Service Parameter record (e.g. minimum waiting time, etc)
+    static
+    boolean ndefMessageContainsServiceParameterRecord(@NonNull byte[] ndefMessage, @NonNull String serviceName) {
+        NdefMessage m = null;
+        try {
+            m = new NdefMessage(ndefMessage);
+        } catch (FormatException e) {
+            Logger.w(TAG, "Error parsing NDEF message", e);
+            return false;
+        }
+
+        for (NdefRecord r : m.getRecords()) {
+            byte[] p = r.getPayload();
+            byte[] snUtf8 = serviceName.getBytes(UTF_8);
+            if (r.getTnf() == NdefRecord.TNF_WELL_KNOWN
+                    && Arrays.equals("Tp".getBytes(UTF_8), r.getType())
+                    && p != null
+                    && p.length > snUtf8.length + 2
+                    && p[0] == 0x10
+                    && p[1] == snUtf8.length
+                    && Arrays.equals(snUtf8, Arrays.copyOfRange(p, 2, 2 + snUtf8.length))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Returns null if parsing fails, otherwise returns a ParsedHandoverSelectMessage instance
+    static @Nullable ParsedHandoverSelectMessage
+    parseHandoverSelectMessage(@NonNull byte[] ndefMessage) {
+        NdefMessage m = null;
+        try {
+            m = new NdefMessage(ndefMessage);
+        } catch (FormatException e) {
+            Logger.w(TAG, "Error parsing NDEF message", e);
+            return null;
+        }
+
+        boolean validHandoverSelectMessage = false;
+        ParsedHandoverSelectMessage ret = new ParsedHandoverSelectMessage();
+        for (NdefRecord r : m.getRecords()) {
+            // Handle Handover Select record for NFC Forum Connection Handover specification
+            // version 1.5 (encoded as 0x15 below).
+            //
+            if (r.getTnf() == NdefRecord.TNF_WELL_KNOWN
+                    && Arrays.equals(r.getType(), "Hs".getBytes(UTF_8))) {
+                byte[] payload = r.getPayload();
+                if (payload.length >= 1 && payload[0] == 0x15) {
+                    // The NDEF payload of the Handover Select Record SHALL consist of a single
+                    // octet that contains the MAJOR_VERSION and MINOR_VERSION numbers,
+                    // optionally followed by an embedded NDEF message.
+                    //
+                    // If present, the NDEF message SHALL consist of one of the following options:
+                    // - One or more ALTERNATIVE_CARRIER_RECORDs
+                    // - One or more ALTERNATIVE_CARRIER_RECORDs followed by an ERROR_RECORD
+                    // - An ERROR_RECORD.
+                    //
+                    //byte[] ndefMessage = Arrays.copyOfRange(payload, 1, payload.length);
+                    // TODO: check that the ALTERNATIVE_CARRIER_RECORD matches
+                    //   the ALTERNATIVE_CARRIER_CONFIGURATION record retrieved below.
+                    validHandoverSelectMessage = true;
+                }
+            }
+
+            // DeviceEngagement record
+            //
+            if (r.getTnf() == NdefRecord.TNF_EXTERNAL_TYPE
+                    && Arrays.equals(r.getType(),
+                    "iso.org:18013:deviceengagement".getBytes(UTF_8))
+                    && Arrays.equals(r.getId(), "mdoc".getBytes(UTF_8))) {
+                ret.encodedDeviceEngagement = r.getPayload();
+            }
+
+            // This parses the various carrier specific NDEF records, see
+            // DataTransport.parseNdefRecord() for details.
+            //
+            if (r.getTnf() == NdefRecord.TNF_MIME_MEDIA) {
+                ConnectionMethod cm = ConnectionMethod.fromNdefRecord(r);
+                if (cm != null) {
+                    ret.connectionMethods.add(cm);
+                }
+            }
+        }
+
+        if (!validHandoverSelectMessage) {
+            Logger.w(TAG, "Hs record not found");
+            return null;
+        }
+        if (ret.encodedDeviceEngagement == null) {
+            Logger.w(TAG, "DeviceEngagement record not found");
+            return null;
+        }
+        return ret;
+    }
+
+    static class ParsedHandoverSelectMessage {
+        @NonNull byte[] encodedDeviceEngagement = null;
+        @NonNull List<ConnectionMethod> connectionMethods = new ArrayList<>();
+    }
+
 }

--- a/identity/src/main/java/com/android/identity/VerificationHelper.java
+++ b/identity/src/main/java/com/android/identity/VerificationHelper.java
@@ -18,7 +18,6 @@ package com.android.identity;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import android.app.Activity;
 import android.content.Context;
 import android.net.Uri;
 import android.nfc.NdefMessage;
@@ -26,27 +25,29 @@ import android.nfc.NdefRecord;
 import android.nfc.NfcAdapter;
 import android.nfc.Tag;
 import android.nfc.tech.IsoDep;
-import android.nfc.tech.Ndef;
-import android.os.Bundle;
 import android.util.Base64;
 import android.util.Log;
+
+import androidx.annotation.Nullable;
 import androidx.core.util.Pair;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.OptionalInt;
+import java.util.UUID;
 import java.util.concurrent.Executor;
 
 import co.nstant.in.cbor.CborBuilder;
 import co.nstant.in.cbor.model.DataItem;
-import co.nstant.in.cbor.model.Map;
 import co.nstant.in.cbor.model.SimpleValue;
 
 /**
@@ -238,19 +239,10 @@ public class VerificationHelper {
     public void
     nfcProcessOnTagDiscovered(@NonNull Tag tag) {
         Logger.d(TAG, "Tag discovered!");
-        for (String tech : tag.getTechList()) {
-            Logger.d(TAG, "tech: " + tech);
-            if (tech.equals(Ndef.class.getName())) {
-                Logger.d(TAG, "Found ndef tech!");
-                if (mDeviceEngagement != null) {
-                    Logger.d(TAG, "Already have device engagement "
-                            + "so not inspecting what was received via "
-                            + "NFC");
-                } else {
-                    setNdefDeviceEngagement(Ndef.get(tag));
-                }
 
-            } else if (tech.equals(IsoDep.class.getName())) {
+        // Find IsoDep since we're skipping NDEF checks and doing everything ourselves via APDUs
+        for (String tech : tag.getTechList()) {
+            if (tech.equals(IsoDep.class.getName())) {
                 mNfcIsoDep = IsoDep.get(tag);
                 // If we're doing QR code engagement _and_ NFC data transfer
                 // it's possible that we're now in a state where we're
@@ -265,6 +257,29 @@ public class VerificationHelper {
                 }
             }
         }
+
+        if (mNfcIsoDep == null) {
+            Logger.d(TAG, "no IsoDep technology found");
+            return;
+        }
+
+        startNfcHandover();
+
+        /*
+        // Look for Ndef
+        for (String tech : tag.getTechList()) {
+            if (tech.equals(Ndef.class.getName())) {
+                Logger.d(TAG, "Found ndef tech!");
+                if (mDeviceEngagement != null) {
+                    Logger.d(TAG, "Already have device engagement "
+                            + "so not inspecting what was received via "
+                            + "NFC");
+                } else {
+                    processInitialNdefMessage(Ndef.get(tag));
+                }
+            }
+        }
+         */
     }
 
     /**
@@ -319,95 +334,327 @@ public class VerificationHelper {
                 "Invalid QR Code device engagement text: " + qrDeviceEngagement));
     }
 
-    void setNdefDeviceEngagement(@NonNull Ndef ndef) {
-        byte[] handoverSelectMessage;
-        byte[] encodedDeviceEngagement = null;
-        boolean validHandoverSelectMessage = false;
+    static byte[] buildApduReadBinary(int offset, int length) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(0x00);
+        baos.write(0xb0);
+        baos.write(offset / 0x100);
+        baos.write(offset & 0xff);
+        baos.write(0x00);
+        baos.write(length / 0x100);
+        baos.write(length & 0xff);
+        return baos.toByteArray();
+    }
 
-        NdefMessage m = ndef.getCachedNdefMessage();
-
-        handoverSelectMessage = m.toByteArray();
-        if (Logger.isDebugEnabled()) {
-            Logger.d(TAG, 
-                    "In decodeNdefTag, handoverSelectMessage: " + Util.toHex(m.toByteArray()));
-        }
-
-        List<ConnectionMethod> parsedConnectionMethodsFromNfc = new ArrayList<>();
-        for (NdefRecord r : m.getRecords()) {
-            if (Logger.isDebugEnabled()) {
-                Logger.d(TAG, "record: " + Util.toHex(r.getPayload()));
-            }
-
-            // Handle Handover Select record for NFC Forum Connection Handover specification
-            // version 1.5 (encoded as 0x15 below).
-            //
-            if (r.getTnf() == NdefRecord.TNF_WELL_KNOWN
-                    && Arrays.equals(r.getType(), "Hs".getBytes(UTF_8))) {
-                byte[] payload = r.getPayload();
-                if (payload.length >= 1 && payload[0] == 0x15) {
-                    // The NDEF payload of the Handover Select Record SHALL consist of a single
-                    // octet that contains the MAJOR_VERSION and MINOR_VERSION numbers,
-                    // optionally followed by an embedded NDEF message.
-                    //
-                    // If present, the NDEF message SHALL consist of one of the following options:
-                    // - One or more ALTERNATIVE_CARRIER_RECORDs
-                    // - One or more ALTERNATIVE_CARRIER_RECORDs followed by an ERROR_RECORD
-                    // - An ERROR_RECORD.
-                    //
-                    Logger.d(TAG, "Processing Handover Select message");
-                    //byte[] ndefMessage = Arrays.copyOfRange(payload, 1, payload.length);
-                    // TODO: check that the ALTERNATIVE_CARRIER_RECORD matches
-                    //   the ALTERNATIVE_CARRIER_CONFIGURATION record retrieved below.
-                    validHandoverSelectMessage = true;
-                }
-            }
-
-            // DeviceEngagement record
-            //
-            if (r.getTnf() == NdefRecord.TNF_EXTERNAL_TYPE
-                    && Arrays.equals(r.getType(),
-                    "iso.org:18013:deviceengagement".getBytes(UTF_8))
-                    && Arrays.equals(r.getId(), "mdoc".getBytes(UTF_8))) {
-                encodedDeviceEngagement = r.getPayload();
-                if (Logger.isDebugEnabled()) {
-                    Logger.d(TAG, 
-                            "Device Engagement from NFC: " + Util.toHex(encodedDeviceEngagement));
-                }
-            }
-
-            // This parses the various carrier specific NDEF records, see
-            // DataTransport.parseNdefRecord() for details.
-            //
-            if (r.getTnf() == NdefRecord.TNF_MIME_MEDIA) {
-                ConnectionMethod cm = ConnectionMethod.fromNdefRecord(r);
-                if (cm != null) {
-                    parsedConnectionMethodsFromNfc.add(cm);
-                }
-            }
-
-        }
-
-        if (Logger.isDebugEnabled()) {
-            for (ConnectionMethod cm : parsedConnectionMethodsFromNfc) {
-                Logger.d(TAG, "Have connection method " + cm);
-            }
-        }
-
-        if (validHandoverSelectMessage && !parsedConnectionMethodsFromNfc.isEmpty()) {
-            Logger.d(TAG, "Reporting Device Engagement through NFC");
-            DataItem readerHandover = new CborBuilder()
-                    .addArray()
-                    .add(handoverSelectMessage)    // Handover Select message
-                    .add(SimpleValue.NULL)         // Handover Request message
-                    .end()
-                    .build().get(0);
-            setDeviceEngagement(encodedDeviceEngagement, readerHandover);
-
-            reportDeviceEngagementReceived(parsedConnectionMethodsFromNfc);
+    static private
+    byte[] buildApdu(int cla, int ins, int p1, int p2, @Nullable byte[] data, int le) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(cla);
+        baos.write(ins);
+        baos.write(p1);
+        baos.write(p2);
+        boolean hasExtendedLc = false;
+        if (data == null) {
+            baos.write(0);
+        } else if (data.length < 256) {
+            baos.write(data.length);
         } else {
-            reportError(new IllegalArgumentException(
-                    "Invalid Handover Select message: " + Util.toHex(m.toByteArray())));
+            hasExtendedLc = true;
+            baos.write(0x00);
+            baos.write(data.length / 0x100);
+            baos.write(data.length & 0xff);
         }
+        if (data != null && data.length > 0) {
+            try {
+                baos.write(data);
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        if (le > 0) {
+            if (le == 256) {
+                baos.write(0x00);
+            } else if (le < 256) {
+                baos.write(le);
+            } else {
+                if (!hasExtendedLc) {
+                    baos.write(0x00);
+                }
+                if (le == 65536) {
+                    baos.write(0x00);
+                    baos.write(0x00);
+                } else {
+                    baos.write(le / 0x100);
+                    baos.write(le & 0xff);
+                }
+            }
+        }
+
+        return baos.toByteArray();
+    }
+
+    private byte[] readBinary(@NonNull IsoDep isoDep, int offset, int size)
+            throws IOException {
+        byte[] apdu;
+        byte[] ret;
+
+        apdu = buildApduReadBinary(offset, size);
+        ret = isoDep.transceive(apdu);
+        if (ret.length < 2 || ret[ret.length - 2] != ((byte) 0x90) || ret[ret.length - 1] != ((byte) 0x00)) {
+            Logger.e(TAG, "Error sending READ_BINARY command: " + Util.toHex(ret));
+            return null;
+        }
+        return Arrays.copyOfRange(ret, 0, ret.length - 2);
+    }
+
+    private byte[] ndefReadMessage(@NonNull IsoDep isoDep)
+            throws IOException {
+        byte[] apdu;
+        byte[] ret;
+
+        apdu = buildApduReadBinary(0x0000, 2);
+        ret = isoDep.transceive(apdu);
+        if (ret.length != 4 || ret[2] != ((byte) 0x90) || ret[3] != ((byte) 0x00)) {
+            Logger.e(TAG, "Error sending second READ_BINARY command for length: " + Util.toHex(ret));
+            return null;
+        }
+        int replyLen = ((int) ret[0] & 0xff) * 256 + ((int) ret[1] & 0xff);
+
+        apdu = buildApduReadBinary(0x0002, replyLen);
+        ret = isoDep.transceive(apdu);
+        if (ret.length != replyLen + 2 || ret[replyLen] != ((byte) 0x90) || ret[replyLen + 1] != ((byte) 0x00)) {
+            Logger.e(TAG, "Error sending second READ_BINARY command for payload: " + Util.toHex(ret));
+            return null;
+        }
+        return Arrays.copyOfRange(ret, 0, ret.length - 2);
+    }
+
+    private byte[] ndefTransact(@NonNull IsoDep isoDep, @NonNull byte[] ndefMessage)
+            throws IOException {
+        byte[] apdu;
+        byte[] ret;
+
+        // See Type 4 Tag Technical Specification Version 1.2 section 7.5.5 NDEF Write Procedure
+        // for how this is done.
+
+        // TODO: Optimize by merging these three write operations into one. This is permissible
+        // as per this text from the standard:
+        //
+        //   If the entire NDEF Message can be written with a single UPDATE_BINARY
+        //   Command, the Reader/Writer MAY write NLEN and ENLEN (Symbol 6), as
+        //   well as the entire NDEF Message (Symbol 5) using a single
+        //   UPDATE_BINARY Command. In this case the Reader/Writer SHALL
+        //   proceed to Symbol 5 and merge Symbols 5 and 6 operations into a single
+        //   UPDATE_BINARY Command.
+        //
+
+        // TODO: need to implement looping if NDEF message is >= 256 bytes.
+        if (ndefMessage.length >= 256) {
+            throw new IllegalStateException("TODO: need to handle NDEF messages >= 256 bytes");
+        }
+
+        // First command is UPDATE_BINARY to reset length
+        apdu = buildApdu(0x00, 0xd6, 0x00, 0x00, new byte[] {0x00, 0x00}, 0);
+        ret = isoDep.transceive(apdu);
+        if (!Arrays.equals(ret, NfcUtil.STATUS_WORD_OK)) {
+            Logger.e(TAG, "Error sending initial UPDATE_BINARY command: " + Util.toHex(ret));
+            return null;
+        }
+
+        // Second command is UPDATE_BINARY with payload, starting at offset 2.
+        apdu = buildApdu(0x00, 0xd6, 0x00, 0x02, ndefMessage, 0);
+        ret = isoDep.transceive(apdu);
+        if (!Arrays.equals(ret, NfcUtil.STATUS_WORD_OK)) {
+            Logger.e(TAG, "Error sending second UPDATE_BINARY command: " + Util.toHex(ret));
+            return null;
+        }
+
+        // Third command is UPDATE_BINARY to write the length
+        byte[] encodedLength = new byte[] {
+                (byte) ((ndefMessage.length / 0x100) & 0xff),
+                (byte) (ndefMessage.length & 0xff)};
+        apdu = buildApdu(0x00, 0xd6, 0x00, 0x00, encodedLength, 0);
+        ret = isoDep.transceive(apdu);
+        if (!Arrays.equals(ret, NfcUtil.STATUS_WORD_OK)) {
+            Logger.e(TAG, "Error sending third UPDATE_BINARY command: " + Util.toHex(ret));
+            return null;
+        }
+
+        // Read NDEF file...
+        //
+        return ndefReadMessage(isoDep);
+    }
+
+
+    private void startNfcHandover() {
+        Logger.d(TAG, "Starting NFC handover thread");
+
+        long timeMillisBegin = System.currentTimeMillis();
+
+        // TODO: need settings UI where the user can specify which methods to offer when
+        //   using NFC negotiated handover.
+        List<ConnectionMethod> connectionMethods = new ArrayList<>();
+        connectionMethods.add(new ConnectionMethodBle(
+                false,
+                true,
+                null,
+                UUID.randomUUID()));
+
+        // TODO: also start these connection methods early...
+
+        final IsoDep isoDep = mNfcIsoDep;
+        Thread transceiverThread = new Thread() {
+            @Override
+            public void run() {
+                byte[] ret;
+                try {
+                    isoDep.connect();
+                    isoDep.setTimeout(20 * 1000);  // 20 seconds
+
+                    byte[] selectCommand = buildApdu(0x00, 0xa4, 0x04, 0x00,
+                            Util.fromHex("D2760000850101"), 0);
+                    ret = isoDep.transceive(selectCommand);
+                    if (!Arrays.equals(ret, NfcUtil.STATUS_WORD_OK)) {
+                        throw new IllegalStateException("NDEF application selection failed, ret: " + Util.toHex(ret));
+                    }
+
+                    ret = isoDep.transceive(NfcUtil.createApduSelectFile(NfcUtil.CAPABILITY_CONTAINER_FILE_ID));
+                    if (!Arrays.equals(ret, NfcUtil.STATUS_WORD_OK)) {
+                        throw new IllegalStateException("Error selecting capability file, ret: " + Util.toHex(ret));
+                    }
+
+                    byte[] ccFileInitial = readBinary(isoDep, 0, 2);
+                    if (ccFileInitial == null || ccFileInitial.length != 2) {
+                        throw new IllegalStateException("Error reading CC file length");
+                    }
+
+                    int ccFileLength = ((int) ccFileInitial[0] & 0xff) * 256 + ((int) ccFileInitial[1] & 0xff);
+                    byte[] ccFile = readBinary(isoDep, 0, ccFileLength);
+                    if (ccFile == null) {
+                        throw new IllegalStateException("Error reading CC file");
+                    }
+
+                    // TODO: look at mapping version in ccFile
+
+                    int ndefFileId = ((int) ccFile[9] & 0xff) * 256 + ((int) ccFile[10] & 0xff);
+                    Logger.d(TAG, String.format(Locale.US, "NDEF file id: 0x%04x", ndefFileId));
+
+                    ret = isoDep.transceive(NfcUtil.createApduSelectFile(NfcUtil.NDEF_FILE_ID));
+                    if (!Arrays.equals(ret, NfcUtil.STATUS_WORD_OK)) {
+                        throw new IllegalStateException("Error selecting NDEF file, ret: " + Util.toHex(ret));
+                    }
+
+                    // First see if we should use negotiated handover..
+                    byte[] initialNdefMessage = ndefReadMessage(isoDep);
+                    if (!NfcUtil.ndefMessageContainsServiceParameterRecord(initialNdefMessage,
+                            "urn:nfc:sn:handover")) {
+
+                        long elapsedTime = System.currentTimeMillis() - timeMillisBegin;
+                        Logger.d(TAG, String.format(Locale.US,
+                                "Time spent in NFC static handover: %d ms", elapsedTime));
+
+                        Logger.d(TAG, "No urn:nfc:sn:handover record found - assuming NFC static handover");
+                        NfcUtil.ParsedHandoverSelectMessage hs = NfcUtil.parseHandoverSelectMessage(initialNdefMessage);
+                        if (hs == null) {
+                            throw new IllegalStateException("Error parsing Handover Select message");
+                        }
+
+                        if (hs.connectionMethods.isEmpty()) {
+                            throw new IllegalStateException("No connection methods in Handover Select");
+                        }
+
+                        if (Logger.isDebugEnabled()) {
+                            for (ConnectionMethod cm : hs.connectionMethods) {
+                                Logger.d(TAG, "Connection method from static handover: " + cm);
+                            }
+                        }
+
+                        Logger.d(TAG, "Reporting Device Engagement through NFC");
+                        DataItem readerHandover = new CborBuilder()
+                                .addArray()
+                                .add(initialNdefMessage)   // Handover Select message
+                                .add(SimpleValue.NULL)     // Handover Request message
+                                .end()
+                                .build().get(0);
+                        setDeviceEngagement(hs.encodedDeviceEngagement, readerHandover);
+                        reportDeviceEngagementReceived(hs.connectionMethods);
+                        return;
+                    }
+
+                    Logger.d(TAG, "Service Parameter for urn:nfc:sn:handover found - negotiated handover");
+                    // TODO: Look at other fields in Service Parameter Record payload including
+                    //   minimum waiting time, max NDEF message size, and others.
+
+                    // Select the service, the resulting NDEF message is specified in
+                    // in Tag NDEF Exchange Protocol Technical Specification Version 1.0
+                    // section 4.3 TNEP Status Message
+                    ret = ndefTransact(isoDep, NfcUtil.createNdefMessageServiceSelect("urn:nfc:sn:handover"));
+                    if (ret == null || !Arrays.equals(ret, Util.fromHex("d10201546500"))) {
+                        throw new IllegalStateException("Service selection failed");
+                    }
+
+                    // Now send Handover Request, the resulting NDEF message is Handover Response..
+                    byte[] hrMessage = NfcUtil.createNdefMessageHandoverRequest(
+                            connectionMethods,
+                            null); // TODO: pass ReaderEngagement message
+                    Logger.d(TAG, "Handover Request sent: " + Util.toHex(hrMessage));
+                    byte[] hsMessage = ndefTransact(isoDep, hrMessage);
+                    if (ret == null) {
+                        throw new IllegalStateException("Handover Request failed");
+                    }
+                    Logger.d(TAG, "Handover Select received: " + Util.toHex(hsMessage));
+
+                    long elapsedTime = System.currentTimeMillis() - timeMillisBegin;
+                    Logger.d(TAG, String.format(Locale.US,
+                            "Time spent in NFC negotiated handover: %d ms", elapsedTime));
+
+                    byte[] encodedDeviceEngagement = null;
+                    List<ConnectionMethod> parsedCms = new ArrayList<>();
+                    NdefMessage ndefHsMessage = new NdefMessage(hsMessage);
+                    for (NdefRecord r : ndefHsMessage.getRecords()) {
+                        // DeviceEngagement record
+                        //
+                        if (r.getTnf() == NdefRecord.TNF_EXTERNAL_TYPE
+                                && Arrays.equals(r.getType(),
+                                "iso.org:18013:deviceengagement".getBytes(UTF_8))
+                                && Arrays.equals(r.getId(), "mdoc".getBytes(UTF_8))) {
+                            encodedDeviceEngagement = r.getPayload();
+                            if (Logger.isDebugEnabled()) {
+                                Logger.d(TAG, "Device Engagement from NFC negotiated handover: "
+                                        + Util.toHex(encodedDeviceEngagement));
+                            }
+                        } else if (r.getTnf() == NdefRecord.TNF_MIME_MEDIA) {
+                            ConnectionMethod cm = ConnectionMethod.fromNdefRecord(r);
+                            if (cm != null) {
+                                parsedCms.add(cm);
+                                Logger.d(TAG, "CM: " + cm);
+                            }
+                        }
+                    }
+                    if (encodedDeviceEngagement == null) {
+                        throw new IllegalStateException("Device Engagement not found in HS message");
+                    }
+                    if (parsedCms.size() != 1) {
+                        throw new IllegalStateException("Expected only one Alternative Carrier, found "
+                                + parsedCms.size());
+                    }
+
+                    DataItem handover = new CborBuilder()
+                            .addArray()
+                            .add(hsMessage)   // Handover Select message
+                            .add(hrMessage)   // Handover Request message
+                            .end()
+                            .build().get(0);
+                    setDeviceEngagement(encodedDeviceEngagement, handover);
+
+                    reportDeviceEngagementReceived(parsedCms);
+
+                } catch (Throwable t) {
+                    reportError(t);
+                }
+            }
+        };
+        transceiverThread.start();
     }
 
     private void setDeviceEngagement(@NonNull byte[] deviceEngagement, @NonNull DataItem handover) {


### PR DESCRIPTION
This works as-is but needs a bit of cleanup and also UI settings elements before we can land it. It currently defaults to NFC static handover meaning there are no functional changes.

Unit tests cover both NFC static handover and negotiated handover.

Test: New unit tests and all unit tests pass.
Test: Manually tested.