### PR TITLE
Fix linter crash.

### DIFF
--- a/identity/src/main/java/com/android/identity/VerificationHelper.java
+++ b/identity/src/main/java/com/android/identity/VerificationHelper.java
@@ -476,7 +476,8 @@ public class VerificationHelper {
                     }
                     if (ccFile.length < 15) {
                         throw new IllegalStateException(
-                                String.format(Locale.US, "CC file is %d bytes, expected 15"));
+                                String.format(Locale.US, "CC file is %d bytes, expected 15",
+                                        ccFile.length));
                     }
 
                     // TODO: look at mapping version in ccFile


### PR DESCRIPTION
The linter started crashing after PR 166 landed. This fixes the problem and also fixes a bug where the int parameter for a %d directive in String.format() wasn't passed.

Test: Builds.
