### PR TITLE
mdoc reader: Fix CC file handling.

### DIFF
--- a/identity/src/androidTest/java/com/android/identity/NfcEnagementHelperTest.java
+++ b/identity/src/androidTest/java/com/android/identity/NfcEnagementHelperTest.java
@@ -127,13 +127,6 @@ public class NfcEnagementHelperTest {
         Assert.assertNotNull(responseApdu);
         Assert.assertArrayEquals(NfcUtil.STATUS_WORD_OK, responseApdu);
 
-        // Get length of CC file
-        apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduReadBinary(0, 2));
-        responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);
-        Assert.assertNotNull(responseApdu);
-        // The response contains the length as 2 bytes followed by STATUS_WORD_OK
-        Assert.assertArrayEquals(Util.fromHex("000f9000"), responseApdu);
-
         // Get CC file
         apduRouter.addReceivedApdu(ndefAppId, NfcUtil.createApduReadBinary(0, 15));
         responseApdu = apdusSentByHelper.poll(5000, TimeUnit.MILLISECONDS);

--- a/identity/src/main/java/com/android/identity/NfcUtil.java
+++ b/identity/src/main/java/com/android/identity/NfcUtil.java
@@ -92,7 +92,9 @@ class NfcUtil {
         baos.write(0xb0);
         baos.write(offset / 0x100);
         baos.write(offset & 0xff);
-        if (length < 0x100) {
+        if (length == 0) {
+            throw new IllegalArgumentException("Length cannot be zero");
+        } else if (length < 0x100) {
             baos.write(length & 0xff);
         } else {
             baos.write(0x00);


### PR DESCRIPTION
NFC Forum Type 4 Tag Technical Specification Version 1.2 section 5.3.1 says to use a short READ_BINARY for the CC file (b/c the CC File contains the value for MLe). Also we already know the lenght of the CC file (at least the parts we're interested in), so hardcode the length to 15 instead of getting the length and then all the payload.

Unify APDU generation routines (instead of having multiple copies) and have the READ_BINARY one use short length if the request length fits in a byte.

The root cause for this problem is that when we landed the NFC Negotiated Handover we starting using NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK which means the OS won't do anything and we do all the NDEF detection ourselves via IsoDep. Here are the APDUs received by the holder device before we started using SKIP_NDEF_CHECK:

 00a4040007d276000085010100  # Application Select
 00a4000c02e103              # CC File select
 00b000000f                  # short READ_BINARY for 15 bytes
 00a4000c02e104              # NDEF file select
 00b0000002                  # short READ_BINARY for NDEF file length
 00b000020000ce              # READ_BINARY for NDEF file payload

and all these are generated by Android (system/nfc/src/nfc/tags/rw_t4t.cc), not our mdoc reader app.

After we started using SKIP_NDEF_CHECK we generated these ourselves but we did so incorrectly

 00a4040007d2760000850101
 00a4000c02e103
 00b00000000002
 00b0000000000f
 00a4000c02e104
 00b00000000002
 00b000020000ce

since we're using long READ_BINARY for the CC file and Type 4 spec specifically says not to. We're also getting the length of the CC file which is unnecessary since we know it's always going to be just 15 bytes. Most importantly, these commands violate the Section 7.5.3 NDEF Detection Procedure which specifically says to use a short READ_BINARY for the CC file.

After this commit the APDUs sent to the device with the mdoc are as follows:

 00a4040007d2760000850101
 00a4000c02e103
 00b000000f
 00a4000c02e104
 00b0000002
 00b00002ce

which looks almost like what Android is doing when using SKIP_NDEF_CHECK with the exception that Android is using a long READ_BINARY when the length actually fits in a short READ_BINARY.

This should bring the mdoc reader back to a state where it sends almost the same APDUs as we did when we weren't using the NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK flag. This should solve some of the problems we've run into at the mDL test event.

Test: Unit tests pass
Test: Manually tested NFC static and negotiated handover
