### PR TITLE
Two small holder fixes.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/document/DocumentManager.kt
+++ b/appholder/src/main/java/com/android/mdl/app/document/DocumentManager.kt
@@ -42,7 +42,7 @@ class DocumentManager private constructor(private val context: Context) {
     )
 
     init {
-        PreferencesHelper.setHardwareBacked(true)
+        PreferencesHelper.setHardwareBacked(false)
     }
 
     fun getDocuments(): Collection<Document> = runBlocking {

--- a/appholder/src/main/java/com/android/mdl/app/util/PreferencesHelper.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/PreferencesHelper.kt
@@ -100,7 +100,7 @@ object PreferencesHelper {
     }
 
     fun isConnectionAutoCloseEnabled(): Boolean {
-        return sharedPreferences.getBoolean(CONNECTION_AUTO_CLOSE, true)
+        return sharedPreferences.getBoolean(CONNECTION_AUTO_CLOSE, false)
     }
 
     fun setConnectionAutoCloseEnabled(enabled: Boolean) {


### PR DESCRIPTION
Avoid crash at presentation where the wrong PresentationSession is created (HW-backed session for Keystore-backed credentials).

Also change the default fot "Auto-close connection" to false since this needs a little bit of work on the identity library side to work reliably.

Test: Manually tested
