### PR TITLE
Wire up setting for NFC handover.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
@@ -132,8 +132,11 @@ class NfcEngagementHandler : HostApduService() {
             nfcApduRouter,
             nfcEngagementListener,
             applicationContext.mainExecutor())
-        builder.useStaticHandover(connectionSetup.getConnectionMethods())
-        //builder.useNegotiatedHandover()
+        if (PreferencesHelper.shouldUseStaticHandover()) {
+            builder.useStaticHandover(connectionSetup.getConnectionMethods())
+        } else {
+            builder.useNegotiatedHandover()
+        }
         engagementHelper = builder.build()
     }
 


### PR DESCRIPTION
This makes it possible in the holder to select whether to use negotiated or static handover. The default is static handover.

Test: Manually tested.
