### PR TITLE
Point `cborEncode` to `cborEncodeWithoutCanonicalizing` thereby making all cbor encodings use nonCanonical()

### DIFF
--- a/identity/src/main/java/com/android/identity/Util.java
+++ b/identity/src/main/java/com/android/identity/Util.java
@@ -180,15 +180,7 @@ class Util {
 
     static @NonNull
     byte[] cborEncode(@NonNull DataItem dataItem) {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try {
-            new CborEncoder(baos).encode(dataItem);
-        } catch (CborException e) {
-            // This should never happen and we don't want cborEncode() to throw since that
-            // would complicate all callers. Log it instead.
-            throw new IllegalStateException("Unexpected failure encoding data", e);
-        }
-        return baos.toByteArray();
+        return cborEncodeWithoutCanonicalizing(dataItem);
     }
 
     static @NonNull


### PR DESCRIPTION
Might be too big of a change to make, not sure if you had other plans to test it more gradually.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR