### PR TITLE
Delete Util.cborEncodeWithoutCanonicalizing() and fix static auth data test.

### DIFF
--- a/identity/src/androidTest/java/com/android/identity/DeviceResponseGeneratorTest.java
+++ b/identity/src/androidTest/java/com/android/identity/DeviceResponseGeneratorTest.java
@@ -112,7 +112,7 @@ public class DeviceResponseGeneratorTest {
 
         // Also put in some complicated CBOR to check that we don't accidentally
         // canonicalize this, leading to digest mismatches on the reader side.
-        byte[] rawCbor1 = Util.cborEncodeWithoutCanonicalizing(
+        byte[] rawCbor1 = Util.cborEncode(
                 new CborBuilder()
                         .addMap()
                         .put("a", "foo")
@@ -127,7 +127,7 @@ public class DeviceResponseGeneratorTest {
                 "  'c' : 'baz'\n" +
                 "}", Util.cborPrettyPrint(rawCbor1));
 
-        byte[] rawCbor2 = Util.cborEncodeWithoutCanonicalizing(
+        byte[] rawCbor2 = Util.cborEncode(
                 new CborBuilder()
                         .addMap()
                         .put("c", "baz")

--- a/identity/src/androidTest/java/com/android/identity/StaticAuthDataTest.java
+++ b/identity/src/androidTest/java/com/android/identity/StaticAuthDataTest.java
@@ -42,21 +42,15 @@ public class StaticAuthDataTest {
 
     @Test
     @SmallTest
-    public void testDecodeStaticAuthData() throws Exception {
-        /* Manually builds up CBOR that conforms to EXAMPLE_STATIC_AUTH_DATA_HEX
-         * defined in the bottom of this class. Then checks that decodeStaticAuthData()
-         * decodes it correctly.
-         */
-
-        CborBuilder builder = new CborBuilder();
-        MapBuilder<CborBuilder> outerBuilder = builder.addMap();
-        outerBuilder.addKey("org.namespace");
-        outerBuilder.end();
+    public void testStaticAuthData() throws Exception {
+        // This test checks that the order of the maps in IssuerSignedItem is preserved
+        // when using Utility.encodeStaticAuthData() and that no canonicalization takes
+        // place.
 
         DataItem issuerSignedItem = new CborBuilder()
                 .addMap()
-                .put("digestID", 42)
                 .put("random", new byte[] {0x50, 0x51, 0x52})
+                .put("digestID", 42)
                 .put("elementIdentifier", "dataElementName")
                 .put(new UnicodeString("elementValue"), SimpleValue.NULL)
                 .end()
@@ -71,83 +65,7 @@ public class StaticAuthDataTest {
                 .put(new UnicodeString("elementValue"), SimpleValue.NULL)
                 .end()
                 .build().get(0);
-        byte[] encodedIssuerSignedItem2 = Util.cborEncodeWithoutCanonicalizing(issuerSignedItem2);
-
-        DataItem digestIdMappingItem = new CborBuilder()
-                .addMap()
-                .putArray("org.namespace")
-                .add(Util.cborBuildTaggedByteString(encodedIssuerSignedItem))
-                .add(Util.cborBuildTaggedByteString(encodedIssuerSignedItem2))
-                .end()
-                .end()
-                .build().get(0);
-
-        byte[] staticAuthData = Util.cborEncode(new CborBuilder()
-                .addMap()
-                .put(new UnicodeString("digestIdMapping"), digestIdMappingItem)
-                // Make issuerAuth look like a valid COSE_Sign1
-                .putArray("issuerAuth") // IssuerAuth
-                    .addArray().end()
-                    .add(SimpleValue.NULL)
-                    .add(new byte[] {0x01, 0x02})
-                .end()
-                .end()
-                .build().get(0));
-
-        Assert.assertEquals(EXAMPLE_STATIC_AUTH_DATA_HEX, Util.toHex(staticAuthData));
-
-        // Now check that decodeStaticAuthData() correctly decodes CBOR conforming to this CDDL
-        Pair<Map<String, List<byte[]>>, byte[]> val = Utility.decodeStaticAuthData(staticAuthData);
-        Map<String, List<byte[]>> digestIdMapping = val.first;
-        byte[] encodedStaticAuthData = val.second;
-
-        // Check that the IssuerSignedItem instances are correctly decoded and the order
-        // of the map matches what was put in above
-        Assert.assertEquals(1, digestIdMapping.size());
-        List<byte[]> list = digestIdMapping.get("org.namespace");
-        Assert.assertNotNull(list);
-        Assert.assertEquals(2, list.size());
-        Assert.assertEquals("{\n" +
-                "  'random' : [0x50, 0x51, 0x52],\n" +
-                "  'digestID' : 42,\n" +
-                "  'elementValue' : null,\n" +
-                "  'elementIdentifier' : 'dataElementName'\n" +
-                "}", Util.cborPrettyPrint(list.get(0)));
-        Assert.assertEquals("{\n" +
-                "  'digestID' : 43,\n" +
-                "  'random' : [0x53, 0x54, 0x55],\n" +
-                "  'elementIdentifier' : 'dataElementName2',\n" +
-                "  'elementValue' : null\n" +
-                "}", Util.cborPrettyPrint(list.get(1)));
-    }
-
-    @Test
-    @SmallTest
-    public void testEncodeStaticAuthData() throws Exception {
-        /* Uses encodeStaticAuthData() to build up CBOR that conforms to
-         * EXAMPLE_STATIC_AUTH_DATA_HEX defined in the bottom of this class.
-         * Then checks that the same bytes are produced.
-         */
-
-        DataItem issuerSignedItem = new CborBuilder()
-                .addMap()
-                .put("digestID", 42)
-                .put("random", new byte[] {0x50, 0x51, 0x52})
-                .put("elementIdentifier", "dataElementName")
-                .put(new UnicodeString("elementValue"), SimpleValue.NULL)
-                .end()
-                .build().get(0);
-        byte[] encodedIssuerSignedItem = Util.cborEncode(issuerSignedItem);
-
-        DataItem issuerSignedItem2 = new CborBuilder()
-                .addMap()
-                .put("digestID", 43)
-                .put("random", new byte[] {0x53, 0x54, 0x55})
-                .put("elementIdentifier", "dataElementName2")
-                .put(new UnicodeString("elementValue"), SimpleValue.NULL)
-                .end()
-                .build().get(0);
-        byte[] encodedIssuerSignedItem2 = Util.cborEncodeWithoutCanonicalizing(issuerSignedItem2);
+        byte[] encodedIssuerSignedItem2 = Util.cborEncode(issuerSignedItem2);
 
         Map<String, List<byte[]>> issuerSignedMapping = new HashMap<>();
         issuerSignedMapping.put("org.namespace",
@@ -164,67 +82,59 @@ public class StaticAuthDataTest {
 
         byte[] staticAuthData = Utility.encodeStaticAuthData(issuerSignedMapping, encodedIssuerAuth);
 
-        Assert.assertEquals(EXAMPLE_STATIC_AUTH_DATA_HEX, Util.toHex(staticAuthData));
-    }
+        Assert.assertEquals(
+                "{\n" +
+                        "  \"digestIdMapping\": {\n" +
+                        "    \"org.namespace\": [\n" +
+                        "      24(<< {\n" +
+                        "        \"random\": h'505152',\n" +
+                        "        \"digestID\": 42,\n" +
+                        "        \"elementIdentifier\": \"dataElementName\",\n" +
+                        "        \"elementValue\": null\n" +
+                        "      } >>),\n" +
+                        "      24(<< {\n" +
+                        "        \"digestID\": 43,\n" +
+                        "        \"random\": h'535455',\n" +
+                        "        \"elementIdentifier\": \"dataElementName2\",\n" +
+                        "        \"elementValue\": null\n" +
+                        "      } >>)\n" +
+                        "    ]\n" +
+                        "  },\n" +
+                        "  \"issuerAuth\": [\n" +
+                        "    [],\n" +
+                        "    null,\n" +
+                        "    h'0102'\n" +
+                        "  ]\n" +
+                        "}",
+                CborUtil.toDiagnostics(
+                        staticAuthData,
+                        CborUtil.DIAGNOSTICS_FLAG_EMBEDDED_CBOR + CborUtil.DIAGNOSTICS_FLAG_PRETTY_PRINT));
 
-    // If you go to cbor.me with the hex value below you'll get
-    //
-    //  {
-    //    "issuerAuth": [[], null, << 1, 2 >>],
-    //    "digestIdMapping": {
-    //      "org.namespace": [
-    //        24(<< {
-    //                "random": h'505152',
-    //                "digestID": 42,
-    //                "elementValue": null,
-    //                "elementIdentifier": "dataElementName"
-    //                } >>),
-    //        24(<< {
-    //                "digestID": 43,
-    //                "random": h'535455',
-    //                "elementIdentifier": "dataElementName2",
-    //                "elementValue": null
-    //                } >>)
-    //      ]
-    //    }
-    //  }
-    //
-    // which by inspection matches this CDDL:
-    //
-    //     StaticAuthData = {
-    //         "digestIdMapping": DigestIdMapping,
-    //         "issuerAuth" : IssuerAuth
-    //     }
-    //
-    //     DigestIdMapping = {
-    //         NameSpace =&gt; [ + IssuerSignedItemBytes ]
-    //     }
-    //
-    //     ; Defined in ISO 18013-5
-    //     ;
-    //     NameSpace = String
-    //     DataElementIdentifier = String
-    //     DigestID = uint
-    //     IssuerAuth = COSE_Sign1 ; The payload is MobileSecurityObjectBytes
-    //
-    //     IssuerSignedItemBytes = #6.24(bstr .cbor IssuerSignedItem)
-    //
-    //     IssuerSignedItem = {
-    //       "digestID" : uint,                           ; Digest ID for issuer data auth
-    //       "random" : bstr,                             ; Random value for issuer data auth
-    //       "elementIdentifier" : DataElementIdentifier, ; Data element identifier
-    //       "elementValue" : NULL                        ; Placeholder for Data element value
-    //     }
-    //
-    // TODO: We should add support for 'emb cbor' in Util.cborPrettyPrint() so we can just
-    //   compare against a printed value instead of a hexdump.
-    //
-    private final String EXAMPLE_STATIC_AUTH_DATA_HEX =
-            "a26f64696765737449644d617070696e67a16d6f72672e6e616d657370616365"
-          + "82d8185847a4686469676573744944182a6672616e646f6d4350515271656c65"
-          + "6d656e744964656e7469666965726f64617461456c656d656e744e616d656c65"
-          + "6c656d656e7456616c7565f6d8185848a4686469676573744944182b6672616e"
-          + "646f6d4353545571656c656d656e744964656e7469666965727064617461456c"
-          + "656d656e744e616d65326c656c656d656e7456616c7565f66a69737375657241"
-          + "7574688380f6420102";
+        // Now check we can decode it
+        Pair<Map<String, List<byte[]>>, byte[]> val = Utility.decodeStaticAuthData(staticAuthData);
+        Map<String, List<byte[]>> digestIdMapping = val.first;
+
+        // Check that the IssuerSignedItem instances are correctly decoded and the order
+        // of the map matches what was put in above
+        Assert.assertEquals(1, digestIdMapping.size());
+        List<byte[]> list = digestIdMapping.get("org.namespace");
+        Assert.assertNotNull(list);
+        Assert.assertEquals(2, list.size());
+        Assert.assertEquals(
+                "{\n" +
+                        "  \"random\": h'505152',\n" +
+                        "  \"digestID\": 42,\n" +
+                        "  \"elementIdentifier\": \"dataElementName\",\n" +
+                        "  \"elementValue\": null\n" +
+                        "}",
+                CborUtil.toDiagnostics(list.get(0), CborUtil.DIAGNOSTICS_FLAG_PRETTY_PRINT));
+        Assert.assertEquals(
+                "{\n" +
+                        "  \"digestID\": 43,\n" +
+                        "  \"random\": h'535455',\n" +
+                        "  \"elementIdentifier\": \"dataElementName2\",\n" +
+                        "  \"elementValue\": null\n" +
+                        "}",
+                CborUtil.toDiagnostics(list.get(1), CborUtil.DIAGNOSTICS_FLAG_PRETTY_PRINT));
+    }
 }

--- a/identity/src/main/java/com/android/identity/CredentialData.java
+++ b/identity/src/main/java/com/android/identity/CredentialData.java
@@ -189,7 +189,7 @@ class CredentialData {
             }
 
             DataItem cborValue = map.get(new UnicodeString("value"));
-            byte[] data = Util.cborEncodeWithoutCanonicalizing(cborValue);
+            byte[] data = Util.cborEncode(cborValue);
             builder.putEntry(namespaceName, name, accessControlProfileIds, data);
         }
 
@@ -784,7 +784,7 @@ class CredentialData {
                 | KeyStoreException e) {
             throw new RuntimeException("Error encrypting CBOR for saving to disk", e);
         }
-        return Util.cborEncodeWithoutCanonicalizing(builder.build().get(0));
+        return Util.cborEncode(builder.build().get(0));
     }
 
     private void saveToDiskAuthKeys(MapBuilder<CborBuilder> map) {

--- a/identity/src/main/java/com/android/identity/DeviceResponseGenerator.java
+++ b/identity/src/main/java/com/android/identity/DeviceResponseGenerator.java
@@ -225,6 +225,6 @@ public final class DeviceResponseGenerator {
         mapBuilder.put("status", mStatusCode);
         mapBuilder.end();
 
-        return Util.cborEncodeWithoutCanonicalizing(deviceResponseBuilder.build().get(0));
+        return Util.cborEncode(deviceResponseBuilder.build().get(0));
     }
 }

--- a/identity/src/main/java/com/android/identity/DeviceResponseParser.java
+++ b/identity/src/main/java/com/android/identity/DeviceResponseParser.java
@@ -266,7 +266,7 @@ public final class DeviceResponseParser {
                     }
                     boolean digestMatch = Arrays.equals(expectedDigest, digest);
                     builder.addIssuerEntry(nameSpace, elementName,
-                            Util.cborEncodeWithoutCanonicalizing(elementValue),
+                            Util.cborEncode(elementValue),
                             digestMatch);
                 }
             }

--- a/identity/src/main/java/com/android/identity/Util.java
+++ b/identity/src/main/java/com/android/identity/Util.java
@@ -18,7 +18,6 @@ package com.android.identity;
 
 import android.content.Context;
 import android.security.keystore.KeyProperties;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -78,7 +77,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.Queue;
 import java.util.TimeZone;
 import java.util.UUID;
 
@@ -180,11 +178,6 @@ class Util {
 
     static @NonNull
     byte[] cborEncode(@NonNull DataItem dataItem) {
-        return cborEncodeWithoutCanonicalizing(dataItem);
-    }
-
-    static @NonNull
-    byte[] cborEncodeWithoutCanonicalizing(@NonNull DataItem dataItem) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try {
             new CborEncoder(baos).nonCanonical().encode(dataItem);
@@ -1515,7 +1508,7 @@ class Util {
         issuerSignedItem.put(new UnicodeString("elementValue"), elementValue);
 
         // By using the non-canonical encoder the order is preserved.
-        return Util.cborEncodeWithoutCanonicalizing(issuerSignedItem);
+        return Util.cborEncode(issuerSignedItem);
     }
 
     static @NonNull
@@ -1810,7 +1803,7 @@ class Util {
         if (dataItem == null) {
             return -1;
         }
-        return cborEncodeWithoutCanonicalizing(dataItem).length;
+        return cborEncode(dataItem).length;
     }
 
     /**

--- a/identity/src/test/java/com/android/identity/UtilTest.java
+++ b/identity/src/test/java/com/android/identity/UtilTest.java
@@ -40,11 +40,9 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.PublicKey;
 import java.security.Security;
 import java.security.Signature;
 import java.security.cert.X509Certificate;
-import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -666,7 +664,7 @@ public class UtilTest {
                 .put("elementIdentifier", "foo")
                 .end()
                 .build().get(0);
-        encoded = Util.cborEncodeWithoutCanonicalizing(di);
+        encoded = Util.cborEncode(di);
         assertEquals("{\n" +
                 "  'random' : [0x01, 0x02, 0x03],\n" +
                 "  'digestID' : 42,\n" +
@@ -690,7 +688,7 @@ public class UtilTest {
                 .put(new UnicodeString("elementValue"), SimpleValue.NULL)
                 .end()
                 .build().get(0);
-        encoded = Util.cborEncodeWithoutCanonicalizing(di);
+        encoded = Util.cborEncode(di);
         assertEquals("{\n" +
                 "  'digestID' : 42,\n" +
                 "  'random' : [0x01, 0x02, 0x03],\n" +


### PR DESCRIPTION
Since Util.cborEncode() is equivalent now, just use that.

Also simplify the StaticAuthDataTest to use the new CborUtil.toDiagnostics() which can print embedded CBOR.

Test: All unit tests pass.
