### PR TITLE
Change NFC AC record TNF ID to 0x04 (NFC Forum external type) 

### DIFF
--- a/identity/src/main/java/com/android/identity/ConnectionMethod.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethod.java
@@ -81,7 +81,7 @@ public abstract class ConnectionMethod {
     ConnectionMethod fromNdefRecord(@NonNull NdefRecord record, boolean isForHandoverSelect) {
         // BLE Carrier Configuration record
         //
-        if (record.getTnf() == 0x02
+        if (record.getTnf() == NdefRecord.TNF_MIME_MEDIA
                 && Arrays.equals(record.getType(),
                 "application/vnd.bluetooth.le.oob".getBytes(UTF_8))
                 && Arrays.equals(record.getId(), "0".getBytes(UTF_8))) {
@@ -90,7 +90,7 @@ public abstract class ConnectionMethod {
 
         // Wifi Aware Carrier Configuration record
         //
-        if (record.getTnf() == 0x02
+        if (record.getTnf() == NdefRecord.TNF_MIME_MEDIA
                 && Arrays.equals(record.getType(),
                 "application/vnd.wfa.nan".getBytes(UTF_8))
                 && Arrays.equals(record.getId(), "W".getBytes(UTF_8))) {
@@ -105,7 +105,7 @@ public abstract class ConnectionMethod {
 
         // NFC Carrier Configuration record
         //
-        if (record.getTnf() == 0x02
+        if (record.getTnf() == NdefRecord.TNF_EXTERNAL_TYPE
                 && Arrays.equals(record.getType(),
                 "iso.org:18013:nfc".getBytes(UTF_8))
                 && Arrays.equals(record.getId(), "nfc".getBytes(UTF_8))) {

--- a/identity/src/main/java/com/android/identity/ConnectionMethodNfc.java
+++ b/identity/src/main/java/com/android/identity/ConnectionMethodNfc.java
@@ -208,7 +208,7 @@ public class ConnectionMethodNfc extends ConnectionMethod {
         encodeInt(0x02, (int) mResponseDataFieldMaxLength, baos);
         byte[] oobData = baos.toByteArray();
 
-        NdefRecord record = new NdefRecord(NdefRecord.TNF_MIME_MEDIA,
+        NdefRecord record = new NdefRecord(NdefRecord.TNF_EXTERNAL_TYPE,
                 "iso.org:18013:nfc".getBytes(UTF_8),
                 carrierDataReference,
                 oobData);

--- a/identity/src/main/java/com/android/identity/NfcEngagementHelper.java
+++ b/identity/src/main/java/com/android/identity/NfcEngagementHelper.java
@@ -673,7 +673,8 @@ public class NfcEngagementHelper {
             // This parses the various carrier specific NDEF records, see
             // DataTransport.parseNdefRecord() for details.
             //
-            if (r.getTnf() == NdefRecord.TNF_MIME_MEDIA) {
+            if ((r.getTnf() == NdefRecord.TNF_MIME_MEDIA) ||
+                    (r.getTnf() == NdefRecord.TNF_EXTERNAL_TYPE)) {
                 ConnectionMethod cm = ConnectionMethod.fromNdefRecord(r, false);
                 if (cm != null) {
                     Logger.d(TAG, "Found connectionMethod: " + cm);

--- a/identity/src/main/java/com/android/identity/NfcUtil.java
+++ b/identity/src/main/java/com/android/identity/NfcUtil.java
@@ -302,7 +302,8 @@ class NfcUtil {
             // This parses the various carrier specific NDEF records, see
             // DataTransport.parseNdefRecord() for details.
             //
-            if (r.getTnf() == NdefRecord.TNF_MIME_MEDIA) {
+            if ((r.getTnf() == NdefRecord.TNF_MIME_MEDIA) ||
+                    (r.getTnf() == NdefRecord.TNF_EXTERNAL_TYPE)) {
                 ConnectionMethod cm = ConnectionMethod.fromNdefRecord(r, true);
                 if (cm != null) {
                     ret.connectionMethods.add(cm);

--- a/identity/src/main/java/com/android/identity/VerificationHelper.java
+++ b/identity/src/main/java/com/android/identity/VerificationHelper.java
@@ -636,7 +636,8 @@ public class VerificationHelper {
                             encodedDeviceEngagement = r.getPayload();
                             Logger.dCbor(TAG, "Device Engagement from NFC negotiated handover",
                                     encodedDeviceEngagement);
-                        } else if (r.getTnf() == NdefRecord.TNF_MIME_MEDIA) {
+                        } else if ((r.getTnf() == NdefRecord.TNF_MIME_MEDIA) ||
+                                (r.getTnf() == NdefRecord.TNF_EXTERNAL_TYPE)) {
                             ConnectionMethod cm = ConnectionMethod.fromNdefRecord(r, true);
                             if (cm != null) {
                                 parsedCms.add(cm);


### PR DESCRIPTION
Google apps use TNF == 0x02 (Media-type) for all AC records including NFC which is wrong
According to mDL spec, it should be 0x04 (NFC Forum external type) 

Test: Manually (used other vendor mDL holder which detects the issue)

Fixes #243

- [x] Tests pass