### PR TITLE
Removing code that closes a FileOutputStream before a sync is completed

### DIFF
--- a/identity/src/androidTest/java/com/android/identity/X509CertificateSigningTest.java
+++ b/identity/src/androidTest/java/com/android/identity/X509CertificateSigningTest.java
@@ -100,7 +100,6 @@ public class X509CertificateSigningTest {
             try {
                 outputStream = file.startWrite();
                 outputStream.write(cert.getEncoded());
-                outputStream.close();
                 file.finishWrite(outputStream);
             } catch (IOException e) {
                 if (outputStream != null) {

--- a/identity/src/main/java/com/android/identity/CredentialData.java
+++ b/identity/src/main/java/com/android/identity/CredentialData.java
@@ -697,7 +697,6 @@ class CredentialData {
         try {
             outputStream = file.startWrite();
             outputStream.write(dataToSaveBytes);
-            outputStream.close();
             file.finishWrite(outputStream);
         } catch (IOException e) {
             if (outputStream != null) {


### PR DESCRIPTION
Fixes an issue where the `FileOutputStream` was being closed before the sync is completed in the finishWrite Call. The finishWrite call in its current implementation will handle closing the stream after the sync is attempted.