### PR TITLE
BLE: Accept shorter writes on Server2Client / Client2Server

### DIFF
--- a/identity/src/main/java/com/android/identity/GattServer.java
+++ b/identity/src/main/java/com/android/identity/GattServer.java
@@ -341,11 +341,10 @@ class GattServer extends BluetoothGattServerCallback {
                 mIncomingMessage.reset();
                 reportMessageReceived(entireMessage);
             } else if (value[0] == 0x01) {
-                if (value.length != getMaxChunkSize() - 3) {
-                    reportError(new Error(String.format(Locale.US,
-                            "Invalid size %d of data written Client2Server characteristic, "
-                            + "expected size %d",
-                            value.length, getMaxChunkSize() - 3)));
+                if (value.length != getCharacteristicValueSize()) {
+                    Logger.w(TAG, String.format(Locale.US,
+                            "Client2Server received %d bytes which is less than the expected %d bytes",
+                            value.length, getCharacteristicValueSize()));
                     return;
                 }
             } else {
@@ -418,29 +417,20 @@ class GattServer extends BluetoothGattServerCallback {
         Logger.d(TAG, "Negotiated MTU " + mtu + " for " + device.getAddress() + " ");
     }
 
-    private int mMaxChunkSize = 0;
+    private int mCharacteristicValueSize = 0;
 
     private int
-    getMaxChunkSize() {
-        if (mMaxChunkSize > 0) {
-            return mMaxChunkSize;
+    getCharacteristicValueSize() {
+        if (mCharacteristicValueSize > 0) {
+            return mCharacteristicValueSize;
         }
-
         int mtuSize = mNegotiatedMtu;
         if (mtuSize == 0) {
             Logger.w(TAG, "MTU not negotiated, defaulting to 23. Performance will suffer.");
             mtuSize = 23;
         }
-
-        if (mtuSize > 515) {
-            Logger.w(TAG, String.format(Locale.US, "MTU size is %d, assuming 515 for maxChunkSize", mtuSize));
-            mMaxChunkSize = 515;
-        } else {
-            Logger.w(TAG, String.format(Locale.US, "MTU size is %d, using this as maxChunkSize", mtuSize));
-            mMaxChunkSize = mtuSize;
-        }
-
-        return mMaxChunkSize;
+        mCharacteristicValueSize = Util.bleCalculateAttributeValueSize(mtuSize);
+        return mCharacteristicValueSize;
     }
 
     void drainWritingQueue() {
@@ -504,20 +494,20 @@ class GattServer extends BluetoothGattServerCallback {
             return;
         }
 
-        // Three less the MTU but we also need room for the leading 0x00 or 0x01.
+        // Also need room for the leading 0x00 or 0x01.
         //
-        int maxChunkSize = getMaxChunkSize() - 4;
+        int maxDataSize = getCharacteristicValueSize() - 1;
 
         int offset = 0;
         do {
-            boolean moreChunksComing = (offset + maxChunkSize < data.length);
+            boolean moreDataComing = (offset + maxDataSize < data.length);
             int size = data.length - offset;
-            if (size > maxChunkSize) {
-                size = maxChunkSize;
+            if (size > maxDataSize) {
+                size = maxDataSize;
             }
 
             byte[] chunk = new byte[size + 1];
-            chunk[0] = moreChunksComing ? (byte) 0x01 : (byte) 0x00;
+            chunk[0] = moreDataComing ? (byte) 0x01 : (byte) 0x00;
             System.arraycopy(data, offset, chunk, 1, size);
 
             mWritingQueue.add(chunk);

--- a/identity/src/main/java/com/android/identity/Util.java
+++ b/identity/src/main/java/com/android/identity/Util.java
@@ -1895,4 +1895,25 @@ class Util {
         return a.compareTo(b);
     }
 
+    // Returns how many bytes should be used for values in the Server2Client and
+    // Client2Server characteristics.
+    static int
+    bleCalculateAttributeValueSize(int mtuSize) {
+        int characteristicValueSize;
+        if (mtuSize > 515) {
+            // Bluetooth Core specification Part F section 3.2.9 says "The maximum length of
+            // an attribute value shall be 512 octets". ... this is enforced in Android as
+            // of Android 13 with the effect being that the application only sees the first
+            // 512 bytes.
+            Logger.w(TAG, String.format(Locale.US, "MTU size is %d, using 512 as "
+                    + "characteristic value size", mtuSize));
+            characteristicValueSize = 512;
+        } else {
+            characteristicValueSize = mtuSize - 3;
+            Logger.w(TAG, String.format(Locale.US, "MTU size is %d, using %d as "
+                    + "characteristic value size", mtuSize, characteristicValueSize));
+        }
+        return characteristicValueSize;
+    }
+
 }


### PR DESCRIPTION
On Server2Client and Client2Server attributes accept writes that are shorter than what ISO 18013-5 currently calls for. Previously we would fail the transaction if this were to happen.

Manually tested this by modifying sendMessage() to chop the data into smaller chunks than what we usually use.

Also slightly rework the nomenclature (in particular avoid the made up word "chunk") and introduce a generic utility function which calculates what the characterstic value size to use should be.

Test: All unit tests pass
Test: Manually tested with BLE central client mode
Test: Manually tested with BLE peripheral server mode
