### PR TITLE
Better handling when the reader sends an invalid COSE_Key for EReaderKey

### DIFF
--- a/identity/src/main/java/com/android/identity/SessionEncryptionDevice.java
+++ b/identity/src/main/java/com/android/identity/SessionEncryptionDevice.java
@@ -158,6 +158,14 @@ final class SessionEncryptionDevice {
         return Util.cborEncode(builder.build().get(0));
     }
 
+    static public @NonNull byte[] encodeStatusToReader(long statusCode) {
+        CborBuilder builder = new CborBuilder();
+        MapBuilder<CborBuilder> mapBuilder = builder.addMap();
+        mapBuilder.put("status", statusCode);
+        mapBuilder.end();
+        return Util.cborEncode(builder.build().get(0));
+    }
+
     /**
      * Decrypts a message received from the remote mDL reader.
      *

--- a/identity/src/main/java/com/android/identity/Util.java
+++ b/identity/src/main/java/com/android/identity/Util.java
@@ -966,6 +966,25 @@ class Util {
         return item;
     }
 
+    // Used for testing only, to create an invalid COSE_Key
+    static @NonNull
+    DataItem cborBuildCoseKeyWithMalformedYPoint(@NonNull PublicKey key) {
+        ECPublicKey ecKey = (ECPublicKey) key;
+        ECPoint w = ecKey.getW();
+        BigInteger malformedY = BigInteger.valueOf(42);
+        byte[] x = sec1EncodeFieldElementAsOctetString(32, w.getAffineX());
+        byte[] y = sec1EncodeFieldElementAsOctetString(32, malformedY);
+        DataItem item = new CborBuilder()
+                .addMap()
+                .put(COSE_KEY_KTY, COSE_KEY_TYPE_EC2)
+                .put(COSE_KEY_EC2_CRV, COSE_KEY_EC2_CRV_P256)
+                .put(COSE_KEY_EC2_X, x)
+                .put(COSE_KEY_EC2_Y, y)
+                .end()
+                .build().get(0);
+        return item;
+    }
+
     static boolean cborMapHasKey(@NonNull DataItem map, @NonNull String key) {
         DataItem item = castTo(Map.class, map).get(new UnicodeString(key));
         return item != null;


### PR DESCRIPTION
In this case, send status code 10 to the reader to end the session and report an error to the application.

Fixes #115.

Test: New unit test and all tests pass.
Issue: 115
