### PR TITLE
Send message with status 10 if unable to decrypt message from reader.

### DIFF
--- a/identity/src/main/java/com/android/identity/Constants.java
+++ b/identity/src/main/java/com/android/identity/Constants.java
@@ -80,6 +80,41 @@ public class Constants {
     public static final int BLE_DATA_RETRIEVAL_CLEAR_CACHE = (1 << 3);
 
     /**
+     * Error: session encryption. The session shall be terminated.
+     *
+     * <p>This value is defined in ISO/IEC 18013-5 Table 20.
+     */
+    public static final long SESSION_DATA_STATUS_ERROR_SESSION_ENCRYPTION = 10;
+
+    /**
+     * Error: CBOR decoding. The session shall be terminated.
+     *
+     * <p>This value is defined in ISO/IEC 18013-5 Table 20.
+     */
+    public static final long SESSION_DATA_STATUS_ERROR_CBOR_DECODING = 11;
+
+    /**
+     * Session termination. The session shall be terminated.
+     *
+     * <p>This value is defined in ISO/IEC 18013-5 Table 20.
+     */
+    public static final long SESSION_DATA_STATUS_SESSION_TERMINATION = 20;
+
+    /**
+     * The status code used for session data exchange.
+     *
+     * These values are defined in ISO/IEC 18013-5 Table 20.
+     *
+     * @hidden
+     */
+    @Retention(SOURCE)
+    @LongDef({SESSION_DATA_STATUS_ERROR_SESSION_ENCRYPTION,
+            SESSION_DATA_STATUS_ERROR_CBOR_DECODING,
+            SESSION_DATA_STATUS_SESSION_TERMINATION})
+    public @interface SessionDataStatus {
+    }
+
+    /**
      * The status code of the document response.
      *
      * These values are defined in ISO/IEC 18013-5 Table 8.

--- a/identity/src/main/java/com/android/identity/PresentationHelper.java
+++ b/identity/src/main/java/com/android/identity/PresentationHelper.java
@@ -281,6 +281,8 @@ public class PresentationHelper {
         try {
             decryptedMessage = mSessionEncryption.decryptMessageFromReader(data);
         } catch (RuntimeException e) {
+            mTransport.sendMessage(mSessionEncryption.encryptMessageToReader(
+                    null, OptionalLong.of(Constants.SESSION_DATA_STATUS_ERROR_SESSION_ENCRYPTION)));
             mTransport.close();
             reportError(new Error("Error decrypting message from reader", e));
             return;
@@ -292,6 +294,8 @@ public class PresentationHelper {
             try {
                 decryptedMessage = mSessionEncryption.decryptMessageFromReader(data);
             } catch (RuntimeException e) {
+                mTransport.sendMessage(mSessionEncryption.encryptMessageToReader(
+                        null, OptionalLong.of(Constants.SESSION_DATA_STATUS_ERROR_SESSION_ENCRYPTION)));
                 mTransport.close();
                 reportError(new Error("Error decrypting message from reader", e));
                 return;
@@ -299,6 +303,8 @@ public class PresentationHelper {
         }
         if (decryptedMessage == null) {
             Logger.d(TAG, "Decryption failed!");
+            mTransport.sendMessage(mSessionEncryption.encryptMessageToReader(
+                    null, OptionalLong.of(Constants.SESSION_DATA_STATUS_ERROR_SESSION_ENCRYPTION)));
             mTransport.close();
             reportError(new Error("Error decrypting message from reader"));
             return;
@@ -334,7 +340,7 @@ public class PresentationHelper {
 
                 Logger.d(TAG, "Message received from reader with status: " + statusCode);
 
-                if (statusCode == 20) {
+                if (statusCode == Constants.SESSION_DATA_STATUS_SESSION_TERMINATION) {
                     mReceivedSessionTerminated = true;
                     mTransport.close();
                     reportDeviceDisconnected(false);
@@ -438,7 +444,7 @@ public class PresentationHelper {
                 } else {
                     Logger.d(TAG, "Sending generic session termination message");
                     byte[] sessionTermination = mSessionEncryption.encryptMessageToReader(
-                            null, OptionalLong.of(20));
+                            null, OptionalLong.of(Constants.SESSION_DATA_STATUS_SESSION_TERMINATION));
                     mTransport.sendMessage(sessionTermination);
                 }
             } else {

--- a/identity/src/main/java/com/android/identity/SessionEncryptionReader.java
+++ b/identity/src/main/java/com/android/identity/SessionEncryptionReader.java
@@ -32,7 +32,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.List;
-import java.util.OptionalInt;
+import java.util.OptionalLong;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -46,13 +46,11 @@ import co.nstant.in.cbor.CborBuilder;
 import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborException;
 import co.nstant.in.cbor.builder.MapBuilder;
-import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.ByteString;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.Map;
 import co.nstant.in.cbor.model.Number;
 import co.nstant.in.cbor.model.UnicodeString;
-import co.nstant.in.cbor.model.UnsignedInteger;
 
 
 /**
@@ -144,7 +142,7 @@ final class SessionEncryptionReader {
      *     CBOR as described above.
      */
     public @NonNull byte[] encryptMessageToDevice(@Nullable byte[] messagePlaintext,
-            @NonNull OptionalInt statusCode) {
+            @NonNull OptionalLong statusCode) {
         byte[] messageCiphertext = null;
         if (messagePlaintext != null) {
             try {
@@ -183,7 +181,7 @@ final class SessionEncryptionReader {
             mapBuilder.put("data", messageCiphertext);
         }
         if (statusCode.isPresent()) {
-            mapBuilder.put("status", statusCode.getAsInt());
+            mapBuilder.put("status", statusCode.getAsLong());
         }
         mapBuilder.end();
         byte[] messageData = Util.cborEncode(builder.build().get(0));
@@ -207,7 +205,7 @@ final class SessionEncryptionReader {
      * @exception IllegalArgumentException if the passed in data does not conform to the CDDL.
      * @exception IllegalStateException if decryption fails.
      */
-    public @NonNull Pair<byte[], OptionalInt> decryptMessageFromDevice(
+    public @NonNull Pair<byte[], OptionalLong> decryptMessageFromDevice(
             @NonNull byte[] messageData) {
         ByteArrayInputStream bais = new ByteArrayInputStream(messageData);
         List<DataItem> dataItems;
@@ -233,13 +231,13 @@ final class SessionEncryptionReader {
             messageCiphertext = ((ByteString) dataItemData).getBytes();
         }
 
-        OptionalInt status = OptionalInt.empty();
+        OptionalLong status = OptionalLong.empty();
         DataItem dataItemStatus = map.get(new UnicodeString("status"));
         if (dataItemStatus != null) {
             if (!(dataItemStatus instanceof Number)) {
                 throw new IllegalArgumentException("status is not a number");
             }
-            status = OptionalInt.of(((Number) dataItemStatus).getValue().intValue());
+            status = OptionalLong.of(((Number) dataItemStatus).getValue().intValue());
         }
 
         byte[] plainText = null;
@@ -268,7 +266,7 @@ final class SessionEncryptionReader {
 
     /**
      * Gets the number of messages encrypted with
-     * {@link #encryptMessageToDevice(byte[], OptionalInt)}.
+     * {@link #encryptMessageToDevice(byte[], OptionalLong)}.
      *
      * @return Number of messages encrypted.
      */

--- a/identity/src/main/java/com/android/identity/VerificationHelper.java
+++ b/identity/src/main/java/com/android/identity/VerificationHelper.java
@@ -40,7 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 
@@ -780,7 +780,7 @@ public class VerificationHelper {
             return;
         }
 
-        Pair<byte[], OptionalInt> decryptedMessage = null;
+        Pair<byte[], OptionalLong> decryptedMessage = null;
         try {
             decryptedMessage = mSessionEncryptionReader.decryptMessageFromDevice(data);
         } catch (Exception e) {
@@ -801,9 +801,9 @@ public class VerificationHelper {
                 mDataTransport.close();
                 reportError(new Error("No data and no status in SessionData"));
             } else {
-                int statusCode = decryptedMessage.second.getAsInt();
+                long statusCode = decryptedMessage.second.getAsLong();
                 Logger.d(TAG, "SessionData with status code " + statusCode);
-                if (statusCode == 20) {
+                if (statusCode == Constants.SESSION_DATA_STATUS_SESSION_TERMINATION) {
                     mDataTransport.close();
                     reportDeviceDisconnected(false);
                 } else {
@@ -912,7 +912,7 @@ public class VerificationHelper {
                 } else {
                     Log.d(TAG, "Sending generic session termination message");
                     byte[] sessionTermination = mSessionEncryptionReader.encryptMessageToDevice(
-                            null, OptionalInt.of(20));
+                            null, OptionalLong.of(Constants.SESSION_DATA_STATUS_SESSION_TERMINATION));
                     mDataTransport.sendMessage(sessionTermination);
                 }
             } else {
@@ -955,7 +955,7 @@ public class VerificationHelper {
         Logger.dCbor(TAG, "DeviceRequest to send", deviceRequestBytes);
 
         byte[] message = mSessionEncryptionReader.encryptMessageToDevice(
-                deviceRequestBytes, OptionalInt.empty());
+                deviceRequestBytes, OptionalLong.empty());
         Logger.dCbor(TAG, "SessionData to send", message);
         mDataTransport.sendMessage(message);
     }

--- a/identity/src/test/java/com/android/identity/SessionEncryptionDeviceTest.java
+++ b/identity/src/test/java/com/android/identity/SessionEncryptionDeviceTest.java
@@ -78,7 +78,8 @@ public class SessionEncryptionDeviceTest {
         // Check that we parse status correctly.
         result = sessionEncryption.decryptMessageFromReader(
                 Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_TERMINATION));
-        Assert.assertEquals(20, result.second.getAsLong());
+        Assert.assertEquals(Constants.SESSION_DATA_STATUS_SESSION_TERMINATION,
+                result.second.getAsLong());
         Assert.assertNull(result.first);
 
         // Check we can generate messages with status.

--- a/identity/src/test/java/com/android/identity/SessionEncryptionReaderTest.java
+++ b/identity/src/test/java/com/android/identity/SessionEncryptionReaderTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import java.math.BigInteger;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.util.OptionalInt;
+import java.util.OptionalLong;
 
 import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.ByteString;
@@ -72,10 +72,10 @@ public class SessionEncryptionReaderTest {
                         Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_ESTABLISHMENT))),
                 sessionEncryption.encryptMessageToDevice(
                         Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST),
-                        OptionalInt.empty()));
+                        OptionalLong.empty()));
 
         // Check that decryption works.
-        Pair<byte[], OptionalInt> result = sessionEncryption.decryptMessageFromDevice(
+        Pair<byte[], OptionalLong> result = sessionEncryption.decryptMessageFromDevice(
                 Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_DATA));
         Assert.assertFalse(result.second.isPresent());
         Assert.assertArrayEquals(
@@ -85,13 +85,14 @@ public class SessionEncryptionReaderTest {
         // Check that we parse status correctly.
         result = sessionEncryption.decryptMessageFromDevice(
                 Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_TERMINATION));
-        Assert.assertEquals(20, result.second.getAsInt());
+        Assert.assertEquals(Constants.SESSION_DATA_STATUS_SESSION_TERMINATION, result.second.getAsLong());
         Assert.assertNull(result.first);
 
         // Check we can generate messages with status.
         Assert.assertArrayEquals(
                 Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_TERMINATION),
-                sessionEncryption.encryptMessageToDevice(null, OptionalInt.of(20)));
+                sessionEncryption.encryptMessageToDevice(null,
+                        OptionalLong.of(Constants.SESSION_DATA_STATUS_SESSION_TERMINATION)));
 
     }
 }


### PR DESCRIPTION
Previous behavior is that we would just terminate the session. With this change before session termination we send a message with no data and status 10 which according to 18013-5 Table 20 means "Error: session decryption".

It's not clear the standard actually requires an mdoc to do this but unfortunately it's something that certain test suites will check for.

Add new unit test to check the behavior and introduce symbolic constants instead of hardcoding 10 and 20.

Test: New unit test and all unit tests pass.
Test: Manually tested reference apps on two Pixel devices.
Issue: 115
