### PR TITLE
Update build.gradle to use Java 1.8

### DIFF
--- a/wwwverifier/build.gradle
+++ b/wwwverifier/build.gradle
@@ -58,8 +58,8 @@ appengine {
 group = 'com.google.sps'
 version = '1'
 description = 'portfolio'
-java.sourceCompatibility = JavaVersion.VERSION_11
-java.targetCompatibility = JavaVersion.VERSION_11
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+java.targetCompatibility = JavaVersion.VERSION_1_8
 
 publishing {
   publications {


### PR DESCRIPTION
Encountered the following error after deploying to app engine:
```
com/android/identity/wwwreader/RequestServlet has been compiled by a more recent version of the Java Runtime (class file version 55.0
--
this version of the Java Runtime only recognizes class file versions up to 52.0

```

Noticed that the Java 11 is used in build.gradle for both source and target compatibility. Updating it to use Java 1.8