### PR TITLE
Slightly refactor API to make it possible to properly auto-close connections.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/MainActivity.kt
+++ b/appholder/src/main/java/com/android/mdl/app/MainActivity.kt
@@ -112,10 +112,7 @@ class MainActivity : AppCompatActivity() {
 
         viewModel.startPresentationReverseEngagement(mdocUri, originInfos)
         val navController = findNavController(R.id.nav_host_fragment)
-        navController.navigate(
-            R.id.transferDocumentFragment,
-            bundleOf(TransferDocumentFragment.CLOSE_AFTER_SERVING_KEY to true)
-        )
+        navController.navigate(R.id.transferDocumentFragment)
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/appholder/src/main/java/com/android/mdl/app/fragment/TransferDocumentFragment.kt
+++ b/appholder/src/main/java/com/android/mdl/app/fragment/TransferDocumentFragment.kt
@@ -23,18 +23,10 @@ import com.android.mdl.app.util.log
 import com.android.mdl.app.viewmodel.TransferDocumentViewModel
 
 class TransferDocumentFragment : Fragment() {
-
-    companion object {
-        const val CLOSE_AFTER_SERVING_KEY = "closeAfterServing"
-    }
-
     private var _binding: FragmentTransferDocumentBinding? = null
     private val binding get() = _binding!!
 
     private val viewModel: TransferDocumentViewModel by activityViewModels()
-    private val closeAfterServing by lazy {
-        arguments?.getBoolean("closeAfterServing", false) ?: false
-    }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -85,12 +77,6 @@ class TransferDocumentFragment : Fragment() {
 
     private fun onRequestServed() {
         log("Request Served")
-        if (PreferencesHelper.isConnectionAutoCloseEnabled()) {
-            onCloseConnection(
-                sendSessionTerminationMessage = true,
-                useTransportSpecificSessionTermination = false
-            )
-        }
     }
 
     private fun onTransferRequested() {
@@ -156,6 +142,11 @@ class TransferDocumentFragment : Fragment() {
                 // Send response with 0 documents
                 viewModel.sendResponseForSelection()
             }
+            // TODO: this is kind of a hack but we really need to move the sending of the
+            //  message to here instead of in the auth confirmation dialog
+            if (PreferencesHelper.isConnectionAutoCloseEnabled()) {
+                hideButtons()
+            }
         } catch (e: Exception) {
             val message = "On request received error: ${e.message}"
             log(message, e)
@@ -181,9 +172,6 @@ class TransferDocumentFragment : Fragment() {
         log("Disconnected")
         hideButtons()
         TransferManager.getInstance(requireContext()).disconnect()
-        if (closeAfterServing) {
-            requireActivity().finish()
-        }
     }
 
     private fun onTransferError() {

--- a/appholder/src/main/java/com/android/mdl/app/transfer/QrCommunicationSetup.kt
+++ b/appholder/src/main/java/com/android/mdl/app/transfer/QrCommunicationSetup.kt
@@ -52,7 +52,6 @@ class QrCommunicationSetup(
                 qrEngagement.handover
             )
             deviceRetrievalHelper = builder.build()
-            deviceRetrievalHelper?.setSendSessionTerminationMessage(true)
             qrEngagement.close()
             onDeviceRetrievalHelperReady(session, deviceRetrievalHelper!!)
         }

--- a/appholder/src/main/java/com/android/mdl/app/transfer/ReverseQrCommunicationSetup.kt
+++ b/appholder/src/main/java/com/android/mdl/app/transfer/ReverseQrCommunicationSetup.kt
@@ -72,7 +72,6 @@ class ReverseQrCommunicationSetup(
             session
         ).useReverseEngagement(transport, encodedReaderEngagement, origins)
         presentation = builder.build()
-        presentation?.setSendSessionTerminationMessage(true)
         onPresentationReady(session, presentation!!)
     }
 }

--- a/appholder/src/main/java/com/android/mdl/app/transfer/TransferManager.kt
+++ b/appholder/src/main/java/com/android/mdl/app/transfer/TransferManager.kt
@@ -255,8 +255,11 @@ class TransferManager private constructor(private val context: Context) {
         return null
     }
 
-    fun sendResponse(deviceResponse: ByteArray) {
-        communication.sendResponse(deviceResponse)
+    fun sendResponse(deviceResponse: ByteArray, closeAfterSending: Boolean) {
+        communication.sendResponse(deviceResponse, closeAfterSending)
+        if (closeAfterSending) {
+            disconnect()
+        }
     }
 
     fun readDocumentEntries(document: Document): CredentialDataResult.Entries? {

--- a/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
@@ -82,7 +82,6 @@ class NfcEngagementHandler : HostApduService() {
                 engagementHelper.handover
             )
             presentation = builder.build()
-            presentation?.setSendSessionTerminationMessage(true)
             communication.setupPresentation(presentation!!)
             engagementHelper.close()
             transferManager.updateStatus(TransferStatus.CONNECTED)

--- a/appholder/src/main/java/com/android/mdl/app/viewmodel/TransferDocumentViewModel.kt
+++ b/appholder/src/main/java/com/android/mdl/app/viewmodel/TransferDocumentViewModel.kt
@@ -9,6 +9,7 @@ import androidx.databinding.ObservableInt
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import com.android.identity.Constants
 import com.android.identity.Constants.DEVICE_RESPONSE_STATUS_OK
 import com.android.identity.CredentialInvalidatedException
 import com.android.identity.DeviceRequestParser
@@ -22,6 +23,9 @@ import com.android.mdl.app.document.DocumentManager
 import com.android.mdl.app.transfer.TransferManager
 import com.android.mdl.app.util.TransferStatus
 import com.android.mdl.app.util.logWarning
+import com.android.mdl.app.util.PreferencesHelper
+import java.util.Optional
+import java.util.OptionalLong
 
 class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
 
@@ -98,6 +102,7 @@ class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
         requestedElements.addAll(result)
     }
 
+    // Returns true if a response was sent, false if additional auth is needed
     fun sendResponseForSelection(): Boolean {
         val elementsToSend = signedElements.collect()
         val response = DeviceResponseGenerator(DEVICE_RESPONSE_STATUS_OK)
@@ -125,7 +130,7 @@ class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
                 logWarning("No requestedDocument for " + signedDocument.documentType)
             }
         }
-        transferManager.sendResponse(response.generate())
+        transferManager.sendResponse(response.generate(), PreferencesHelper.isConnectionAutoCloseEnabled())
         transferManager.setResponseServed()
         val documentsCount = elementsToSend.count()
         documentsSent.set(app.getString(R.string.txt_documents_sent, documentsCount))

--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/DeviceEngagementFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/DeviceEngagementFragment.kt
@@ -121,6 +121,7 @@ class DeviceEngagementFragment : Fragment() {
                 }
 
                 TransferStatus.ERROR -> {
+                    // TODO: Pass and show the actual text of the exception here.
                     Log.d(LOG_TAG, "Error received")
                     Toast.makeText(
                         requireContext(), "Error connecting to holder",

--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/TransferFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/TransferFragment.kt
@@ -91,13 +91,10 @@ class TransferFragment : Fragment() {
                     findNavController().navigate(R.id.action_Transfer_to_ShowDocument)
                 }
                 TransferStatus.DISCONNECTED -> {
-                    Toast.makeText(
-                        requireContext(), "Error: Disconnected",
-                        Toast.LENGTH_SHORT
-                    ).show()
-                    findNavController().navigate(R.id.action_Transfer_to_RequestOptions)
+                    binding.tvStatus.text = "Disconnected"
                 }
                 TransferStatus.ERROR -> {
+                    // TODO: Pass and show the actual text of the exception here.
                     Toast.makeText(
                         requireContext(), "Error connecting to holder",
                         Toast.LENGTH_SHORT

--- a/identity/src/androidTest/java/com/android/identity/DeviceRetrievalHelperTest.java
+++ b/identity/src/androidTest/java/com/android/identity/DeviceRetrievalHelperTest.java
@@ -347,7 +347,7 @@ public class DeviceRetrievalHelperTest {
                                     issuerSignedDataItemsWithValues,
                                     null,
                                     encodedIssuerAuth);
-                            presentation[0].sendDeviceResponse(generator.generate());
+                            presentation[0].sendDeviceResponse(generator.generate(), OptionalLong.empty());
 
                         } catch (NoAuthenticationKeyAvailableException |
                                 InvalidReaderSignatureException |

--- a/identity/src/main/java/com/android/identity/DataTransport.java
+++ b/identity/src/main/java/com/android/identity/DataTransport.java
@@ -120,7 +120,7 @@ public abstract class DataTransport {
      * call this right after {@link #connect()}, data will be queued up and sent once a connection
      * has been established.
      *
-     * @param data the data to send
+     * @param data the data to send, must be at least one byte.
      */
     abstract void sendMessage(@NonNull byte[] data);
 

--- a/identity/src/main/java/com/android/identity/DataTransportBleCentralClientMode.java
+++ b/identity/src/main/java/com/android/identity/DataTransportBleCentralClientMode.java
@@ -72,6 +72,7 @@ class DataTransportBleCentralClientMode extends DataTransportBle {
     ScanCallback mScanCallback = new ScanCallback() {
         @Override
         public void onScanResult(int callbackType, ScanResult result) {
+            Logger.d(TAG, "onScanCallback: callbackType=" + callbackType + " result=" + result);
             // if we already scanned and connect to device we don't want to
             // reconnect to another GattClient instance.
             if (mIsConnecting) {
@@ -343,6 +344,9 @@ class DataTransportBleCentralClientMode extends DataTransportBle {
 
     @Override
     public void sendMessage(@NonNull byte[] data) {
+        if (data.length == 0) {
+            throw new IllegalArgumentException("Data to send cannot be empty");
+        }
         if (mGattServer != null) {
             mGattServer.sendMessage(data);
         } else if (mGattClient != null) {

--- a/identity/src/main/java/com/android/identity/DataTransportBlePeripheralServerMode.java
+++ b/identity/src/main/java/com/android/identity/DataTransportBlePeripheralServerMode.java
@@ -336,6 +336,9 @@ class DataTransportBlePeripheralServerMode extends DataTransportBle {
 
     @Override
     public void sendMessage(@NonNull byte[] data) {
+        if (data.length == 0) {
+            throw new IllegalArgumentException("Data to send cannot be empty");
+        }
         if (mGattServer != null) {
             mGattServer.sendMessage(data);
         } else if (mGattClient != null) {


### PR DESCRIPTION
Fix a problem with BLE data transport methods where data isn't flushed before the connection is closed.

Also rework DeviceRetrievalHelper.SendMessage() so it's possible to specify the status code in addition or instead of the DeviceResponse CBOR to send.

Combined, these two fixes makes it possible for an application to send status 20 (session termination) in addition to DeviceResponse. Use this to implement the "Auto close connection" preference in the holder application. Fix up VerificationHelper so looks at both status and data and it behaves in the expected way when the holder does this.

This has been tested with both mdoc BLE central client mode and mdoc BLE peripheral server mode and with the case where holder uses "auto close connection" and not. For the latter, was also tested with either party terminating the connection both with using status 20 and when using the transport-specific way to terminate (BLE characteristic).

Add sendTransportSpecificTermination() which can be used instead of sending status 20. Also remove setSendSessionTerminationMessage() since the app is now expected to always perform session termination itself before calling disconnect().

Fixes #270.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR