### PR TITLE
Logging improvements and CBOR helper for printing diagnostics.

### DIFF
--- a/identity/src/main/java/com/android/identity/CborUtil.java
+++ b/identity/src/main/java/com/android/identity/CborUtil.java
@@ -1,0 +1,310 @@
+package com.android.identity;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+
+import java.io.ByteArrayInputStream;
+import java.lang.annotation.Retention;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+
+import co.nstant.in.cbor.CborDecoder;
+import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.model.AbstractFloat;
+import co.nstant.in.cbor.model.ByteString;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.DoublePrecisionFloat;
+import co.nstant.in.cbor.model.NegativeInteger;
+import co.nstant.in.cbor.model.SimpleValue;
+import co.nstant.in.cbor.model.UnsignedInteger;
+
+class CborUtil {
+    private static final String TAG = "CborUtil";
+
+
+    static final int DIAGNOSTICS_FLAG_EMBEDDED_CBOR = (1 << 0);
+
+    static final int DIAGNOSTICS_FLAG_PRETTY_PRINT = (1 << 1);
+
+    @Retention(SOURCE)
+    @IntDef(
+            flag = true,
+            value = {
+                    DIAGNOSTICS_FLAG_EMBEDDED_CBOR,
+                    DIAGNOSTICS_FLAG_PRETTY_PRINT
+            })
+    public @interface DiagnosticsFlags {
+    }
+
+    // Returns true iff all elements in |items| are not compound (e.g. an array or a map).
+    private static boolean cborAreAllDataItemsNonCompound(@NonNull List<DataItem> items,
+                                                          @DiagnosticsFlags int flags) {
+        for (DataItem item : items) {
+            if ((flags & CborUtil.DIAGNOSTICS_FLAG_EMBEDDED_CBOR) != 0
+                    && item.hasTag() && item.getTag().getValue() == 24) {
+                return false;
+            }
+            switch (item.getMajorType()) {
+                case ARRAY:
+                case MAP:
+                    return false;
+
+                default:
+                    // Do nothing
+                    break;
+            }
+        }
+        return true;
+    }
+
+    private static boolean cborFitsInSingleLine(@NonNull List<DataItem> items,
+                                                @DiagnosticsFlags int flags) {
+        // For now just use this heuristic.
+        return cborAreAllDataItemsNonCompound(items, flags) && items.size() < 8;
+    }
+
+    private static void toDiagnostics(@NonNull StringBuilder sb,
+                                      int indent,
+                                      @NonNull DataItem dataItem,
+                                      @DiagnosticsFlags int flags) {
+        int count;
+
+        boolean pretty = ((flags & DIAGNOSTICS_FLAG_PRETTY_PRINT) != 0);
+        String indentString = "";
+        if (pretty) {
+            StringBuilder indentBuilder = new StringBuilder();
+            for (int n = 0; n < indent; n++) {
+                indentBuilder.append(' ');
+            }
+            indentString = indentBuilder.toString();
+        }
+
+        if (dataItem.hasTag()) {
+            sb.append(String.format(Locale.US, "%d(", dataItem.getTag().getValue()));
+        }
+
+        switch (dataItem.getMajorType()) {
+            case INVALID:
+                sb.append("<invalid>");
+                break;
+
+            case UNSIGNED_INTEGER:
+                // Major type 0: an unsigned integer.
+                sb.append(((UnsignedInteger) dataItem).getValue());
+                break;
+
+            case NEGATIVE_INTEGER:
+                // Major type 1: a negative integer.
+                sb.append(((NegativeInteger) dataItem).getValue());
+                break;
+
+            case BYTE_STRING:
+                // Major type 2: a byte string.
+                byte[] bstrValue = ((ByteString) dataItem).getBytes();
+
+                if (dataItem.hasTag() && dataItem.getTag().getValue() == 24
+                        && (flags & DIAGNOSTICS_FLAG_EMBEDDED_CBOR) != 0) {
+                    sb.append("<< ");
+                    ByteArrayInputStream bais = new ByteArrayInputStream(bstrValue);
+                    List<DataItem> dataItems = null;
+                    try {
+                        dataItems = new CborDecoder(bais).decode();
+                        if (dataItems.size() >= 1) {
+                            toDiagnostics(sb, indent, Util.cborDecode(bstrValue), flags);
+                            if (dataItems.size() > 1) {
+                                Logger.w(TAG, "Multiple data items in embedded CBOR, "
+                                        + "only printing the first");
+                                sb.append(String.format(Locale.US,
+                                        " Error: omitting %d additional items",
+                                        dataItems.size() - 1));
+                            }
+                        } else {
+                            sb.append("Error: 0 Data Items");
+                        }
+                    } catch (CborException e) {
+                        // Never throw an exception
+                        sb.append("Error Decoding CBOR");
+                        Logger.w(TAG, "Error decoding CBOR: " + e);
+                    }
+                    sb.append(" >>");
+                } else {
+                    sb.append("h'");
+                    count = 0;
+                    for (byte b : bstrValue) {
+                        sb.append(String.format(Locale.US, "%02x", b));
+                        count++;
+                    }
+                    sb.append("'");
+                }
+                break;
+
+            case UNICODE_STRING:
+                // Major type 3: string of Unicode characters that is encoded as UTF-8 [RFC3629].
+                String strValue = Util.checkedStringValue(dataItem);
+                String escapedStrValue = strValue.replace("\"", "\\\"");
+                sb.append("\"" + escapedStrValue + "\"");
+                break;
+
+            case ARRAY:
+                // Major type 4: an array of data items.
+                List<DataItem> items = ((co.nstant.in.cbor.model.Array) dataItem).getDataItems();
+                if (!pretty || cborFitsInSingleLine(items, flags)) {
+                    sb.append("[");
+                    count = 0;
+                    for (DataItem item : items) {
+                        toDiagnostics(sb, indent, item, flags);
+                        if (++count < items.size()) {
+                            sb.append(", ");
+                        }
+                    }
+                    sb.append("]");
+                } else {
+                    sb.append("[\n").append(indentString);
+                    count = 0;
+                    for (DataItem item : items) {
+                        sb.append("  ");
+                        toDiagnostics(sb, indent + 2, item, flags);
+                        if (++count < items.size()) {
+                            sb.append(",");
+                        }
+                        sb.append("\n").append(indentString);
+                    }
+                    sb.append("]");
+                }
+                break;
+
+            case MAP:
+                // Major type 5: a map of pairs of data items.
+                Collection<DataItem> keys = ((co.nstant.in.cbor.model.Map) dataItem).getKeys();
+                if (!pretty || keys.size() == 0 ){
+                    sb.append("{");
+                    count = 0;
+                    for (DataItem key : keys) {
+                        DataItem value = ((co.nstant.in.cbor.model.Map) dataItem).get(key);
+                        toDiagnostics(sb, indent, key, flags);
+                        sb.append(": ");
+                        toDiagnostics(sb, indent + 2, value, flags);
+                        if (++count < keys.size()) {
+                            sb.append(", ");
+                        }
+                    }
+                    sb.append("}");
+                } else {
+                    sb.append("{\n").append(indentString);
+                    count = 0;
+                    for (DataItem key : keys) {
+                        sb.append("  ");
+                        DataItem value = ((co.nstant.in.cbor.model.Map) dataItem).get(key);
+                        toDiagnostics(sb, indent + 2, key, flags);
+                        sb.append(": ");
+                        toDiagnostics(sb, indent + 2, value, flags);
+                        if (++count < keys.size()) {
+                            sb.append(",");
+                        }
+                        sb.append("\n").append(indentString);
+                    }
+                    sb.append("}");
+                }
+                break;
+
+            case TAG:
+                // Major type 6: optional semantic tagging of other major types
+                //
+                // We never encounter this one since it's automatically handled via the
+                // DataItem that is tagged.
+                break;
+
+            case SPECIAL:
+                // Major type 7: floating point numbers and simple data types that need no
+                // content, as well as the "break" stop code.
+                if (dataItem instanceof SimpleValue) {
+                    switch (((SimpleValue) dataItem).getSimpleValueType()) {
+                        case FALSE:
+                            sb.append("false");
+                            break;
+                        case TRUE:
+                            sb.append("true");
+                            break;
+                        case NULL:
+                            sb.append("null");
+                            break;
+                        case UNDEFINED:
+                            sb.append("undefined");
+                            break;
+                        case RESERVED:
+                            sb.append("reserved");
+                            break;
+                        case UNALLOCATED:
+                            sb.append("simple(");
+                            sb.append(((SimpleValue) dataItem).getValue());
+                            sb.append(")");
+                            break;
+                    }
+                } else if (dataItem instanceof DoublePrecisionFloat) {
+                    DecimalFormat df = new DecimalFormat("0",
+                            DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+                    df.setMaximumFractionDigits(340);
+                    sb.append(df.format(((DoublePrecisionFloat) dataItem).getValue()));
+                } else if (dataItem instanceof AbstractFloat) {
+                    DecimalFormat df = new DecimalFormat("0",
+                            DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+                    df.setMaximumFractionDigits(340);
+                    sb.append(df.format(((AbstractFloat) dataItem).getValue()));
+                } else {
+                    sb.append("break");
+                }
+                break;
+        }
+
+        if (dataItem.hasTag()) {
+            sb.append(")");
+        }
+
+    }
+
+    static @NonNull
+    String toDiagnostics(@NonNull DataItem dataItem) {
+        return toDiagnostics(dataItem, 0);
+    }
+
+    static @NonNull
+    String toDiagnostics(@NonNull DataItem dataItem, @DiagnosticsFlags int flags) {
+        StringBuilder sb = new StringBuilder();
+        toDiagnostics(sb, 0, dataItem, flags);
+        return sb.toString();
+    }
+
+    static @NonNull
+    String toDiagnostics(@NonNull byte[] encodedCbor) {
+        return toDiagnostics(encodedCbor, 0);
+    }
+
+    static @NonNull
+    String toDiagnostics(@NonNull byte[] encodedCbor, @DiagnosticsFlags int flags) {
+        StringBuilder sb = new StringBuilder();
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(encodedCbor);
+        List<DataItem> dataItems = null;
+        try {
+            dataItems = new CborDecoder(bais).decode();
+        } catch (CborException e) {
+            // Never throw an exception
+            return "Error Decoding CBOR";
+        }
+        int count = 0;
+        for (DataItem dataItem : dataItems) {
+            if (count > 0) {
+                sb.append(",\n");
+            }
+            toDiagnostics(sb, 0, dataItem, flags);
+            count++;
+        }
+        return sb.toString();
+    }
+
+}

--- a/identity/src/main/java/com/android/identity/DataTransportNfc.java
+++ b/identity/src/main/java/com/android/identity/DataTransportNfc.java
@@ -96,7 +96,7 @@ public class DataTransportNfc extends DataTransport {
                     if (messageToSend == null) {
                         continue;
                     }
-                    Logger.d(TAG, "Sending message " + Util.toHex(messageToSend));
+                    Logger.dHex(TAG, "Sending message", messageToSend);
 
                     if (mListenerLeReceived == -1) {
                         reportError(new Error("ListenerLeReceived not set"));
@@ -195,7 +195,7 @@ public class DataTransportNfc extends DataTransport {
         byte[] ret = null;
         mHostApduService = hostApduService;
 
-        Logger.d(TAG, "nfcDataTransferProcessCommandApdu apdu " + Util.toHex(apdu));
+        Logger.dHex(TAG, "nfcDataTransferProcessCommandApdu apdu", apdu);
 
         int commandType = NfcUtil.nfcGetCommandType(apdu);
         if (!mDataTransferAidSelected) {
@@ -243,7 +243,7 @@ public class DataTransportNfc extends DataTransport {
             reportConnected();
             return NfcUtil.STATUS_WORD_OK;
         }
-        Logger.w(TAG, "handleSelectByAid: Unexpected AID selected in APDU " + Util.toHex(apdu));
+        Logger.wHex(TAG, "handleSelectByAid: Unexpected AID selected in APDU", apdu);
         return NfcUtil.STATUS_WORD_FILE_NOT_FOUND;
     }
 
@@ -578,9 +578,9 @@ public class DataTransportNfc extends DataTransport {
 
                     byte[] selectCommand = buildApdu(0x00, 0xa4, 0x04, 0x00,
                             NfcUtil.AID_FOR_MDL_DATA_TRANSFER, 0);
-                    Logger.d(TAG, "selectCommand: " + Util.toHex(selectCommand));
+                    Logger.dHex(TAG, "selectCommand", selectCommand);
                     byte[] selectResponse = mIsoDep.transceive(selectCommand);
-                    Logger.d(TAG, "selectResponse: " + Util.toHex(selectResponse));
+                    Logger.dHex(TAG, "selectResponse", selectResponse);
                     if (!Arrays.equals(selectResponse, NfcUtil.STATUS_WORD_OK)) {
                         reportError(new Error("Unexpected response to AID SELECT"));
                         return;
@@ -596,9 +596,7 @@ public class DataTransportNfc extends DataTransport {
                         } catch (InterruptedException e) {
                             continue;
                         }
-                        if (Logger.isDebugEnabled()) {
-                            Logger.d(TAG, "Sending message " + Util.toHex(messageToSend));
-                        }
+                        Logger.dHex(TAG, "Sending message", messageToSend);
 
                         byte[] data = encapsulateInDo53(messageToSend);
 
@@ -625,9 +623,7 @@ public class DataTransportNfc extends DataTransport {
                             byte[] envelopeCommand = buildApdu(moreChunksComing ? 0x10 : 0x00,
                                     0xc3, 0x00, 0x00, chunk, le);
 
-                            if (Logger.isDebugEnabled()) {
-                                Logger.d(TAG, "envelopeCommand " + Util.toHex(envelopeCommand));
-                            }
+                            Logger.dHex(TAG, "envelopeCommand", envelopeCommand);
 
                             long t0 = System.currentTimeMillis();
                             byte[] envelopeResponse = mIsoDep.transceive(envelopeCommand);
@@ -643,16 +639,14 @@ public class DataTransportNfc extends DataTransport {
                                     envelopeResponse.length,
                                     bitsPerSec));
 
-                            if (Logger.isDebugEnabled()) {
-                                Logger.d(TAG, "Received " + Util.toHex(envelopeResponse));
-                            }
+
+                            Logger.dHex(TAG, "Received", envelopeResponse);
 
                             offset += size;
 
                             if (moreChunksComing) {
                                 // Don't care about response.
-                                Logger.d(TAG, "envResponse (more chunks coming) " + Util.toHex(
-                                        envelopeResponse));
+                                Logger.dHex(TAG, "envResponse (more chunks coming)", envelopeResponse);
                             } else {
                                 lastEnvelopeResponse = envelopeResponse;
                             }

--- a/identity/src/main/java/com/android/identity/GattClient.java
+++ b/identity/src/main/java/com/android/identity/GattClient.java
@@ -564,9 +564,7 @@ class GattClient extends BluetoothGattCallback {
 
 
     void sendMessage(@NonNull byte[] data) {
-        if (Logger.isDebugEnabled()) {
-            Util.dumpHex(TAG, "sendMessage", data);
-        }
+        Logger.dHex(TAG, "sendMessage", data);
 
         // Use socket for L2CAP if applicable
         if (mL2CAPClient != null) {

--- a/identity/src/main/java/com/android/identity/GattServer.java
+++ b/identity/src/main/java/com/android/identity/GattServer.java
@@ -484,9 +484,7 @@ class GattServer extends BluetoothGattServerCallback {
     }
 
     void sendMessage(@NonNull byte[] data) {
-        if (Logger.isDebugEnabled()) {
-            Util.dumpHex(TAG, "sendMessage", data);
-        }
+        Logger.dHex(TAG, "sendMessage", data);
 
         // Uses socket L2CAP when it is available
         if (mL2CAPServer != null) {

--- a/identity/src/main/java/com/android/identity/NfcEngagementHelper.java
+++ b/identity/src/main/java/com/android/identity/NfcEngagementHelper.java
@@ -259,7 +259,7 @@ public class NfcEngagementHelper {
         byte[] ret = null;
 
         if (Logger.isDebugEnabled()) {
-            Logger.d(TAG, "nfcProcessCommandApdu: apdu " + Util.toHex(apdu));
+            Logger.dHex(TAG, "nfcProcessCommandApdu: apdu", apdu);
         }
 
         int commandType = NfcUtil.nfcGetCommandType(apdu);
@@ -296,7 +296,7 @@ public class NfcEngagementHelper {
             Logger.d(TAG, "handleSelectByAid: NFC engagement AID selected");
             return NfcUtil.STATUS_WORD_OK;
         }
-        Logger.d(TAG, "handleSelectByAid: Unexpected AID selected in APDU " + Util.toHex(apdu));
+        Logger.dHex(TAG, "handleSelectByAid: Unexpected AID selected in APDU", apdu);
         return NfcUtil.STATUS_WORD_FILE_NOT_FOUND;
     }
 
@@ -371,11 +371,7 @@ public class NfcEngagementHelper {
             if (mUsingNegotiatedHandover) {
                 Logger.d(TAG, "handleSelectFile: NDEF file selected and using negotiated handover");
                 byte[] message = calculateNegotiatedHandoverInitialNdefMessage();
-                if (Logger.isDebugEnabled()) {
-                    Logger.d(TAG, String.format(Locale.US,
-                            "handleSelectFile: Negotiated Handover initial NDEF message is %d bytes: %s",
-                            message.length, Util.toHex(message)));
-                }
+                Logger.dHex(TAG, "handleSelectFile: Initial NDEF message", message);
                 byte[] fileContents = new byte[message.length + 2];
                 fileContents[0] = (byte) (message.length / 256);
                 fileContents[1] = (byte) (message.length & 0xff);
@@ -388,10 +384,7 @@ public class NfcEngagementHelper {
                 byte[] hsMessage = NfcUtil.createNdefMessageHandoverSelect(
                         mStaticHandoverConnectionMethods,
                         mEncodedDeviceEngagement);
-                if (Logger.isDebugEnabled()) {
-                    Logger.d(TAG, String.format(Locale.US, "handleSelectFile: HS is %d bytes: %s",
-                            hsMessage.length, Util.toHex(hsMessage)));
-                }
+                Logger.dHex(TAG, "handleSelectFile: Handover Select", hsMessage);
                 byte[] fileContents = new byte[hsMessage.length + 2];
                 fileContents[0] = (byte) (hsMessage.length / 256);
                 fileContents[1] = (byte) (hsMessage.length & 0xff);
@@ -405,10 +398,8 @@ public class NfcEngagementHelper {
                         .add(SimpleValue.NULL)  // Handover Request message
                         .end()
                         .build().get(0));
-                if (Logger.isDebugEnabled()) {
-                    Logger.d(TAG, "NFC static DeviceEngagement: " + Util.toHex(mEncodedDeviceEngagement));
-                    Logger.d(TAG, "NFC static Handover: " + Util.toHex(mEncodedHandover));
-                }
+                Logger.dCbor(TAG, "NFC static DeviceEngagement", mEncodedDeviceEngagement);
+                Logger.dCbor(TAG, "NFC static Handover", mEncodedHandover);
 
                 // Technically we should ensure the transports are up until sending the response...
                 setupTransports(mStaticHandoverConnectionMethods);
@@ -500,7 +491,7 @@ public class NfcEngagementHelper {
 
         byte[] payload = new byte[dataSize];
         System.arraycopy(apdu, dataBeginsAt, payload, 0, dataSize);
-        Logger.d(TAG, String.format(Locale.US, "handleUpdateBinary: payload: %s", Util.toHex(payload)));
+        Logger.dHex(TAG,"handleUpdateBinary: payload", payload);
 
         // TODO: properly implement state machine in:
         //  Type 4 Tag Technical Specification Version 1.2 section 7.5.5 NDEF Write Procedure
@@ -519,7 +510,7 @@ public class NfcEngagementHelper {
 
     private @NonNull
     byte[] handleServiceSelect(@NonNull byte[] ndefMessagePayload) {
-        Logger.d(TAG, "handleServiceSelect: payload " + Util.toHex(ndefMessagePayload));
+        Logger.dHex(TAG, "handleServiceSelect: payload", ndefMessagePayload);
         // NDEF message specified in NDEF Exchange Protocol 1.0: 4.2.2 Service Select Record
         NdefMessage message = null;
         try {
@@ -555,11 +546,7 @@ public class NfcEngagementHelper {
         // Service selection.
 
         byte[] statusMessage = calculateStatusMessage(0x00);
-        if (Logger.isDebugEnabled()) {
-            Logger.d(TAG, String.format(Locale.US,
-                    "handleServiceSelect: Status message is %d bytes: %s",
-                    statusMessage.length, Util.toHex(statusMessage)));
-        }
+        Logger.dHex(TAG, "handleServiceSelect: Status message", statusMessage);
         byte[] fileContents = new byte[statusMessage.length + 2];
         fileContents[0] = (byte) (statusMessage.length / 256);
         fileContents[1] = (byte) (statusMessage.length & 0xff);
@@ -571,7 +558,7 @@ public class NfcEngagementHelper {
 
     private @NonNull
     byte[] handleHandoverRequest(@NonNull byte[] ndefMessagePayload) {
-        Logger.d(TAG, "handleHandoverRequest: payload " + Util.toHex(ndefMessagePayload));
+        Logger.dHex(TAG, "handleHandoverRequest: payload", ndefMessagePayload);
         NdefMessage message = null;
         try {
             message = new NdefMessage(ndefMessagePayload);
@@ -656,10 +643,8 @@ public class NfcEngagementHelper {
                 .add(mHandoverRequestMessage)  // Handover Request message
                 .end()
                 .build().get(0));
-        if (Logger.isDebugEnabled()) {
-            Logger.d(TAG, "NFC negotiated DeviceEngagement: " + Util.toHex(mEncodedDeviceEngagement));
-            Logger.d(TAG, "NFC negotiated Handover: " + Util.toHex(mEncodedHandover));
-        }
+        Logger.dCbor(TAG, "NFC negotiated DeviceEngagement", mEncodedDeviceEngagement);
+        Logger.dCbor(TAG, "NFC negotiated Handover", mEncodedHandover);
 
         // Technically we should ensure the transports are up until sending the response...
         setupTransports(listWithSelectedConnectionMethod);

--- a/identity/src/main/java/com/android/identity/PresentationHelper.java
+++ b/identity/src/main/java/com/android/identity/PresentationHelper.java
@@ -174,9 +174,7 @@ public class PresentationHelper {
                     mapBuilder.end();
                     byte[] messageData = Util.cborEncode(builder.build().get(0));
 
-                    if (Logger.isDebugEnabled()) {
-                        Util.dumpHex(TAG, "MessageData for reverse engagement", messageData);
-                    }
+                    Logger.dCbor(TAG, "MessageData for reverse engagement to send", messageData);
                     mTransport.sendMessage(messageData);
                 } else {
                     throw new IllegalStateException("Unexpected onConnected callback");
@@ -277,9 +275,7 @@ public class PresentationHelper {
     }
 
     private void processMessageReceived(@NonNull byte[] data) {
-        if (Logger.isDebugEnabled()) {
-            Util.dumpHex(TAG, "SessionData", data);
-        }
+        Logger.dCbor(TAG, "SessionData received", data);
         ensureSessionEncryption(data);
         Pair<byte[], OptionalLong> decryptedMessage = null;
         try {
@@ -325,9 +321,7 @@ public class PresentationHelper {
                 }
             }
 
-            if (Logger.isDebugEnabled()) {
-                Util.dumpHex(TAG, "Received DeviceRequest", decryptedMessage.first);
-            }
+            Logger.dCbor(TAG, "DeviceRequest received", decryptedMessage.first);
 
             reportDeviceRequest(decryptedMessage.first);
         } else {
@@ -413,9 +407,7 @@ public class PresentationHelper {
     public void sendDeviceResponse(@NonNull byte[] deviceResponseBytes,
         @Nullable TransmissionProgressListener progressListener,
         @Nullable Executor progressExecutor) {
-        if (Logger.isDebugEnabled()) {
-            Util.dumpHex(TAG, "Sending DeviceResponse", deviceResponseBytes);
-        }
+        Logger.dCbor(TAG, "DeviceResponse to send", deviceResponseBytes);
         byte[] encryptedData =
             mSessionEncryption.encryptMessageToReader(deviceResponseBytes, OptionalLong.empty());
         mTransport.sendMessage(encryptedData, progressListener, progressExecutor);

--- a/identity/src/main/java/com/android/identity/QrEngagementHelper.java
+++ b/identity/src/main/java/com/android/identity/QrEngagementHelper.java
@@ -163,10 +163,8 @@ public class QrEngagementHelper {
         engagementGenerator.setConnectionMethods(mConnectionMethods);
         mEncodedDeviceEngagement = engagementGenerator.generate();
         mEncodedHandover = Util.cborEncode(SimpleValue.NULL);
-        if (Logger.isDebugEnabled()) {
-            Logger.d(TAG, "QR DE: " + Util.toHex(mEncodedDeviceEngagement));
-            Logger.d(TAG, "QR handover: " + Util.toHex(mEncodedHandover));
-        }
+        Logger.dCbor(TAG, "QR DE", mEncodedDeviceEngagement);
+        Logger.dCbor(TAG, "QR handover", mEncodedHandover);
 
         reportDeviceEngagementReady();
     }

--- a/identity/src/main/java/com/android/identity/Util.java
+++ b/identity/src/main/java/com/android/identity/Util.java
@@ -173,16 +173,6 @@ class Util {
         return sb.toString();
     }
 
-    static void dumpHex(@NonNull String tag, @NonNull String message,
-            @NonNull byte[] bytes) {
-        Log.i(tag, message + " (" + bytes.length + " bytes)");
-        final int chunkSize = 1024;
-        for (int offset = 0; offset < bytes.length; offset += chunkSize) {
-            String s = toHex(bytes, offset, Math.min(bytes.length, offset + chunkSize));
-            Log.i(tag, "data: " + s);
-        }
-    }
-
     static @NonNull
     String base16(@NonNull byte[] bytes) {
         return toHex(bytes).toUpperCase(Locale.ROOT);

--- a/identity/src/test/java/com/android/identity/CborUtilTest.java
+++ b/identity/src/test/java/com/android/identity/CborUtilTest.java
@@ -1,0 +1,260 @@
+package com.android.identity;
+
+import static org.junit.Assert.assertEquals;
+
+import androidx.test.filters.SmallTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.model.ByteString;
+import co.nstant.in.cbor.model.DoublePrecisionFloat;
+import co.nstant.in.cbor.model.SimpleValue;
+import co.nstant.in.cbor.model.SimpleValueType;
+import co.nstant.in.cbor.model.UnsignedInteger;
+
+public class CborUtilTest {
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsString() {
+        Assert.assertEquals("\"foobar\"",
+                CborUtil.toDiagnostics(Util.cborEncodeString("foobar")));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsStringEscapingWorks() {
+        Assert.assertEquals("\"foobar \\\" foobar\"",
+                CborUtil.toDiagnostics(Util.cborEncodeString("foobar \" foobar")));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsByteString() {
+        Assert.assertEquals("h'0102f0'",
+                CborUtil.toDiagnostics(Util.cborEncodeBytestring(new byte[]{0x01, 0x02, (byte) 0xf0})));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsNumber() {
+        Assert.assertEquals("42", CborUtil.toDiagnostics(Util.cborEncodeNumber(42)));
+        Assert.assertEquals("-42", CborUtil.toDiagnostics(Util.cborEncodeNumber(-42)));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsFloat() {
+        assertEquals("1.1", CborUtil.toDiagnostics(new DoublePrecisionFloat(1.1)));
+        assertEquals("-42.0000000001", CborUtil.toDiagnostics(new DoublePrecisionFloat(-42.0000000001)));
+        assertEquals("-5", CborUtil.toDiagnostics(new DoublePrecisionFloat(-5)));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsSpecial() {
+        assertEquals("false", CborUtil.toDiagnostics(new SimpleValue(SimpleValueType.FALSE)));
+        assertEquals("true", CborUtil.toDiagnostics(new SimpleValue(SimpleValueType.TRUE)));
+        assertEquals("null", CborUtil.toDiagnostics(new SimpleValue(SimpleValueType.NULL)));
+        assertEquals("undefined", CborUtil.toDiagnostics(new SimpleValue(SimpleValueType.UNDEFINED)));
+        assertEquals("reserved", CborUtil.toDiagnostics(new SimpleValue(SimpleValueType.RESERVED)));
+        assertEquals("simple(42)", CborUtil.toDiagnostics(new SimpleValue(42)));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsArray() {
+        assertEquals("[1, \"text\", h'010203']",
+                CborUtil.toDiagnostics(new CborBuilder()
+                        .addArray()
+                        .add(1)
+                        .add("text")
+                        .add(new ByteString(new byte[]{1, 2, 3}))
+                        .end()
+                        .build().get(0)));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsArrayPrettyNonCompound() {
+        assertEquals("[1, 2, 3]",
+                CborUtil.toDiagnostics(new CborBuilder()
+                        .addArray()
+                        .add(1)
+                        .add(2)
+                        .add(3)
+                        .end()
+                        .build().get(0),
+                        CborUtil.DIAGNOSTICS_FLAG_PRETTY_PRINT));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsArrayPrettyWithCompound() {
+        assertEquals("[\n" +
+                        "  1,\n" +
+                        "  2,\n" +
+                        "  3,\n" +
+                        "  [\"foo\", \"bar\"]\n" +
+                        "]",
+                CborUtil.toDiagnostics(new CborBuilder()
+                                .addArray()
+                                .add(1)
+                                .add(2)
+                                .add(3)
+                                .addArray()
+                                .add("foo")
+                                .add("bar")
+                                .end()
+                                .end()
+                                .build().get(0),
+                        CborUtil.DIAGNOSTICS_FLAG_PRETTY_PRINT));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsMap() {
+        assertEquals("{\"foo\": 1, \"bar\": \"text\", 42: h'010203'}",
+                CborUtil.toDiagnostics(new CborBuilder()
+                        .addMap()
+                        .put("foo", 1)
+                        .put("bar", "text")
+                        .put(new UnsignedInteger(42), new ByteString(new byte[]{1, 2, 3}))
+                        .end()
+                        .build().get(0)));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsMapPretty() {
+        assertEquals("{\n" +
+                        "  \"foo\": 1,\n" +
+                        "  \"bar\": \"text\",\n" +
+                        "  42: h'010203'\n" +
+                        "}",
+                CborUtil.toDiagnostics(new CborBuilder()
+                        .addMap()
+                        .put("foo", 1)
+                        .put("bar", "text")
+                        .put(new UnsignedInteger(42), new ByteString(new byte[]{1, 2, 3}))
+                        .end()
+                        .build().get(0),
+                        CborUtil.DIAGNOSTICS_FLAG_PRETTY_PRINT));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsTagged() {
+        assertEquals("0(\"2013-03-21T20:04:00Z\")",
+                CborUtil.toDiagnostics(new CborBuilder()
+                        .add("2013-03-21T20:04:00Z").tagged(0)
+                        .build().get(0)));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsEmbeddedCborOff() {
+        assertEquals("24(h'66666f6f626172')",
+                CborUtil.toDiagnostics(new CborBuilder()
+                        .add(Util.cborEncodeString("foobar")).tagged(24)
+                        .build().get(0)));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsEmbeddedCborOn() {
+        assertEquals("24(<< \"foobar\" >>)",
+                CborUtil.toDiagnostics(new CborBuilder()
+                        .add(Util.cborEncodeString("foobar")).tagged(24)
+                        .build().get(0), CborUtil.DIAGNOSTICS_FLAG_EMBEDDED_CBOR));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsTestVector() {
+        assertEquals(
+                "{0: \"1.0\", 1: [1, 24(<< {1: 2, -1: 1, -2: h'5a88d182bce5f42efa59943f33359d2e8a968ff289d93e5fa444b624343167fe', -3: h'b16e8cf858ddc7690407ba61d4c338237a8cfcf3de6aa672fc60a557aa32fc67'} >>)], 2: [[2, 1, {0: false, 1: true, 11: h'45efef742b2c4837a9a3b0e1d05a6917'}]]}",
+                CborUtil.toDiagnostics(
+                        Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_ENGAGEMENT),
+                        CborUtil.DIAGNOSTICS_FLAG_EMBEDDED_CBOR));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsTestVectorPretty() {
+        assertEquals(
+                "{\n" +
+                        "  0: \"1.0\",\n" +
+                        "  1: [1, 24(h'a4010220012158205a88d182bce5f42efa59943f33359d2e8a968ff289d93e5fa444b624343167fe225820b16e8cf858ddc7690407ba61d4c338237a8cfcf3de6aa672fc60a557aa32fc67')],\n" +
+                        "  2: [\n" +
+                        "    [\n" +
+                        "      2,\n" +
+                        "      1,\n" +
+                        "      {\n" +
+                        "        0: false,\n" +
+                        "        1: true,\n" +
+                        "        11: h'45efef742b2c4837a9a3b0e1d05a6917'\n" +
+                        "      }\n" +
+                        "    ]\n" +
+                        "  ]\n" +
+                        "}",
+                CborUtil.toDiagnostics(
+                        Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_ENGAGEMENT),
+                        CborUtil.DIAGNOSTICS_FLAG_PRETTY_PRINT));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsTestVectorPrettyAndWithEmbedded() {
+        assertEquals(
+                "{\n" +
+                        "  0: \"1.0\",\n" +
+                        "  1: [\n" +
+                        "    1,\n" +
+                        "    24(<< {\n" +
+                        "      1: 2,\n" +
+                        "      -1: 1,\n" +
+                        "      -2: h'5a88d182bce5f42efa59943f33359d2e8a968ff289d93e5fa444b624343167fe',\n" +
+                        "      -3: h'b16e8cf858ddc7690407ba61d4c338237a8cfcf3de6aa672fc60a557aa32fc67'\n" +
+                        "    } >>)\n" +
+                        "  ],\n" +
+                        "  2: [\n" +
+                        "    [\n" +
+                        "      2,\n" +
+                        "      1,\n" +
+                        "      {\n" +
+                        "        0: false,\n" +
+                        "        1: true,\n" +
+                        "        11: h'45efef742b2c4837a9a3b0e1d05a6917'\n" +
+                        "      }\n" +
+                        "    ]\n" +
+                        "  ]\n" +
+                        "}",
+                CborUtil.toDiagnostics(
+                        Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_ENGAGEMENT),
+                        CborUtil.DIAGNOSTICS_FLAG_EMBEDDED_CBOR |
+                                CborUtil.DIAGNOSTICS_FLAG_PRETTY_PRINT));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsInvalidCbor() {
+        // Make sure we don't throw if data to print isn't valid CBOR
+        assertEquals("Error Decoding CBOR",
+                CborUtil.toDiagnostics(new byte[] {(byte) 0x83, 0x01, 0x02}));
+    }
+
+    @Test
+    @SmallTest
+    public void testDiagnosticsEmbeddedInvalidCbor() {
+        // Make sure we don't throw if embedded CBOR to print isn't valid CBOR
+        assertEquals("24(<< Error Decoding CBOR >>)",
+                CborUtil.toDiagnostics(new CborBuilder()
+                        .add(new byte[] {(byte) 0x83, 0x01, 0x02}).tagged(24)
+                        .build().get(0),
+                        CborUtil.DIAGNOSTICS_FLAG_EMBEDDED_CBOR));
+    }
+
+}


### PR DESCRIPTION
Add new CborUtil.toDiagnostics() which returns a string with the given CBOR (either a DataItem or a byte[]) print in diagnostics format as per RFC 8949 Section 8. Add flags so the caller can request it to be pretty-printed (indent and newlines) and also whether it should print embedded CBOR bytestrings.

Also introduce new Logger methods which prints CBor (both hex and diagnostics) or Hex for a given byte[], and adjust callsites to use this. This cleans up callsites since they no longer need to use Logger.isDebugEnabled() to avoid a costly conversion in the event that debug isn't enabled.

Test: New unit tests and all unit tests pass
