### PR TITLE
Support referrer not being set for 18013-7 transactions.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/MainActivity.kt
+++ b/appholder/src/main/java/com/android/mdl/app/MainActivity.kt
@@ -109,16 +109,17 @@ class MainActivity : AppCompatActivity() {
             Log.e(LOG_TAG, "No mdoc:// URI")
             return
         }
-        if (mdocReferrerUri == null) {
-            Log.e(LOG_TAG, "No referrer URI")
-            return
-        }
-
         Log.i(LOG_TAG, "uri: $mdocUri")
-        Log.i(LOG_TAG, "referrer: $mdocReferrerUri")
 
         val originInfos = ArrayList<OriginInfo>()
-        originInfos.add(OriginInfoWebsite(1, mdocReferrerUri))
+        if (mdocReferrerUri == null) {
+            Log.w(LOG_TAG, "No referrer URI")
+            // TODO: maybe bail in the future if this isn't set.
+        } else {
+            Log.i(LOG_TAG, "referrer: $mdocReferrerUri")
+            originInfos.add(OriginInfoWebsite(1, mdocReferrerUri))
+        }
+
         viewModel.startPresentationReverseEngagement(mdocUri, originInfos)
         val navController = findNavController(R.id.nav_host_fragment)
         navController.navigate(

--- a/identity/src/main/java/com/android/identity/PresentationHelper.java
+++ b/identity/src/main/java/com/android/identity/PresentationHelper.java
@@ -158,9 +158,7 @@ public class PresentationHelper {
                     EngagementGenerator generator = new EngagementGenerator(
                             mEphemeralKeyPair.getPublic(),
                             EngagementGenerator.ENGAGEMENT_VERSION_1_1);
-                    for (OriginInfo originInfo : mReverseEngagementOriginInfos) {
-                        generator.addOriginInfo(originInfo);
-                    }
+                    generator.setOriginInfos(mReverseEngagementOriginInfos);
                     mDeviceEngagement = generator.generate();
 
                     // 18013-7 says to use ReaderEngagementBytes for Handover when ReaderEngagement
@@ -176,7 +174,7 @@ public class PresentationHelper {
                     byte[] messageData = Util.cborEncode(builder.build().get(0));
 
                     if (Logger.isDebugEnabled()) {
-                        Util.dumpHex(TAG, "DeviceEngagement for reverse engagement", messageData);
+                        Util.dumpHex(TAG, "MessageData for reverse engagement", messageData);
                     }
                     mTransport.sendMessage(messageData);
                 } else {

--- a/identity/src/main/java/com/android/identity/QrEngagementHelper.java
+++ b/identity/src/main/java/com/android/identity/QrEngagementHelper.java
@@ -235,9 +235,7 @@ public class QrEngagementHelper implements NfcApduRouter.Listener {
         EngagementGenerator engagementGenerator =
                 new EngagementGenerator(mEphemeralKeyPair.getPublic(),
                         EngagementGenerator.ENGAGEMENT_VERSION_1_0);
-        for (ConnectionMethod cm : mConnectionMethods) {
-            engagementGenerator.addConnectionMethod(cm);
-        }
+        engagementGenerator.setConnectionMethods(mConnectionMethods);
         mEncodedDeviceEngagement = engagementGenerator.generate();
         mEncodedHandover = Util.cborEncode(SimpleValue.NULL);
         if (Logger.isDebugEnabled()) {

--- a/identity/src/main/java/com/android/identity/VerificationHelper.java
+++ b/identity/src/main/java/com/android/identity/VerificationHelper.java
@@ -85,6 +85,7 @@ public class VerificationHelper {
     private List<ConnectionMethod> mReverseEngagementConnectionMethods;
     private List<DataTransport> mReverseEngagementListeningTransports;
     private int mNumReverseEngagementTransportsStillSettingUp;
+    private List<ConnectionMethod> mConnectionMethodsForReaderEngagement;
     private EngagementGenerator mReaderEngagementGenerator;
     private byte[] mReaderEngagement;
 
@@ -129,6 +130,7 @@ public class VerificationHelper {
                 mEphemeralKeyPair.getPublic(),
                 EngagementGenerator.ENGAGEMENT_VERSION_1_1);
 
+        mConnectionMethodsForReaderEngagement = new ArrayList<>();
         synchronized (helper) {
             for (DataTransport transport : mReverseEngagementListeningTransports) {
                 transport.setListener(new DataTransport.Listener() {
@@ -136,8 +138,7 @@ public class VerificationHelper {
                     public void onConnectionMethodReady() {
                         Logger.d(TAG, "onConnectionMethodReady for " + transport);
                         synchronized (helper) {
-                            mReaderEngagementGenerator.addConnectionMethod(
-                                    transport.getConnectionMethod());
+                            mConnectionMethodsForReaderEngagement.add(transport.getConnectionMethod());
                             mNumReverseEngagementTransportsStillSettingUp -= 1;
                             if (mNumReverseEngagementTransportsStillSettingUp == 0) {
                                 allReverseEngagementTransportsAreSetup();
@@ -196,6 +197,7 @@ public class VerificationHelper {
     void allReverseEngagementTransportsAreSetup() {
         Logger.d(TAG, "All reverse engagement listening transports are now set up");
 
+        mReaderEngagementGenerator.setConnectionMethods(mConnectionMethodsForReaderEngagement);
         mReaderEngagement = mReaderEngagementGenerator.generate();
         mReaderEngagementGenerator = null;
 

--- a/identity/src/test/java/com/android/identity/EngagementGeneratorTest.java
+++ b/identity/src/test/java/com/android/identity/EngagementGeneratorTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.spec.ECGenParameterSpec;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 public class EngagementGeneratorTest {
@@ -64,8 +66,12 @@ public class EngagementGeneratorTest {
 
         EngagementGenerator eg = new EngagementGenerator(eSenderKey.getPublic(),
                 ENGAGEMENT_VERSION_1_1);
-        eg.addConnectionMethod(new ConnectionMethodHttp("http://www.example.com/verifier/123"));
-        eg.addOriginInfo(new OriginInfoWebsite(OriginInfo.CAT_DELIVERY, "http://www.example.com/verifier"));
+        List<ConnectionMethod> connectionMethods = new ArrayList<>();
+        connectionMethods.add(new ConnectionMethodHttp("http://www.example.com/verifier/123"));
+        eg.setConnectionMethods(connectionMethods);
+        List<OriginInfo> originInfos = new ArrayList<>();
+        originInfos.add(new OriginInfoWebsite(OriginInfo.CAT_DELIVERY, "http://www.example.com/verifier"));
+        eg.setOriginInfos(originInfos);
         byte[] encodedEngagement = eg.generate();
 
         EngagementParser parser = new EngagementParser(encodedEngagement);
@@ -92,11 +98,13 @@ public class EngagementGeneratorTest {
         UUID uuid = UUID.randomUUID();
         EngagementGenerator eg = new EngagementGenerator(eSenderKey.getPublic(),
                 ENGAGEMENT_VERSION_1_0);
-        eg.addConnectionMethod(new ConnectionMethodBle(
+        List<ConnectionMethod> connectionMethods = new ArrayList<>();
+        connectionMethods.add(new ConnectionMethodBle(
                 false,
                 true,
                 null,
                 uuid));
+        eg.setConnectionMethods(connectionMethods);
         byte[] encodedEngagement = eg.generate();
 
         EngagementParser parser = new EngagementParser(encodedEngagement);


### PR DESCRIPTION
Some mobile web browsers (Firefox on Android) do not convey the referrer URL which makes our application bail. Instead, just attempt the request and convey an empty OriginInfos array and let the mdoc reader website deal with an empty OriginInfos.

To implement this, we need to change the API on EngagementGenerator so it's possible to set an empty OriginInfos because 18013-7 says that this must be present (even if empty).

Test: Manually tested.
