### PR TITLE
Add CredentialInvalidatedException.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/viewmodel/TransferDocumentViewModel.kt
+++ b/appholder/src/main/java/com/android/mdl/app/viewmodel/TransferDocumentViewModel.kt
@@ -1,13 +1,16 @@
 package com.android.mdl.app.viewmodel
 
 import android.app.Application
+import android.util.Log
 import android.view.View
+import android.widget.Toast
 import androidx.databinding.ObservableField
 import androidx.databinding.ObservableInt
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.android.identity.Constants.DEVICE_RESPONSE_STATUS_OK
+import com.android.identity.CredentialInvalidatedException
 import com.android.identity.DeviceRequestParser
 import com.android.identity.DeviceResponseGenerator
 import com.android.mdl.app.R
@@ -112,6 +115,12 @@ class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
                 if (authNeeded) {
                     return false
                 }
+            } catch (e: CredentialInvalidatedException) {
+                logWarning("Credential '${signedDocument.identityCredentialName}' is invalid. Deleting.")
+                documentManager.deleteCredentialByName(signedDocument.identityCredentialName)
+                Toast.makeText(app.applicationContext, "Deleting invalid credential "
+                    + signedDocument.identityCredentialName,
+                    Toast.LENGTH_SHORT).show()
             } catch (e: NoSuchElementException) {
                 logWarning("No requestedDocument for " + signedDocument.documentType)
             }

--- a/identity/src/main/java/com/android/identity/CredentialData.java
+++ b/identity/src/main/java/com/android/identity/CredentialData.java
@@ -1524,6 +1524,9 @@ class CredentialData {
             KeyStore ks = KeyStore.getInstance("AndroidKeyStore");
             ks.load(null);
             KeyStore.Entry entry = ks.getEntry(acpAlias, null);
+            if (entry == null) {
+                throw new CredentialInvalidatedException("Failed getting key used for credential");
+            }
             SecretKey secretKey = ((KeyStore.SecretKeyEntry) entry).getSecretKey();
 
             Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");

--- a/identity/src/main/java/com/android/identity/CredentialInvalidatedException.java
+++ b/identity/src/main/java/com/android/identity/CredentialInvalidatedException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Thrown if underlying key material for a credential has been invalidated.
+ */
+public class CredentialInvalidatedException extends IllegalStateException {
+    /**
+     * Constructs a new {@link CredentialInvalidatedException} exception.
+     *
+     * @param message the detail message.
+     */
+    public CredentialInvalidatedException(@NonNull String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new {@link CredentialInvalidatedException} exception.
+     *
+     * @param message the detail message.
+     * @param cause   the cause.
+     */
+    public CredentialInvalidatedException(@NonNull String message, @NonNull Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/identity/src/main/java/com/android/identity/IdentityCredential.java
+++ b/identity/src/main/java/com/android/identity/IdentityCredential.java
@@ -327,6 +327,7 @@ public abstract class IdentityCredential {
      * @throws InvalidRequestMessageException         if the requestMessage is malformed.
      * @throws EphemeralPublicKeyNotFoundException    if the ephemeral public key was not found in
      *                                                the session transcript.
+     * @throws CredentialInvalidatedException         if the credential has been invalidated
      * @deprecated Use {@link PresentationSession} instead.
      */
     @Deprecated

--- a/identity/src/main/java/com/android/identity/PresentationSession.java
+++ b/identity/src/main/java/com/android/identity/PresentationSession.java
@@ -158,6 +158,7 @@ public abstract class PresentationSession {
      *                                                the signature failed to validate.
      * @throws EphemeralPublicKeyNotFoundException    if the ephemeral public key was not found in
      *                                                the session transcript.
+     * @throws CredentialInvalidatedException         if the credential has been invalidated
      */
     public abstract @Nullable CredentialDataResult getCredentialData(
             @NonNull String credentialName, @NonNull CredentialDataRequest request)


### PR DESCRIPTION
This is a runtime exception and it's thrown if the user has removed the LSKF since the credential was created.

Also update appholder to catch this exception and delete the credential if caught. Also notify the user of this action with a toast.

Manually test this behavior by creating a credential w/ user auth when the device has a LSKF. Then remove the LSKF and try presenting it.

Test: Manually tested
Issue: 247

Fixes #247
