### PR TITLE
Flag to skip request reader auth structure parsing

### DIFF
--- a/identity/src/main/java/com/android/identity/DeviceRequestParser.java
+++ b/identity/src/main/java/com/android/identity/DeviceRequestParser.java
@@ -83,7 +83,14 @@ public final class DeviceRequestParser {
      * but the signature check fails. The method {@link DocumentRequest#getReaderAuthenticated()}
      * can used to get additional information whether {@code ItemsRequest} was authenticated.
      *
-     * @param skipReaderAuthParseAndCheck - flag to skip force skip parsing the reader auth structre
+     * @param skipReaderAuthParseAndCheck Flag to skip force skip parsing the reader auth structure.
+     *                                    This flag is useful when the user knows that:
+     *                                      - they will ignore the reader auth result (optional in 18013-5)
+     *                                      - and explicitly don't want to parse it
+     *                                    For example, if this code is to be used in production and
+     *                                    there is uncertainty about which devices will have which
+     *                                    security providers, and there is concern about running
+     *                                    into parsing / validating issues.
      * @return a {@link DeviceRequestParser.DeviceRequest} with the parsed data.
      * @throws IllegalArgumentException if the given data isn't valid CBOR or not conforming
      *                                  to the CDDL for its type.

--- a/identity/src/main/java/com/android/identity/DeviceRequestParser.java
+++ b/identity/src/main/java/com/android/identity/DeviceRequestParser.java
@@ -113,6 +113,9 @@ public final class DeviceRequestParser {
      *                                  to the CDDL for its type.
      * @throws IllegalStateException    if required data hasn't been set using the setter
      *                                  methods on this class.
+     * @throws GeneralSecurityException may be thrown if there issues within the default security
+     *                                  provider. Use <code>setSkipReaderAuthParseAndCheck</code> to
+     *                                  skip some usage of security provider in reader auth parsing.
      */
     @NonNull
     public DeviceRequest parse() {


### PR DESCRIPTION
Enabling flag has side effect of automatically treating as an unverified reader.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR