### PR TITLE
Make it possible to return error codes for data elements.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/transfer/TransferManager.kt
+++ b/appholder/src/main/java/com/android/mdl/app/transfer/TransferManager.kt
@@ -197,6 +197,7 @@ class TransferManager private constructor(private val context: Context) {
                             docType,
                             c,
                             first1,
+                            null,
                             second1
                         )
                     } catch (e: IllegalArgumentException) {

--- a/identity/src/androidTest/java/com/android/identity/PresentationHelperTest.java
+++ b/identity/src/androidTest/java/com/android/identity/PresentationHelperTest.java
@@ -343,6 +343,7 @@ public class PresentationHelperTest {
                             generator.addDocument(request.getDocType(),
                                     result,
                                     issuerSignedDataItemsWithValues,
+                                    null,
                                     encodedIssuerAuth);
                             presentation[0].sendDeviceResponse(generator.generate());
 


### PR DESCRIPTION
Return an error for a data element is possible according to ISO 18013-5:2021 but our DeviceResponseGenerator class didn't provide a way to do this.

This commit doesn't include API in DeviceResponseParser to obtain the errors, this may be done in a future commit.

Test: Unit tests
Issue: 98
