### PR TITLE
reader: Soften warning when portrait is missing.

### DIFF
--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
@@ -167,11 +167,13 @@ class ShowDocumentFragment : Fragment() {
 
         for (doc in documents) {
             if (!checkPortraitPresenceIfRequired(doc)) {
-                // provide an informed exit from the request if the holder opts not to share the portrait image
-                sb.append("<h3>WARNING: <font color=\"red\">No portrait image provided for ${doc.docType}.</font></h3><br>")
-                sb.append("<h3>This means it's not possible to verify the presenter is the authorized holder of the mDL.<br>")
-                sb.append("<br>You should avoid any business transactions or inquiries until proper identification is confirmed.</h3>")
-                return sb.toString()
+                // Warn if portrait isn't included in the response.
+                sb.append("<h3>WARNING: <font color=\"red\">No portrait image provided "
+                        + "for ${doc.docType}.</font></h3><br>")
+                sb.append("<i>This means it's not possible to verify the presenter is the authorized "
+                        + "holder. Be careful doing any business transactions or inquiries until "
+                        + "proper identification is confirmed.</i><br>")
+                sb.append("<br>")
             }
         }
 


### PR DESCRIPTION
PR #276 introduced a warning if the portrait was missing which is good but it's too aggressive to not show the rest of the response. Instead, show the warning where the portrait would normally be but continue to show the rest of the response.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR