### PR TITLE
Fix COSE_Key encoding.

### DIFF
--- a/identity/src/main/java/com/android/identity/Util.java
+++ b/identity/src/main/java/com/android/identity/Util.java
@@ -31,6 +31,7 @@ import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERSequenceGenerator;
+import org.bouncycastle.util.BigIntegers;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -966,14 +967,20 @@ class Util {
         return ret;
     }
 
+    /* Encodes an integer according to Section 2.3.5 Field-Element-to-Octet-String Conversion
+     * of SEC 1: Elliptic Curve Cryptography (https://www.secg.org/sec1-v2.pdf).
+     */
+    static @NonNull
+    byte[] sec1EncodeFieldElementAsOctetString(int octetStringSize, BigInteger fieldValue) {
+        return BigIntegers.asUnsignedByteArray(octetStringSize, fieldValue);
+    }
+
     static @NonNull
     DataItem cborBuildCoseKey(@NonNull PublicKey key) {
         ECPublicKey ecKey = (ECPublicKey) key;
         ECPoint w = ecKey.getW();
-        // X and Y are always positive so for interop we remove any leading zeroes
-        // inserted by the BigInteger encoder.
-        byte[] x = stripLeadingZeroes(w.getAffineX().toByteArray());
-        byte[] y = stripLeadingZeroes(w.getAffineY().toByteArray());
+        byte[] x = sec1EncodeFieldElementAsOctetString(32, w.getAffineX());
+        byte[] y = sec1EncodeFieldElementAsOctetString(32, w.getAffineY());
         DataItem item = new CborBuilder()
                 .addMap()
                 .put(COSE_KEY_KTY, COSE_KEY_TYPE_EC2)
@@ -1113,6 +1120,13 @@ class Util {
         }
         byte[] encodedX = cborMapExtractByteString(coseKey, COSE_KEY_EC2_X);
         byte[] encodedY = cborMapExtractByteString(coseKey, COSE_KEY_EC2_Y);
+
+        if (encodedX.length != 32) {
+            Logger.w(TAG, "Expected 32 bytes for X in COSE_Key, found " + encodedX.length);
+        }
+        if (encodedY.length != 32) {
+            Logger.w(TAG, "Expected 32 bytes for Y in COSE_Key, found " + encodedY.length);
+        }
 
         BigInteger x = new BigInteger(1, encodedX);
         BigInteger y = new BigInteger(1, encodedY);

--- a/identity/src/test/java/com/android/identity/UtilTest.java
+++ b/identity/src/test/java/com/android/identity/UtilTest.java
@@ -40,9 +40,11 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.PublicKey;
 import java.security.Security;
 import java.security.Signature;
 import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -595,6 +597,29 @@ public class UtilTest {
                 + "0xd8, 0x86, 0x5c, 0x28, 0x2c, 0xd5, 0xa5, 0x13, 0xff, 0x3b, 0xd1, 0xde, 0x70, "
                 + "0x5e, 0xbb, 0xe2, 0x2d, 0x42, 0xbe, 0x53]\n"
                 + "]", Util.cborPrettyPrint(mac));
+    }
+
+    @Test
+    public void coseKeyEncoding() throws Exception {
+        // This checks the encoding of X and Y are encoded as specified in
+        // Section 2.3.5 Field-Element-to-Octet-String Conversion of
+        // SEC 1: Elliptic Curve Cryptography (https://www.secg.org/sec1-v2.pdf).
+        assertEquals("{\n" +
+                        "  1 : 2,\n" +
+                        "  -1 : 1,\n" +
+                        "  -2 : [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, " +
+                                "0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, " +
+                                "0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, " +
+                                "0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01],\n" +
+                        "  -3 : [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, " +
+                                "0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, " +
+                                "0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, " +
+                                "0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02]\n" +
+                        "}",
+                Util.cborPrettyPrint(Util.cborBuildCoseKey(
+                        Util.getPublicKeyFromIntegers(
+                                BigInteger.valueOf(1),
+                                BigInteger.valueOf(2)))));
     }
 
     @Test


### PR DESCRIPTION
RFC 8152 section 13.1.1.  Double Coordinate Curves says to use [SEC1] for converting X coordinates to bstr (and to preserve leading zero octects) which implies the octet string for each coordinate is always 32 bytes (for curve P-256).

This was discovered when testing against an implementation that wasn't as tolerants as other implementations.

Also add a warning if receiving/decoding a COSE_Key where this requirement isn't met.

Test: New unit test
Test: All unit tests pass
Test: Manually performed a presentation
