### PR TITLE
Keystore: Disable StrongBox usage for now.

### DIFF
--- a/identity/src/main/java/com/android/identity/CredentialData.java
+++ b/identity/src/main/java/com/android/identity/CredentialData.java
@@ -1310,12 +1310,15 @@ class CredentialData {
                             .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512);
 
                     boolean isStrongBoxBacked = false;
+                    /* Disable StrongBox usage for now, see Issue #259 for details
+                     *
                     PackageManager pm = mContext.getPackageManager();
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P &&
                             pm.hasSystemFeature(PackageManager.FEATURE_STRONGBOX_KEYSTORE)) {
                         isStrongBoxBacked = true;
                         builder.setIsStrongBoxBacked(true);
                     }
+                     */
                     kpg.initialize(builder.build());
                     kpg.generateKeyPair();
                     Log.i(TAG, "AuthKey created, strongBoxBacked=" + isStrongBoxBacked);


### PR DESCRIPTION
StrongBox is unfortunately broken on some older devices so we need a way to have the application to specify whether to use it or not, depending on e.g. make/model of the device. A future update will make this configurable. See Issue #259 for details.

Test: Manually tested.
