### PR TITLE
Add new credential store.

### DIFF
--- a/identity-android/src/androidTest/java/com/android/identity/android/credential/AndroidKeystoreCredentialStoreTest.java
+++ b/identity-android/src/androidTest/java/com/android/identity/android/credential/AndroidKeystoreCredentialStoreTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity.android.credential;
+
+import android.content.Context;
+
+import com.android.identity.AndroidAttestationExtensionParser;
+import com.android.identity.android.keystore.AndroidKeystore;
+import com.android.identity.android.storage.AndroidStorageEngine;
+import com.android.identity.credential.Credential;
+import com.android.identity.credential.CredentialStore;
+import com.android.identity.keystore.KeystoreEngine;
+import com.android.identity.keystore.KeystoreEngineRepository;
+import com.android.identity.storage.StorageEngine;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+// See CredentialStoreTest in non-Android tests for main tests for CredentialStore. These
+// tests are just for the Android-specific bits including attestation.
+//
+public class AndroidKeystoreCredentialStoreTest {
+
+    StorageEngine mStorageEngine;
+
+    KeystoreEngine mKeystoreEngine;
+
+    KeystoreEngineRepository mKeystoreEngineRepository;
+
+    @Before
+    public void setup() {
+        Context context = androidx.test.InstrumentationRegistry.getTargetContext();
+        File storageDir = new File(context.getDataDir(), "ic-testing");
+        mStorageEngine = new AndroidStorageEngine.Builder(context, storageDir).build();
+
+        mKeystoreEngineRepository = new KeystoreEngineRepository();
+        mKeystoreEngine = new AndroidKeystore(context, mStorageEngine);
+        mKeystoreEngineRepository.addImplementation(mKeystoreEngine);
+    }
+
+    @Test
+    public void testBasic() throws IOException {
+
+        CredentialStore credentialStore = new CredentialStore(
+                mStorageEngine,
+                mKeystoreEngineRepository);
+
+        byte[] credentialKeyAttestationChallenge = new byte[] {10, 11, 12};
+
+        Credential credential = credentialStore.createCredential(
+                "testCredential",
+                new AndroidKeystore.CreateKeySettings.Builder(credentialKeyAttestationChallenge).build());
+        Assert.assertEquals("testCredential", credential.getName());
+        List<X509Certificate> certChain = credential.getAttestation();
+
+        // Check the attestation extension
+        AndroidAttestationExtensionParser parser = new AndroidAttestationExtensionParser(certChain.get(0));
+        Assert.assertArrayEquals(credentialKeyAttestationChallenge, parser.getAttestationChallenge());
+        AndroidAttestationExtensionParser.SecurityLevel securityLevel = parser.getKeymasterSecurityLevel();
+        Assert.assertEquals(AndroidAttestationExtensionParser.SecurityLevel.TRUSTED_ENVIRONMENT, securityLevel);
+
+        // Create pending authentication key and check its attestation
+        byte[] authKeyChallenge = new byte[] {20, 21, 22};
+        Credential.PendingAuthenticationKey pendingAuthenticationKey =
+                credential.createPendingAuthenticationKey(new AndroidKeystore.CreateKeySettings.Builder(authKeyChallenge)
+                        .setUserAuthenticationRequired(true, 30*1000)
+                        .build(),
+                        null);
+        parser = new AndroidAttestationExtensionParser(pendingAuthenticationKey.getAttestation().get(0));
+        Assert.assertArrayEquals(authKeyChallenge,
+                parser.getAttestationChallenge());
+        Assert.assertEquals(AndroidAttestationExtensionParser.SecurityLevel.TRUSTED_ENVIRONMENT,
+                parser.getKeymasterSecurityLevel());
+
+        // Check we can load the credential...
+        credential = credentialStore.lookupCredential("testCredential");
+        Assert.assertNotNull(credential);
+        Assert.assertEquals("testCredential", credential.getName());
+        List<X509Certificate> certChain2 = credential.getAttestation();
+        Assert.assertEquals(certChain.size(), certChain2.size());
+        for (int n = 0; n < certChain.size(); n++) {
+            Assert.assertEquals(certChain.get(n), certChain2.get(n));
+        }
+
+        Assert.assertNull(credentialStore.lookupCredential("nonExistingCredential"));
+
+        // Check creating a credential with an existing name overwrites the existing one
+        credential = credentialStore.createCredential(
+                "testCredential",
+                new AndroidKeystore.CreateKeySettings.Builder(credentialKeyAttestationChallenge).build());
+        Assert.assertEquals("testCredential", credential.getName());
+        // At least the leaf certificate should be different
+        List<X509Certificate> certChain3 = credential.getAttestation();
+        Assert.assertNotEquals(certChain3.get(0), certChain2.get(0));
+
+        credential = credentialStore.lookupCredential("testCredential");
+        Assert.assertNotNull(credential);
+        Assert.assertEquals("testCredential", credential.getName());
+
+        credentialStore.deleteCredential("testCredential");
+        Assert.assertNull(credentialStore.lookupCredential("testCredential"));
+    }
+}

--- a/identity/src/main/java/com/android/identity/credential/Credential.java
+++ b/identity/src/main/java/com/android/identity/credential/Credential.java
@@ -1,0 +1,1082 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity.credential;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.android.identity.internal.Util;
+import com.android.identity.keystore.KeystoreEngine;
+import com.android.identity.keystore.KeystoreEngineRepository;
+import com.android.identity.storage.StorageEngine;
+import com.android.identity.util.Logger;
+import com.android.identity.util.Timestamp;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.CborDecoder;
+import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.builder.ArrayBuilder;
+import co.nstant.in.cbor.builder.MapBuilder;
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnicodeString;
+
+/**
+ * This class represents a credential created in {@link CredentialStore}.
+ *
+ * <p>Credentials in this store are identified by a name which must be unique
+ * per credential. For each credential an asymmetric key-pair called <em>CredentialKey</em>
+ * is generated and this key-pair is intended to be the primary identifier for the credential
+ * and used for communication with the credential issuing authority (IA). In particular, the
+ * IA can examine the attestation on <em>CredentialKey</em> to verify that the device is
+ * in a known good state (e.g. verified boot is enabled, the OS is at a sufficiently recent
+ * patch level, it's communicating with the expected Android application, etc.) before
+ * deciding to issue a credential to the device.
+ *
+ * <p>Data can be stored in credentials using the {@link NameSpacedData} abstraction
+ * which contains a set of key/value pairs, organized by namespace. This can be
+ * set and get using {@link #setNameSpacedData(NameSpacedData)} and
+ * {@link #getNameSpacedData()}. Typically this is sent by the issuer at
+ * credential creation and when data in the credential has changed. Additionally,
+ * the application can set/get any data of data it wants using
+ * {@link #setApplicationData(String, byte[])} and {@link #getApplicationData(String)}.
+ * Both kinds of data is persisted for the life-time of the application.
+ *
+ * <p>Each credential may have a number of <em>Authentication Keys</em>
+ * associated with it. These keys are intended to be used in ways specified by the
+ * underlying credential shape but the general idea is that they are created on
+ * the device and then sent to the issuer for certification. The issuer then returns
+ * some shape-specific data related to the key. For Mobile Driving License and MDOCs according
+ * to <a href="https://www.iso.org/standard/69084.html">ISO/IEC 18013-5:2021</a>
+ * the authentication key plays the role of <em>DeviceKey</em> and the issuer-signed
+ * data includes the <em>Mobile Security Object</em> which includes the authentication
+ * key and is signed by the issuer. This is used for anti-cloning and to return data signed
+ * by the device. The way it works in this API is that the application can use
+ * {@link #createPendingAuthenticationKey(KeystoreEngine.CreateKeySettings, AuthenticationKey)}
+ * to get a {@link PendingAuthenticationKey}. With this in hand, the application can use
+ * {@link PendingAuthenticationKey#getAttestation()} and send the attestation
+ * to the issuer for certification. The issuer will then craft credential-shape
+ * specific data (for ISO/IEC 18013-5:2021 it will be a signed MSO which references
+ * the public part of the newly created authentication key) and send it back
+ * to the app. The application can then call
+ * {@link PendingAuthenticationKey#certify(byte[], Timestamp, Timestamp)} to
+ * upgrade the {@link PendingAuthenticationKey} to a {@link AuthenticationKey}.
+ *
+ * <p>At credential presentation time the application first uses {@link CredentialStore}
+ * to find a suitable {@link Credential} for presentation. TODO: link to CredentialRequest
+ * and DeviceResponseGenerator when this part of the code lands.
+ *
+ * <p>There is nothing mDL/MDOC specific about this type, it can be used for any kind
+ * of credential regardless of shape, presentation, or issuance protocol used.
+ */
+public class Credential {
+    private static final String TAG = "Credential";
+    static final String CREDENTIAL_PREFIX = "IC_Credential_";
+
+    static final String CREDENTIAL_KEY_ALIAS_PREFIX = "IC_CredentialKey_";
+
+    static final String AUTHENTICATION_KEY_ALIAS_PREFIX = "IC_AuthenticationKey_";
+
+    private final StorageEngine mStorageEngine;
+    private final KeystoreEngineRepository mKeystoreEngineRepository;
+    private String mName;
+    private String mCredentialKeyAlias;
+
+    private NameSpacedData mNameSpacedData = new NameSpacedData.Builder().build();
+    private KeystoreEngine mKeystoreEngine;
+    private LinkedHashMap<String, byte[]> mApplicationData = new LinkedHashMap<>();
+
+    private List<PendingAuthenticationKey> mPendingAuthenticationKeys = new ArrayList<>();
+    private List<AuthenticationKey> mAuthenticationKeys = new ArrayList<>();
+
+    private long mAuthenticationKeyCounter;
+
+    private Credential(@NonNull StorageEngine storageEngine,
+                       @NonNull KeystoreEngineRepository keystoreEngineRepository) {
+        mStorageEngine = storageEngine;
+        mKeystoreEngineRepository = keystoreEngineRepository;
+    }
+
+    // Called by CredentialStore.createCredential().
+    static Credential create(@NonNull StorageEngine storageEngine,
+                             @NonNull KeystoreEngineRepository keystoreEngineRepository,
+                             @NonNull String name,
+                             @NonNull KeystoreEngine.CreateKeySettings credentialKeySettings) {
+
+        Credential credential = new Credential(storageEngine, keystoreEngineRepository);
+        credential.mName = name;
+        String keystoreEngineClassName = credentialKeySettings.getKeystoreEngineClass().getName();
+        credential.mKeystoreEngine = keystoreEngineRepository.getImplementation(keystoreEngineClassName);
+        if (credential.mKeystoreEngine == null) {
+            throw new IllegalStateException("No KeystoreEngine with name " + keystoreEngineClassName);
+        }
+        credential.mCredentialKeyAlias = CREDENTIAL_KEY_ALIAS_PREFIX + name;
+
+        credential.mKeystoreEngine.createKey(credential.mCredentialKeyAlias, credentialKeySettings);
+
+        credential.saveCredential();
+
+        return credential;
+    }
+
+    private void saveCredential() {
+        CborBuilder builder = new CborBuilder();
+        MapBuilder<CborBuilder> map = builder.addMap();
+        map.put("keystoreImplementationClassName", mKeystoreEngine.getClass().getName());
+        map.put("credentialKeyAlias", mCredentialKeyAlias);
+        map.put(new UnicodeString("nameSpacedData"), mNameSpacedData.toCbor());
+
+        MapBuilder<MapBuilder<CborBuilder>> applicationDataBuilder =
+                map.putMap("applicationData");
+        for (String key : mApplicationData.keySet()) {
+            byte[] value = mApplicationData.get(key);
+            applicationDataBuilder.put(key, value);
+        }
+
+        ArrayBuilder<MapBuilder<CborBuilder>> pendingAuthenticationKeysArrayBuilder =
+                map.putArray("pendingAuthenticationKeys");
+        for (PendingAuthenticationKey pendingAuthenticationKey : mPendingAuthenticationKeys) {
+            pendingAuthenticationKeysArrayBuilder.add(pendingAuthenticationKey.toCbor());
+        }
+
+        ArrayBuilder<MapBuilder<CborBuilder>> authenticationKeysArrayBuilder =
+                map.putArray("authenticationKeys");
+        for (AuthenticationKey authenticationKey : mAuthenticationKeys) {
+            authenticationKeysArrayBuilder.add(authenticationKey.toCbor());
+        }
+
+        map.put("authenticationKeyCounter", mAuthenticationKeyCounter);
+
+        mStorageEngine.put(CREDENTIAL_PREFIX + mName, Util.cborEncode(builder.build().get(0)));
+    }
+
+    // Called by CredentialStore.lookupCredential().
+    static Credential lookup(@NonNull StorageEngine storageEngine,
+                             @NonNull KeystoreEngineRepository keystoreEngineRepository,
+                             @NonNull String name) {
+        Credential credential = new Credential(storageEngine, keystoreEngineRepository);
+        credential.mName = name;
+        if (!credential.loadCredential(keystoreEngineRepository)) {
+            return null;
+        }
+        return credential;
+    }
+
+    private boolean loadCredential(@NonNull KeystoreEngineRepository keystoreEngineRepository) {
+        byte[] data = mStorageEngine.get(CREDENTIAL_PREFIX + mName);
+        if (data == null) {
+            return false;
+        }
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(data);
+        List<DataItem> dataItems;
+        try {
+            dataItems = new CborDecoder(bais).decode();
+        } catch (CborException e) {
+            throw new IllegalStateException("Error decoded CBOR", e);
+        }
+        if (dataItems.size() != 1) {
+            throw new IllegalStateException("Expected 1 item, found " + dataItems.size());
+        }
+        if (!(dataItems.get(0) instanceof co.nstant.in.cbor.model.Map)) {
+            throw new IllegalStateException("Item is not a map");
+        }
+        co.nstant.in.cbor.model.Map map = (co.nstant.in.cbor.model.Map) dataItems.get(0);
+
+        String keystoreImplementationClassName =
+                Util.cborMapExtractString(map, "keystoreImplementationClassName");
+        mKeystoreEngine = keystoreEngineRepository.getImplementation(keystoreImplementationClassName);
+
+        mCredentialKeyAlias = Util.cborMapExtractString(map, "credentialKeyAlias");
+
+        DataItem nameSpacedDataItem = map.get(new UnicodeString("nameSpacedData"));
+        if (nameSpacedDataItem == null) {
+            throw new IllegalStateException("nameSpacedData not found");
+        }
+        mNameSpacedData = NameSpacedData.fromCbor(nameSpacedDataItem);
+
+        mApplicationData = new LinkedHashMap<>();
+        DataItem applicationDataDataItem = map.get(new UnicodeString("applicationData"));
+        if (!(applicationDataDataItem instanceof co.nstant.in.cbor.model.Map)) {
+            throw new IllegalStateException("applicationData not found or not map");
+        }
+        for (DataItem keyItem : ((co.nstant.in.cbor.model.Map) applicationDataDataItem).getKeys()) {
+            String key = ((UnicodeString) keyItem).getString();
+            byte[] value = Util.cborMapExtractByteString(applicationDataDataItem, key);
+            mApplicationData.put(key, value);
+        }
+
+        mPendingAuthenticationKeys = new ArrayList<>();
+        DataItem pendingAuthenticationKeysDataItem = map.get(new UnicodeString("pendingAuthenticationKeys"));
+        if (!(pendingAuthenticationKeysDataItem instanceof Array)) {
+            throw new IllegalStateException("pendingAuthenticationKeys not found or not array");
+        }
+        for (DataItem item : ((Array) pendingAuthenticationKeysDataItem).getDataItems()) {
+            mPendingAuthenticationKeys.add(PendingAuthenticationKey.fromCbor(item, this));
+        }
+
+        mAuthenticationKeys = new ArrayList<>();
+        DataItem authenticationKeysDataItem = map.get(new UnicodeString("authenticationKeys"));
+        if (!(authenticationKeysDataItem instanceof Array)) {
+            throw new IllegalStateException("authenticationKeys not found or not array");
+        }
+        for (DataItem item : ((Array) authenticationKeysDataItem).getDataItems()) {
+            mAuthenticationKeys.add(AuthenticationKey.fromCbor(item, this));
+        }
+
+        mAuthenticationKeyCounter = Util.cborMapExtractNumber(map, "authenticationKeyCounter");
+
+        return true;
+    }
+
+    void deleteCredential() {
+        // Need to use shallow copies because delete() modifies the list.
+        for (PendingAuthenticationKey key : new ArrayList<>(mPendingAuthenticationKeys)) {
+            key.delete();
+        }
+        for (AuthenticationKey key : new ArrayList<>(mAuthenticationKeys)) {
+            key.delete();
+        }
+        mKeystoreEngine.deleteKey(mCredentialKeyAlias);
+        mStorageEngine.delete(CREDENTIAL_PREFIX + mName);
+    }
+
+    /**
+     * Gets the name of the credential.
+     *
+     * @return The name chosen at credential creation time.
+     */
+    public @NonNull String getName() {
+        return mName;
+    }
+
+    /**
+     * Gets the X.509 certificate chain for <em>CredentialKey</em>.
+     *
+     * <p>The application can use this to prove properties about the device at provisioning time.
+     *
+     * @return An X.509 certificate chain for <em>CredentialKey</em>.
+     */
+    public @NonNull List<X509Certificate> getAttestation() {
+        KeystoreEngine.KeyInfo keyInfo = mKeystoreEngine.getKeyInfo(mCredentialKeyAlias);
+        return keyInfo.getAttestation();
+    }
+
+    /**
+     * Gets the alias for <em>CredentialKey</em>.
+     *
+     * <p>This can be used together with the {@link KeystoreEngine} returned by
+     * {@link #getCredentialKeystoreEngine()}.
+     *
+     * @return The alias for <em>CredentialKey</em>.
+     */
+    public @NonNull String getCredentialKeyAlias() {
+        return mCredentialKeyAlias;
+    }
+
+    /**
+     * Gets the keystore engine for <em>CredentialKey</em>.
+     *
+     * <p>This can be used together with the alias returned by
+     * {@link #getCredentialKeyAlias()}.
+     *
+     * @return The {@link KeystoreEngine} used for <em>CredentialKey</em>.
+     */
+    public @NonNull KeystoreEngine getCredentialKeystoreEngine() {
+        return mKeystoreEngine;
+    }
+
+    /**
+     * Gets the name-space-organized key/value pairs for the credential.
+     *
+     * <p>This returns the same data set with {@link #setNameSpacedData(NameSpacedData)}.
+     *
+     * @return A {@link NameSpacedData}.
+     */
+    public @NonNull NameSpacedData getNameSpacedData() {
+        return mNameSpacedData;
+    }
+
+    /**
+     * Sets name-space-organized key/value pairs for the credential.
+     *
+     * @param nameSpacedData A {@link NameSpacedData}.
+     */
+    public void setNameSpacedData(@NonNull NameSpacedData nameSpacedData) {
+        mNameSpacedData = nameSpacedData;
+        saveCredential();
+    }
+
+    /**
+     * Sets application specific data.
+     *
+     * <p>This allows applications to store additional data it wants to associate with the
+     * credential, for example the document type (e.g. DocType for 18013-5 credentials),
+     * user-visible name, logos/background, state, and so on.
+     *
+     * <p>Use {@link #getApplicationData(String)} to read the data back.
+     *
+     * @param key the key for the data.
+     * @param value the value or {@code null} to remove.
+     */
+    public void setApplicationData(@NonNull String key, @Nullable byte[] value) {
+        if (value == null) {
+            mApplicationData.remove(key);
+        } else {
+            mApplicationData.put(key, value);
+        }
+        saveCredential();
+    }
+
+    /**
+     * Sets application specific data as a string.
+     *
+     * <p>Like {@link #setApplicationData(String, byte[])} but encodes the given value
+     * as an UTF-8 string before storing it.
+     *
+     * @param key the key for the data.
+     * @param value the value or {@code null} to remove.
+     */
+    public void setApplicationDataString(@NonNull String key, @Nullable String value) {
+        if (value == null) {
+            mApplicationData.remove(key);
+        } else {
+            mApplicationData.put(key, value.getBytes(StandardCharsets.UTF_8));
+        }
+        saveCredential();
+    }
+
+    /**
+     * Gets application specific data.
+     *
+     * <p>Gets data previously stored with {@link #getApplicationData(String)}.
+     *
+     * @param key the key for the data.
+     * @return the value or {@code null} if there is no value for the given key.
+     */
+    public @Nullable byte[] getApplicationData(@NonNull String key) {
+        return mApplicationData.get(key);
+    }
+
+    /**
+     * Gets application specific data as a string.
+     *
+     * <p>Like {@link #getApplicationData(String)} but decodes the value as
+     * an UTF-8 string before returning it.
+     *
+     * @param key the key for the data.
+     * @return the value or {@code null} if there is no value for the given key.
+     */
+    public @Nullable String getApplicationDataString(@NonNull String key) {
+        byte[] value = mApplicationData.get(key);
+        if (value == null) {
+            return null;
+        }
+        return new String(value, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Finds a suitable authentication key to use.
+     *
+     * @param now Pass current time to ensure that the selected slot's validity period or
+     *   {@code null} to not consider validity times.
+     * @return An authentication key which can be used for signing or {@code null} if none was found.
+     */
+    public @Nullable AuthenticationKey findAuthenticationKey(@Nullable Timestamp now) {
+
+        AuthenticationKey candidate = null;
+        for (AuthenticationKey authenticationKey : mAuthenticationKeys) {
+            // If current time is passed...
+            if (now != null) {
+                // ... ignore slots that aren't yet valid
+                if (now.toEpochMilli() < authenticationKey.getValidFrom().toEpochMilli()) {
+                    continue;
+                }
+                // .. ignore slots that aren't valid anymore
+                if (now.toEpochMilli() > authenticationKey.getValidUntil().toEpochMilli()) {
+                    continue;
+                }
+            }
+            // If we already have a candidate, prefer this one if its usage count is lower
+            if (candidate != null) {
+                if (authenticationKey.getUsageCount() < candidate.getUsageCount()) {
+                    candidate = authenticationKey;
+                }
+            } else {
+                candidate = authenticationKey;
+            }
+        }
+        return candidate;
+    }
+
+    /**
+     * A certified authentication key.
+     *
+     * <p>To create an instance of this type, an application must first use
+     * {@link Credential#createPendingAuthenticationKey(KeystoreEngine.CreateKeySettings, AuthenticationKey)}
+     * to create a {@link PendingAuthenticationKey} and after issuer certification
+     * has been received it can be upgraded to a {@link AuthenticationKey}.
+     */
+    public static class AuthenticationKey {
+        private String mAlias;
+        private int mUsageCount;
+        private byte[] mData;
+        private Timestamp mValidFrom;
+        private Timestamp mValidUntil;
+        private Credential mCredential;
+        private String mKeystoreEngineName;
+        private String mReplacementAlias;
+        private LinkedHashMap<String, byte[]> mApplicationData = new LinkedHashMap<>();
+
+        static AuthenticationKey create(
+                @NonNull PendingAuthenticationKey pendingAuthenticationKey,
+                @NonNull byte[] issuerProvidedAuthenticationData,
+                @NonNull Timestamp validFrom,
+                @NonNull Timestamp validUntil,
+                @NonNull Credential credential) {
+            AuthenticationKey ret = new AuthenticationKey();
+            ret.mAlias = pendingAuthenticationKey.mAlias;
+            ret.mData = issuerProvidedAuthenticationData;
+            ret.mValidFrom = validFrom;
+            ret.mValidUntil = validUntil;
+            ret.mCredential = credential;
+            ret.mKeystoreEngineName = pendingAuthenticationKey.mKeystoreEngineName;
+            ret.mApplicationData = pendingAuthenticationKey.mApplicationData;
+            return ret;
+        }
+
+        /**
+         * Returns how many time the key in the slot has been used.
+         *
+         * @return The number of times the key in slot has been used.
+         */
+        public int getUsageCount() {
+            return mUsageCount;
+        }
+
+        /**
+         * Gets the issuer-provided data associated with the key.
+         *
+         * @return The issuer-provided data.
+         */
+        public @NonNull byte[] getIssuerProvidedData() {
+            return mData;
+        }
+
+        /**
+         * Gets the point in time the issuer-provided data is valid from.
+         *
+         * @return The valid-from time.
+         */
+        public @NonNull Timestamp getValidFrom() {
+            return mValidFrom;
+        }
+
+        /**
+         * Gets the point in time the issuer-provided data is valid until.
+         *
+         * @return The valid-until time.
+         */
+        public @NonNull Timestamp getValidUntil() {
+            return mValidUntil;
+        }
+
+        /**
+         * Deletes the authentication key.
+         *
+         * <p>After deletion, this object should no longer be used.
+         */
+        public void delete() {
+            KeystoreEngine keystoreEngine = mCredential.mKeystoreEngineRepository
+                    .getImplementation(mKeystoreEngineName);
+            if (keystoreEngine == null) {
+                throw new IllegalArgumentException("Unknown engine " + mKeystoreEngineName);
+            }
+            keystoreEngine.deleteKey(mAlias);
+            mCredential.removeAuthenticationKey(this);
+        }
+
+        /**
+         * Increases usage count of the authentication key.
+         */
+        public void increaseUsageCount() {
+            mUsageCount += 1;
+            mCredential.saveCredential();
+        }
+
+        /**
+         * Gets the X.509 certificate chain for the authentication key
+         *
+         * @return An X.509 certificate chain for the authentication key.
+         */
+        public @NonNull List<X509Certificate> getAttestation() {
+            KeystoreEngine keystoreEngine = mCredential.mKeystoreEngineRepository
+                    .getImplementation(mKeystoreEngineName);
+            if (keystoreEngine == null) {
+                throw new IllegalArgumentException("Unknown engine " + mKeystoreEngineName);
+            }
+            KeystoreEngine.KeyInfo keyInfo = keystoreEngine.getKeyInfo(mAlias);
+            return keyInfo.getAttestation();
+        }
+
+        /**
+         * Gets the alias for the authentication key.
+         *
+         * <p>This can be used together with the {@link KeystoreEngine} returned by
+         * {@link #getKeystoreEngine()} ()}.
+         *
+         * @return The alias for the authentication key.
+         */
+        public @NonNull String getAlias() {
+            return mAlias;
+        }
+
+        /**
+         * Gets the keystore engine for the authentication key.
+         *
+         * <p>This can be used together with the alias returned by
+         * {@link #getAlias()}.
+         *
+         * @return The {@link KeystoreEngine} used for <em>CredentialKey</em>.
+         */
+        public @NonNull KeystoreEngine getKeystoreEngine() {
+            KeystoreEngine keystoreEngine = mCredential.mKeystoreEngineRepository
+                    .getImplementation(mKeystoreEngineName);
+            if (keystoreEngine == null) {
+                throw new IllegalArgumentException("Unknown engine " + mKeystoreEngineName);
+            }
+            return keystoreEngine;
+        }
+
+        DataItem toCbor() {
+            CborBuilder builder = new CborBuilder();
+            MapBuilder<CborBuilder> mapBuilder = builder.addMap();
+            mapBuilder.put("alias", mAlias)
+                    .put("keystoreEngineName", mKeystoreEngineName)
+                    .put("usageCount", mUsageCount)
+                    .put("data", mData)
+                    .put("validFrom", mValidFrom.toEpochMilli())
+                    .put("validUntil", mValidUntil.toEpochMilli());
+            MapBuilder<MapBuilder<CborBuilder>> applicationDataBuilder =
+                    mapBuilder.putMap("applicationData");
+            for (String key : mApplicationData.keySet()) {
+                byte[] value = mApplicationData.get(key);
+                applicationDataBuilder.put(key, value);
+            }
+            if (mReplacementAlias != null) {
+                mapBuilder.put("replacementAlias", mReplacementAlias);
+            }
+            return builder.build().get(0);
+        }
+
+        static AuthenticationKey fromCbor(@NonNull DataItem dataItem,
+                                          @NonNull Credential credential) {
+            AuthenticationKey ret = new AuthenticationKey();
+            ret.mAlias = Util.cborMapExtractString(dataItem, "alias");
+            ret.mKeystoreEngineName = Util.cborMapExtractString(dataItem, "keystoreEngineName");
+            ret.mUsageCount = (int) Util.cborMapExtractNumber(dataItem, "usageCount");
+            ret.mData = Util.cborMapExtractByteString(dataItem, "data");
+            ret.mValidFrom = Timestamp.ofEpochMilli(Util.cborMapExtractNumber(dataItem, "validFrom"));
+            ret.mValidUntil = Timestamp.ofEpochMilli(Util.cborMapExtractNumber(dataItem, "validUntil"));
+            if (Util.cborMapHasKey(dataItem, "replacementAlias")) {
+                ret.mReplacementAlias = Util.cborMapExtractString(dataItem, "replacementAlias");
+            }
+            ret.mApplicationData = new LinkedHashMap<>();
+            DataItem applicationDataDataItem = Util.cborMapExtractMap(dataItem, "applicationData");
+            if (!(applicationDataDataItem instanceof co.nstant.in.cbor.model.Map)) {
+                throw new IllegalStateException("applicationData not found or not map");
+            }
+            for (DataItem keyItem : ((co.nstant.in.cbor.model.Map) applicationDataDataItem).getKeys()) {
+                String key = ((UnicodeString) keyItem).getString();
+                byte[] value = Util.cborMapExtractByteString(applicationDataDataItem, key);
+                ret.mApplicationData.put(key, value);
+            }
+            ret.mCredential = credential;
+            return ret;
+        }
+
+        /**
+         * Gets the pending auth key that will replace this key once certified.
+         *
+         * @return An {@link PendingAuthenticationKey} or {@code null} if no key was designated
+         *   to replace this key.
+         */
+        public @Nullable PendingAuthenticationKey getReplacement() {
+            if (mReplacementAlias == null) {
+                return null;
+            }
+            for (PendingAuthenticationKey pendingAuthKey : mCredential.getPendingAuthenticationKeys()) {
+                if (pendingAuthKey.getAlias().equals(mReplacementAlias)) {
+                    return pendingAuthKey;
+                }
+            }
+            Logger.w(TAG, "Pending key with alias " + mReplacementAlias + " which "
+                    + "is intended to replace this key does not exist");
+            return null;
+        }
+
+
+        void setReplacementAlias(@NonNull String alias) {
+            mReplacementAlias = alias;
+            mCredential.saveCredential();
+        }
+
+        /**
+         * Sets application specific data.
+         *
+         * <p>This allows applications to store additional data it wants to associate with the
+         * pending authentication key.
+         *
+         * <p>Use {@link #getApplicationData(String)} to read the data back.
+         *
+         * @param key the key for the data.
+         * @param value the value or {@code null} to remove.
+         */
+        public void setApplicationData(@NonNull String key, @Nullable byte[] value) {
+            if (value == null) {
+                mApplicationData.remove(key);
+            } else {
+                mApplicationData.put(key, value);
+            }
+            mCredential.saveCredential();
+        }
+
+        /**
+         * Sets application specific data as a string.
+         *
+         * <p>Like {@link #setApplicationData(String, byte[])} but encodes the given value
+         * as an UTF-8 string before storing it.
+         *
+         * @param key the key for the data.
+         * @param value the value or {@code null} to remove.
+         */
+        public void setApplicationDataString(@NonNull String key, @Nullable String value) {
+            if (value == null) {
+                mApplicationData.remove(key);
+            } else {
+                mApplicationData.put(key, value.getBytes(StandardCharsets.UTF_8));
+            }
+            mCredential.saveCredential();
+        }
+
+        /**
+         * Gets application specific data.
+         *
+         * <p>Gets data previously stored with {@link #getApplicationData(String)}.
+         *
+         * @param key the key for the data.
+         * @return the value or {@code null} if there is no value for the given key.
+         */
+        public @Nullable byte[] getApplicationData(@NonNull String key) {
+            return mApplicationData.get(key);
+        }
+
+        /**
+         * Gets application specific data as a string.
+         *
+         * <p>Like {@link #getApplicationData(String)} but decodes the value as
+         * an UTF-8 string before returning it.
+         *
+         * @param key the key for the data.
+         * @return the value or {@code null} if there is no value for the given key.
+         */
+        public @Nullable String getApplicationDataString(@NonNull String key) {
+            byte[] value = mApplicationData.get(key);
+            if (value == null) {
+                return null;
+            }
+            return new String(value, StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * An authentication key pending certification.
+     *
+     * <p>To create a pending authentication key, use
+     * {@link Credential#createPendingAuthenticationKey(KeystoreEngine.CreateKeySettings, AuthenticationKey)}.
+     *
+     * <p>Because issuer certification of authentication could take a long time, pending
+     * authentication keys are persisted and {@link Credential#getPendingAuthenticationKeys()}
+     * can be used to get a list of instances. For example this can be used to re-ping
+     * the issuing server for outstanding certification requests.
+     *
+     * <p>Once certification is complete, use {@link #certify(byte[], Timestamp, Timestamp)}
+     * to upgrade to a {@link AuthenticationKey}.
+     */
+    public static class PendingAuthenticationKey {
+        String mKeystoreEngineName;
+
+        String mAlias;
+        Credential mCredential;
+        private String mReplacementForAlias;
+        private LinkedHashMap<String, byte[]> mApplicationData = new LinkedHashMap<>();
+
+        static @NonNull PendingAuthenticationKey create(
+                @NonNull String alias,
+                @NonNull KeystoreEngine.CreateKeySettings createKeySettings,
+                @Nullable AuthenticationKey asReplacementFor,
+                @NonNull Credential credential) {
+            PendingAuthenticationKey ret = new PendingAuthenticationKey();
+            ret.mAlias = alias;
+            ret.mKeystoreEngineName = createKeySettings.getKeystoreEngineClass().getName();
+            KeystoreEngine keystoreEngine = credential.mKeystoreEngineRepository
+                    .getImplementation(ret.mKeystoreEngineName);
+            if (keystoreEngine == null) {
+                throw new IllegalArgumentException("Unknown engine " + ret.mKeystoreEngineName);
+            }
+            keystoreEngine.createKey(alias, createKeySettings);
+            if (asReplacementFor != null) {
+                ret.mReplacementForAlias = asReplacementFor.getAlias();
+            }
+            ret.mCredential = credential;
+            return ret;
+        }
+
+        /**
+         * Gets the X.509 certificate chain for the authentication key pending certification.
+         *
+         * <p>The application should send this key to the issuer which should create issuer-provided
+         * data (e.g. an MSO if using ISO/IEC 18013-5:2021) using the key as the {@code DeviceKey}.
+         *
+         * @return An X.509 certificate chain for the pending authentication key.
+         */
+        public @NonNull List<X509Certificate> getAttestation() {
+            KeystoreEngine keystoreEngine = mCredential.mKeystoreEngineRepository
+                    .getImplementation(mKeystoreEngineName);
+            if (keystoreEngine == null) {
+                throw new IllegalArgumentException("Unknown engine " + mKeystoreEngineName);
+            }
+            KeystoreEngine.KeyInfo keyInfo = keystoreEngine.getKeyInfo(mAlias);
+            return keyInfo.getAttestation();
+        }
+
+        /**
+         * Gets the alias for the pending authentication key.
+         *
+         * <p>This can be used together with the {@link KeystoreEngine} returned by
+         * {@link #getKeystoreEngine()} ()}.
+         *
+         * @return The alias for the authentication key.
+         */
+        public @NonNull String getAlias() {
+            return mAlias;
+        }
+
+        /**
+         * Gets the keystore engine for the pending authentication key.
+         *
+         * <p>This can be used together with the alias returned by
+         * {@link #getAlias()}.
+         *
+         * @return The {@link KeystoreEngine} used for <em>CredentialKey</em>.
+         */
+        public @NonNull KeystoreEngine getKeystoreEngine() {
+            KeystoreEngine keystoreEngine = mCredential.mKeystoreEngineRepository
+                    .getImplementation(mKeystoreEngineName);
+            if (keystoreEngine == null) {
+                throw new IllegalArgumentException("Unknown engine " + mKeystoreEngineName);
+            }
+            return keystoreEngine;
+        }
+
+        /**
+         * Deletes the pending authentication key.
+         */
+        public void delete() {
+            KeystoreEngine keystoreEngine = mCredential.mKeystoreEngineRepository
+                    .getImplementation(mKeystoreEngineName);
+            if (keystoreEngine == null) {
+                throw new IllegalArgumentException("Unknown engine " + mKeystoreEngineName);
+            }
+            keystoreEngine.deleteKey(mAlias);
+            mCredential.removePendingAuthenticationKey(this);
+        }
+
+        /**
+         * Certifies the pending authentication key.
+         *
+         * <p>This will convert this {@link PendingAuthenticationKey} into a
+         * {@link AuthenticationKey} including preserving the application-data
+         * set.
+         *
+         * <p>The {@link PendingAuthenticationKey} object should no longer be used after calling this.
+         *
+         * @param issuerProvidedAuthenticationData the issuer-provided static authentication data.
+         * @param validFrom the point in time before which the data is not valid.
+         * @param validUntil the point in time after which the data is not valid.
+         * @return a {@link AuthenticationKey}.
+         */
+        public @NonNull AuthenticationKey certify(@NonNull byte[] issuerProvidedAuthenticationData,
+                                                  @NonNull Timestamp validFrom,
+                                                  @NonNull Timestamp validUntil) {
+            return mCredential.certifyPendingAuthenticationKey(this,
+                    issuerProvidedAuthenticationData,
+                    validFrom,
+                    validUntil);
+        }
+
+        @NonNull DataItem toCbor() {
+            CborBuilder builder = new CborBuilder();
+            MapBuilder<CborBuilder> mapBuilder = builder.addMap();
+            mapBuilder.put("alias", mAlias)
+                    .put("keystoreEngineName", mKeystoreEngineName);
+            if (mReplacementForAlias != null) {
+                mapBuilder.put("replacementForAlias", mReplacementForAlias);
+            }
+            MapBuilder<MapBuilder<CborBuilder>> applicationDataBuilder =
+                    mapBuilder.putMap("applicationData");
+            for (String key : mApplicationData.keySet()) {
+                byte[] value = mApplicationData.get(key);
+                applicationDataBuilder.put(key, value);
+            }
+            return builder.build().get(0);
+        }
+
+        static PendingAuthenticationKey fromCbor(@NonNull DataItem dataItem,
+                                                 @NonNull Credential credential) {
+            PendingAuthenticationKey ret = new PendingAuthenticationKey();
+            ret.mAlias = Util.cborMapExtractString(dataItem, "alias");
+            ret.mKeystoreEngineName = Util.cborMapExtractString(dataItem, "keystoreEngineName");
+            if (Util.cborMapHasKey(dataItem, "replacementForAlias")) {
+                ret.mReplacementForAlias = Util.cborMapExtractString(dataItem, "replacementForAlias");
+            }
+            ret.mApplicationData = new LinkedHashMap<>();
+            DataItem applicationDataDataItem = Util.cborMapExtractMap(dataItem, "applicationData");
+            if (!(applicationDataDataItem instanceof co.nstant.in.cbor.model.Map)) {
+                throw new IllegalStateException("applicationData not found or not map");
+            }
+            for (DataItem keyItem : ((co.nstant.in.cbor.model.Map) applicationDataDataItem).getKeys()) {
+                String key = ((UnicodeString) keyItem).getString();
+                byte[] value = Util.cborMapExtractByteString(applicationDataDataItem, key);
+                ret.mApplicationData.put(key, value);
+            }
+            ret.mCredential = credential;
+            return ret;
+        }
+
+        /**
+         * Gets the auth key that will be replaced by this key once it's been certified.
+         *
+         * @return An {@link AuthenticationKey} or {@code null} if no key was designated
+         *   when this pending key was created.
+         */
+        public @Nullable AuthenticationKey getReplacementFor() {
+            if (mReplacementForAlias == null) {
+                return null;
+            }
+            for (AuthenticationKey authKey : mCredential.getAuthenticationKeys()) {
+                if (authKey.getAlias().equals(mReplacementForAlias)) {
+                    return authKey;
+                }
+            }
+            Logger.w(TAG, "Key with alias " + mReplacementForAlias + " which "
+                    + "is intended to be replaced does not exist");
+            return null;
+        }
+
+        /**
+         * Sets application specific data.
+         *
+         * <p>This allows applications to store additional data it wants to associate with the
+         * authentication key.
+         *
+         * <p>Use {@link #getApplicationData(String)} to read the data back.
+         *
+         * @param key the key for the data.
+         * @param value the value or {@code null} to remove.
+         */
+        public void setApplicationData(@NonNull String key, @Nullable byte[] value) {
+            if (value == null) {
+                mApplicationData.remove(key);
+            } else {
+                mApplicationData.put(key, value);
+            }
+            mCredential.saveCredential();
+        }
+
+        /**
+         * Sets application specific data as a string.
+         *
+         * <p>Like {@link #setApplicationData(String, byte[])} but encodes the given value
+         * as an UTF-8 string before storing it.
+         *
+         * @param key the key for the data.
+         * @param value the value or {@code null} to remove.
+         */
+        public void setApplicationDataString(@NonNull String key, @Nullable String value) {
+            if (value == null) {
+                mApplicationData.remove(key);
+            } else {
+                mApplicationData.put(key, value.getBytes(StandardCharsets.UTF_8));
+            }
+            mCredential.saveCredential();
+        }
+
+        /**
+         * Gets application specific data.
+         *
+         * <p>Gets data previously stored with {@link #getApplicationData(String)}.
+         *
+         * @param key the key for the data.
+         * @return the value or {@code null} if there is no value for the given key.
+         */
+        public @Nullable byte[] getApplicationData(@NonNull String key) {
+            return mApplicationData.get(key);
+        }
+
+        /**
+         * Gets application specific data as a string.
+         *
+         * <p>Like {@link #getApplicationData(String)} but decodes the value as
+         * an UTF-8 string before returning it.
+         *
+         * @param key the key for the data.
+         * @return the value or {@code null} if there is no value for the given key.
+         */
+        public @Nullable String getApplicationDataString(@NonNull String key) {
+            byte[] value = mApplicationData.get(key);
+            if (value == null) {
+                return null;
+            }
+            return new String(value, StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Creates a new authentication key.
+     *
+     * <p>This returns a {@link PendingAuthenticationKey} which should be sent to the
+     * credential issuer for certification. Use
+     * {@link PendingAuthenticationKey#certify(byte[], Timestamp, Timestamp)} when certification
+     * has been obtained.
+     *
+     * <p>For a higher-level way of managing authentication keys, see
+     * {@link CredentialUtil#managedAuthenticationKeyHelper(Credential, KeystoreEngine.CreateKeySettings, String, Timestamp, int, int, long)}.
+     *
+     * @param createKeySettings settings for the authentication key.
+     * @param asReplacementFor if not {@code null}, replace the given authentication key
+     *                         with this one, once it has been certified.
+     * @return a {@link PendingAuthenticationKey}.
+     * @throws IllegalArgumentException if {@code asReplacementFor} is not null and the given
+     *   key already has a pending key intending to replace it.
+     */
+    public @NonNull PendingAuthenticationKey createPendingAuthenticationKey(
+            @NonNull KeystoreEngine.CreateKeySettings createKeySettings,
+            @Nullable AuthenticationKey asReplacementFor) {
+        if (asReplacementFor != null && asReplacementFor.getReplacement() != null) {
+            throw new IllegalStateException(
+                    "The given key already has an existing pending key intending to replace it");
+        }
+        String alias = AUTHENTICATION_KEY_ALIAS_PREFIX + mName + "_authKey_" + mAuthenticationKeyCounter++;
+        PendingAuthenticationKey pendingAuthenticationKey =
+                PendingAuthenticationKey.create(
+                        alias,
+                        createKeySettings,
+                        asReplacementFor,
+                        this);
+        mPendingAuthenticationKeys.add(pendingAuthenticationKey);
+        if (asReplacementFor != null) {
+            asReplacementFor.setReplacementAlias(pendingAuthenticationKey.getAlias());
+        }
+        saveCredential();
+        return pendingAuthenticationKey;
+    }
+
+    void removePendingAuthenticationKey(@NonNull PendingAuthenticationKey pendingAuthenticationKey) {
+        if (!mPendingAuthenticationKeys.remove(pendingAuthenticationKey)) {
+            throw new IllegalStateException("Error removing pending authentication key");
+        }
+        if (pendingAuthenticationKey.mReplacementForAlias != null) {
+            for (AuthenticationKey authKey : mAuthenticationKeys) {
+                if (authKey.mAlias.equals(pendingAuthenticationKey.mReplacementForAlias)) {
+                    authKey.mReplacementAlias = null;
+                    break;
+                }
+            }
+        }
+        saveCredential();
+    }
+
+    void removeAuthenticationKey(@NonNull AuthenticationKey authenticationKey) {
+        if (!mAuthenticationKeys.remove(authenticationKey)) {
+            throw new IllegalStateException("Error removing authentication key");
+        }
+        if (authenticationKey.mReplacementAlias != null) {
+            for (PendingAuthenticationKey pendingAuthKey : mPendingAuthenticationKeys) {
+                if (pendingAuthKey.mAlias.equals(authenticationKey.mReplacementAlias)) {
+                    pendingAuthKey.mReplacementForAlias = null;
+                    break;
+                }
+            }
+        }
+        saveCredential();
+    }
+
+    @NonNull AuthenticationKey certifyPendingAuthenticationKey(
+            @NonNull PendingAuthenticationKey pendingAuthenticationKey,
+            @NonNull byte[] issuerProvidedAuthenticationData,
+            @NonNull Timestamp validFrom,
+            @NonNull Timestamp validUntil) {
+        if (!mPendingAuthenticationKeys.remove(pendingAuthenticationKey)) {
+            throw new IllegalStateException("Error removing pending authentication key");
+        }
+        AuthenticationKey authenticationKey =
+                AuthenticationKey.create(pendingAuthenticationKey,
+                        issuerProvidedAuthenticationData,
+                        validFrom,
+                        validUntil,
+                        this);
+        mAuthenticationKeys.add(authenticationKey);
+
+        AuthenticationKey authKeyToDelete = pendingAuthenticationKey.getReplacementFor();
+        if (authKeyToDelete != null) {
+            authKeyToDelete.delete();
+        }
+
+        saveCredential();
+        return authenticationKey;
+    }
+
+    /**
+     * Gets all pending authentication keys.
+     *
+     * @return a list of all pending authentication keys.
+     */
+    public @NonNull List<PendingAuthenticationKey> getPendingAuthenticationKeys() {
+        // Return a shallow copy b/c caller might call PendingAuthenticationKey.certify()
+        // or PendingAuthenticationKey.delete() while iterating.
+        return new ArrayList<>(mPendingAuthenticationKeys);
+    }
+
+    /**
+     * Gets all certified authentication keys.
+     *
+     * @return a list of all certified authentication keys.
+     */
+    public @NonNull List<AuthenticationKey> getAuthenticationKeys() {
+        // Return a shallow copy b/c caller might call AuthenticationKey.delete()
+        // while iterating.
+        return new ArrayList<>(mAuthenticationKeys);
+    }
+}

--- a/identity/src/main/java/com/android/identity/credential/CredentialStore.java
+++ b/identity/src/main/java/com/android/identity/credential/CredentialStore.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity.credential;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.android.identity.keystore.KeystoreEngine;
+import com.android.identity.keystore.KeystoreEngineRepository;
+import com.android.identity.storage.StorageEngine;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class for holding real-world identity credentials.
+ *
+ * <p>This class is designed for storing real-world identity credentials such as
+ * Mobile Driving Licenses (mDL) as specified in ISO/IEC 18013-5:2021. It is however
+ * not tied to that specific credential shape and is designed to hold any kind of
+ * credential, regardless of shape, presentation-, or issuance-protocol used.
+ *
+ * <p>This code relies on a Secure Keystore for keys and this dependency is abstracted
+ * by the {@link KeystoreEngine} interface and allows the use of different implementations
+ * on a per-credential basis. Persistent storage of credentials is abstracted via
+ * the {@link StorageEngine} interface which provides a simple key/value store.
+ *
+ * <p>For more details about credentials stored in a {@link CredentialStore} see the
+ * {@link Credential} class.
+ */
+public class CredentialStore {
+    private final StorageEngine mStorageEngine;
+    private final KeystoreEngineRepository mKeystoreEngineRepository;
+
+    /**
+     * Creates a new credential store.
+     *
+     * @param storageEngine the {@link StorageEngine} to use for storing/retrieving credentials.
+     * @param keystoreEngineRepository the repository of configured {@link KeystoreEngine} that can
+     *                                 be used.
+     */
+    public CredentialStore(@NonNull StorageEngine storageEngine,
+                           @NonNull KeystoreEngineRepository keystoreEngineRepository) {
+        mStorageEngine = storageEngine;
+        mKeystoreEngineRepository = keystoreEngineRepository;
+    }
+
+    /**
+     * Creates a new credential.
+     *
+     * <p>If a credential with the given name already exists, it will be overwritten by the
+     * newly created credential.
+     *
+     * @param name name of the credential.
+     * @param credentialKeySettings the settings to use for CredentialKey.
+     * @return A newly created credential.
+     */
+    public @NonNull Credential createCredential(@NonNull String name,
+                                                @NonNull KeystoreEngine.CreateKeySettings credentialKeySettings) {
+        return Credential.create(mStorageEngine,
+                mKeystoreEngineRepository,
+                name,
+                credentialKeySettings);
+    }
+
+    /**
+     * Looks up a previously created credential.
+     *
+     * @param name the name of the credential.
+     * @return the credential or {@code null} if not found.
+     */
+    public @Nullable Credential lookupCredential(@NonNull String name) {
+        return Credential.lookup(mStorageEngine, mKeystoreEngineRepository, name);
+    }
+
+    /**
+     * Lists all credentials in the store.
+     *
+     * @return list of all credential names in the store.
+     */
+    public @NonNull List<String> listCredentials() {
+        ArrayList<String> ret = new ArrayList<>();
+        for (String name : mStorageEngine.enumerate()) {
+            if (name.startsWith(Credential.CREDENTIAL_PREFIX)) {
+                ret.add(name.substring(Credential.CREDENTIAL_PREFIX.length()));
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * Deletes a credential.
+     *
+     * <p>If the credential doesn't exist this does nothing.
+     *
+     * @param name the name of the credential.
+     */
+    public void deleteCredential(@NonNull String name) {
+        Credential credential = lookupCredential(name);
+        if (credential == null) {
+            return;
+        }
+        credential.deleteCredential();
+    }
+}

--- a/identity/src/main/java/com/android/identity/credential/CredentialUtil.java
+++ b/identity/src/main/java/com/android/identity/credential/CredentialUtil.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity.credential;
+
+import androidx.annotation.NonNull;
+
+import com.android.identity.keystore.KeystoreEngine;
+import com.android.identity.util.Timestamp;
+
+/**
+ * A set of utilities and helpers for working with credentials.
+ */
+public class CredentialUtil {
+    /**
+     * A helper for managing a set of authentication keys.
+     *
+     * <p>This helper provides a high-level way to manage authentication keys on a
+     * {@link Credential}. Its goal is to always have a fixed number of authentication
+     * keys available within the following constraints
+     * <ul>
+     *     <li>If a key is used more than {@code maxUsesPerKey} times, a replacement is generated.</li>
+     *     <li>If a key expires within {@code minValidTimeMillis} milliseconds, a replacement is generated.</li>
+     * </ul>
+     * <p>This is all implemented on top of {@link Credential#createPendingAuthenticationKey(KeystoreEngine.CreateKeySettings, Credential.AuthenticationKey)}
+     * and {@link Credential.PendingAuthenticationKey#certify(byte[], Timestamp, Timestamp)}.
+     * The application should examine the return value and if positive, collect the
+     * pending authentication keys via {@link Credential#getPendingAuthenticationKeys()},
+     * send them to the issuer for certification, and then call
+     * {@link Credential.PendingAuthenticationKey#certify(byte[], Timestamp, Timestamp)}
+     * when receiving the certification from the issuer.
+     *
+     * <p>Authentication keys created using this helper will have application data set for
+     * the with the key given by the {@code managedKeyDomain} and the helper will
+     * only touch keys with this key set. This allows the application to manage multiple
+     * sets of authentication keys for different purposes and with different strategies.
+     *
+     * @param credential the credential to manage authentication keys for.
+     * @param createKeySettings the settings used to create new pending authentication keys.
+     * @param managedKeyDomain the identifier to use for created authentication keys.
+     * @param now the time right now, used for figuring out when existing should be replaced.
+     * @param numAuthenticationKeys the number of authentication keys that should be kept.
+     * @param maxUsesPerKey the maximum number of uses per key.
+     * @param minValidTimeMillis requests a replacement for a key if it expires within this window.
+     * @return the number of pending authentication keys created.
+     */
+    public static int managedAuthenticationKeyHelper(
+            @NonNull Credential credential,
+            @NonNull KeystoreEngine.CreateKeySettings createKeySettings,
+            @NonNull String managedKeyDomain,
+            @NonNull Timestamp now,
+            int numAuthenticationKeys,
+            int maxUsesPerKey,
+            long minValidTimeMillis) {
+        // First determine which of the existing keys need a replacement...
+        int numKeysNotNeedingReplacement = 0;
+        int numReplacementsGenerated = 0;
+        for (Credential.AuthenticationKey authKey : credential.getAuthenticationKeys()) {
+            boolean keyExceededUseCount = false;
+            boolean keyBeyondExpirationDate = false;
+
+            if (authKey.getApplicationData(managedKeyDomain) == null) {
+                // not one of ours...
+                continue;
+            }
+
+            if (authKey.getUsageCount() >= maxUsesPerKey) {
+                keyExceededUseCount = true;
+            }
+
+            Timestamp expirationDate = Timestamp.ofEpochMilli(
+                    authKey.getValidUntil().toEpochMilli() - minValidTimeMillis);
+            if (now.toEpochMilli() > expirationDate.toEpochMilli()) {
+                keyBeyondExpirationDate = true;
+            }
+
+            if (keyExceededUseCount || keyBeyondExpirationDate) {
+                if (authKey.getReplacement() == null) {
+                    Credential.PendingAuthenticationKey pendingKey =
+                            credential.createPendingAuthenticationKey(createKeySettings, authKey);
+                    pendingKey.setApplicationData(managedKeyDomain, new byte[0]);
+                    numReplacementsGenerated++;
+                    continue;
+                }
+            }
+            numKeysNotNeedingReplacement++;
+        }
+
+        // It's possible we need to generate pending keys that aren't replacements
+        int numNonReplacementsToGenerate = numAuthenticationKeys
+                - numKeysNotNeedingReplacement
+                - numReplacementsGenerated;
+        if (numNonReplacementsToGenerate > 0) {
+            for (int n = 0; n < numNonReplacementsToGenerate; n++) {
+                Credential.PendingAuthenticationKey pendingKey =
+                        credential.createPendingAuthenticationKey(createKeySettings, null);
+                pendingKey.setApplicationData(managedKeyDomain, new byte[0]);
+            }
+        }
+        return numReplacementsGenerated + numNonReplacementsToGenerate;
+    }
+}

--- a/identity/src/main/java/com/android/identity/credential/NameSpacedData.java
+++ b/identity/src/main/java/com/android/identity/credential/NameSpacedData.java
@@ -1,0 +1,393 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity.credential;
+
+import androidx.annotation.NonNull;
+
+import com.android.identity.internal.Util;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.builder.MapBuilder;
+import co.nstant.in.cbor.model.ByteString;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Tag;
+import co.nstant.in.cbor.model.UnicodeString;
+
+/**
+ * Key/value pairs, organized by name space.
+ *
+ * <p>This class implements a data model which consists of a series of name spaces
+ * (identified by a string such as <em>org.iso.18013.5.1</em>) where each name space
+ * contains a number of key/value pairs where keys are strings and values are
+ * <a href="https://datatracker.ietf.org/doc/html/rfc8949">CBOR</a> values.
+ *
+ * <p>While this happens to be similar to the mDL/MDOC data model used in
+ * <a href="https://www.iso.org/standard/69084.html">ISO/IEC 18013-5:2021</a>,
+ * it's flexible enough to be used to store credential data for any kind of
+ * credential.
+ *
+ * <p>This type is immutable.
+ */
+public class NameSpacedData {
+    private LinkedHashMap<String, LinkedHashMap<String, byte[]>> mMap;
+
+    NameSpacedData() {
+        mMap = new LinkedHashMap<>();
+    }
+
+    private NameSpacedData(LinkedHashMap<String, LinkedHashMap<String, byte[]>> map) {
+        mMap = map;
+    }
+
+    /**
+     * Creates a new {@link NameSpacedData} from encoded CBOR.
+     *
+     * @param encodedCbor CBOR encoded in the format described by {@link #encodeAsCbor()}.
+     * @return A {@link NameSpacedData}.
+     * @throws IllegalArgumentException if the given data is not valid CBOR.
+     * @throws IllegalArgumentException if the given data does not confirm to the CDDL in
+     *                                  {@link #encodeAsCbor()}.
+     */
+    static public @NonNull NameSpacedData fromEncodedCbor(@NonNull byte[] encodedCbor) {
+        return fromCbor(Util.cborDecode(encodedCbor));
+    }
+
+    /**
+     * Gets all the name space names.
+     *
+     * @return list of name space names.
+     */
+    public @NonNull List<String> getNameSpaceNames() {
+        List<String> ret = new ArrayList<>();
+        for (String nameSpaceName : mMap.keySet()) {
+            ret.add(nameSpaceName);
+        }
+        return ret;
+    }
+
+    /**
+     * Gets all data elements in a name space.
+     *
+     * @param nameSpaceName the name space name.
+     * @return list of all data element names in the name space.
+     */
+    public @NonNull List<String> getDataElementNames(@NonNull String nameSpaceName) {
+        LinkedHashMap<String, byte[]> innerMap = mMap.get(nameSpaceName);
+        if (innerMap == null) {
+            throw new IllegalArgumentException("No such namespace '" + nameSpaceName + "'");
+        }
+        List<String> ret = new ArrayList<>();
+        for (String dataElementName : innerMap.keySet()) {
+            ret.add(dataElementName);
+        }
+        return ret;
+    }
+
+    /**
+     * Checks if there's a value for a given data element.
+     *
+     * @param nameSpaceName the name space name.
+     * @param dataElementName the data element name.
+     * @return {@code true} if there's a value for the data element, {@code false} otherwise.
+     */
+    public boolean hasDataElement(@NonNull String nameSpaceName,
+                                  @NonNull String dataElementName) {
+        LinkedHashMap<String, byte[]> innerMap = mMap.get(nameSpaceName);
+        if (innerMap == null) {
+            return false;
+        }
+        return innerMap.get(dataElementName) != null;
+    }
+
+    /**
+     * Gets the raw CBOR for a data element.
+     *
+     * @param nameSpaceName the name space name.
+     * @param dataElementName the data element name.
+     * @return the bytes of the CBOR.
+     * @throws IllegalArgumentException if the given name space doesn't exist.
+     * @throws IllegalArgumentException if the given data element doesn't exist.
+     */
+    public @NonNull byte[] getDataElement(@NonNull String nameSpaceName,
+                                          @NonNull String dataElementName) {
+        LinkedHashMap<String, byte[]> innerMap = mMap.get(nameSpaceName);
+        if (innerMap == null) {
+            throw new IllegalArgumentException("No such namespace '" + nameSpaceName + "'");
+        }
+        byte[] value = innerMap.get(dataElementName);
+        if (value == null) {
+            throw new IllegalArgumentException("No such data element '" + dataElementName + "'");
+        }
+        return value;
+    }
+
+    /**
+     * Like {@link #getDataElement(String, String)} but decodes the CBOR as a string.
+     *
+     * @param nameSpaceName the name space name.
+     * @param dataElementName the data element name.
+     * @return the decoded data.
+     * @throws IllegalArgumentException if the given name space doesn't exist.
+     * @throws IllegalArgumentException if the given data eoement doesn't exist.
+     * @throws IllegalArgumentException if the given data element isn't a string.
+     */
+    public @NonNull String getDataElementString(@NonNull String nameSpaceName,
+                                                @NonNull String dataElementName) {
+        return Util.cborDecodeString(getDataElement(nameSpaceName, dataElementName));
+    }
+
+    /**
+     * Like {@link #getDataElement(String, String)} but decodes the CBOR as a byte string.
+     *
+     * @param nameSpaceName the name space name.
+     * @param dataElementName the data element name.
+     * @return the decoded data.
+     * @throws IllegalArgumentException if the given name space doesn't exist.
+     * @throws IllegalArgumentException if the given data eoement doesn't exist.
+     * @throws IllegalArgumentException if the given data element isn't a byte string.
+     */
+    public @NonNull byte[] getDataElementByteString(@NonNull String nameSpaceName,
+                                                    @NonNull String dataElementName) {
+        return Util.cborDecodeByteString(getDataElement(nameSpaceName, dataElementName));
+    }
+
+    /**
+     * Like {@link #getDataElement(String, String)} but decodes the CBOR as a number.
+     *
+     * @param nameSpaceName the name space name.
+     * @param dataElementName the data element name.
+     * @return the decoded data.
+     * @throws IllegalArgumentException if the given name space doesn't exist.
+     * @throws IllegalArgumentException if the given data eoement doesn't exist.
+     * @throws IllegalArgumentException if the given data element isn't a number.
+     */
+    public long getDataElementNumber(@NonNull String nameSpaceName,
+                                     @NonNull String dataElementName) {
+        return Util.cborDecodeLong(getDataElement(nameSpaceName, dataElementName));
+    }
+
+    /**
+     * Like {@link #getDataElement(String, String)} but decodes the CBOR as a boolean.
+     *
+     * @param nameSpaceName the name space name.
+     * @param dataElementName the data element name.
+     * @return the decoded data.
+     * @throws IllegalArgumentException if the given name space doesn't exist.
+     * @throws IllegalArgumentException if the given data eoement doesn't exist.
+     * @throws IllegalArgumentException if the given data element isn't a boolean.
+     */
+    public boolean getDataElementBoolean(@NonNull String nameSpaceName,
+                                         @NonNull String dataElementName) {
+        return Util.cborDecodeBoolean(getDataElement(nameSpaceName, dataElementName));
+    }
+
+    static NameSpacedData fromCbor(@NonNull DataItem dataItem) {
+        LinkedHashMap<String, LinkedHashMap<String, byte[]>> ret = new LinkedHashMap<>();
+        if (!(dataItem instanceof co.nstant.in.cbor.model.Map)) {
+            throw new IllegalArgumentException("dataItem is not a map");
+        }
+        for (DataItem nameSpaceNameItem : ((co.nstant.in.cbor.model.Map) dataItem).getKeys()) {
+            if (!(nameSpaceNameItem instanceof UnicodeString)) {
+                throw new IllegalArgumentException("Expected string for namespace name");
+            }
+            String namespaceName = ((UnicodeString) nameSpaceNameItem).getString();
+            LinkedHashMap<String, byte[]> dataElementToValueMap = new LinkedHashMap<>();
+            DataItem dataElementItems = Util.cborMapExtractMap(dataItem, namespaceName);
+            if (!(dataElementItems instanceof co.nstant.in.cbor.model.Map)) {
+                throw new IllegalArgumentException("Expected map");
+            }
+            for (DataItem dataElementNameItem : ((co.nstant.in.cbor.model.Map) dataElementItems).getKeys()) {
+                if (!(dataElementNameItem instanceof UnicodeString)) {
+                    throw new IllegalArgumentException("Expected string for data element name");
+                }
+                String dataElementName = ((UnicodeString) dataElementNameItem).getString();
+                DataItem valueItem = ((co.nstant.in.cbor.model.Map) dataElementItems).get(dataElementNameItem);
+                if (!(valueItem instanceof ByteString)) {
+                    throw new IllegalArgumentException("Expected bytestring for data element value");
+                }
+                byte[] value = ((ByteString) valueItem).getBytes();
+                dataElementToValueMap.put(dataElementName, value);
+            }
+            ret.put(namespaceName, dataElementToValueMap);
+        }
+        return new NameSpacedData(ret);
+    }
+
+    DataItem toCbor() {
+        CborBuilder builder = new CborBuilder();
+        MapBuilder<CborBuilder> mapBuilder = builder.addMap();
+        for (String namespaceName : mMap.keySet()) {
+            MapBuilder<MapBuilder<CborBuilder>> innerMapBuilder = mapBuilder.putMap(namespaceName);
+            LinkedHashMap<String, byte[]> namespace = mMap.get(namespaceName);
+            for (String dataElementName : namespace.keySet()) {
+                byte[] dataElementValue = namespace.get(dataElementName);
+                ByteString taggedBstr = new ByteString(dataElementValue);
+                taggedBstr.setTag(new Tag(24));
+                innerMapBuilder.put(new UnicodeString(dataElementName), taggedBstr);
+            }
+        }
+        return builder.build().get(0);
+    }
+
+    /**
+     * Encodes the given {@link NameSpacedData} as CBOR.
+     *
+     * <p>The encoding uses the following CDDL:
+     * <pre>
+     *     NameSpacedCbor = {
+     *         + NameSpaceName =&gt; DataElements
+     *     }
+     *
+     *     NameSpaceName = tstr
+     *
+     *     DataElements = [
+     *         + DataElementName =&gt; DataElementValueBytes
+     *     ]
+     *
+     *     DataElementName = tstr
+     *     DataElementValue = any
+     *     DataElementValueBytes = #6.24(bstr .cbor DataElementValue)
+     * </pre>
+     *
+     * <p>Here's an example of CBOR conforming to the above CDDL printed in diagnostic form:
+     * <pre>
+     *     {
+     *         "org.iso.18013.5.1" : {
+     *             "given_name" : 24(&lt;&lt; "Erika" &gt;&gt;),
+     *             "family_name" : 24(&lt;&lt; "Mustermann" &gt;&gt;),
+     *         },
+     *         "org.iso.18013.5.1.aamva" : {
+     *             "organ_donor" : 24(&lt;&lt; 1 &gt;&gt;)
+     *         }
+     *     }
+     * </pre>
+     *
+     * <p>Name spaces and data elements will be in the order they were inserted using
+     * at construction time, either using the {@link Builder} or
+     * {@link #fromEncodedCbor(byte[])}).
+     *
+     * @return the bytes of the encoding describe above.
+     */
+    public @NonNull byte[] encodeAsCbor() {
+        return Util.cborEncode(toCbor());
+    }
+
+    /**
+     * A builder for {@link NameSpacedData}.
+     */
+    public static class Builder {
+        LinkedHashMap<String, LinkedHashMap<String, byte[]>> mMap = new LinkedHashMap<>();
+
+        /**
+         * Constructor.
+         */
+        public Builder() {}
+
+        /**
+         * Adds a raw CBOR value to the builder.
+         *
+         * <p>For performance-reasons the passed in value isn't validated and it's the
+         * responsibility of the application to perform this check if for example operating
+         * on untrusted data.
+         *
+         * @param nameSpaceName the name space name.
+         * @param dataElementName the data element name.
+         * @param value the bytes of the CBOR.
+         * @return the builder.
+         */
+        public @NonNull Builder putEntry(@NonNull String nameSpaceName,
+                                         @NonNull String dataElementName,
+                                         @NonNull byte[] value) {
+            LinkedHashMap<String, byte[]> innerMap = mMap.get(nameSpaceName);
+            if (innerMap == null) {
+                innerMap = new LinkedHashMap<>();
+                mMap.put(nameSpaceName, innerMap);
+            }
+            innerMap.put(dataElementName, value);
+            return this;
+        }
+
+        /**
+         * Encode the given value as {@code tstr} CBOR and adds it to the builder.
+         *
+         * @param nameSpaceName the name space name.
+         * @param dataElementName the data element name.
+         * @param value A string.
+         * @return the builder.
+         */
+        public @NonNull Builder putEntryString(@NonNull String nameSpaceName,
+                                               @NonNull String dataElementName,
+                                               @NonNull String value) {
+            return putEntry(nameSpaceName, dataElementName, Util.cborEncodeString(value));
+        }
+
+        /**
+         * Encode the given value as {@code bstr} CBOR and adds it to the builder.
+         *
+         * @param nameSpaceName the name space name.
+         * @param dataElementName the data element name.
+         * @param value A byte string.
+         * @return the builder.
+         */
+        public @NonNull Builder putEntryByteString(@NonNull String nameSpaceName,
+                                                   @NonNull String dataElementName,
+                                                   @NonNull byte[] value) {
+            return putEntry(nameSpaceName, dataElementName, Util.cborEncodeBytestring(value));
+        }
+
+        /**
+         * Encode the given value as an integer or unsigned integer and adds it to the builder.
+         *
+         * @param nameSpaceName the name space name.
+         * @param dataElementName the data element name.
+         * @param value The value, as a {@code long}.
+         * @return the builder.
+         */
+        public @NonNull Builder putEntryNumber(@NonNull String nameSpaceName,
+                                               @NonNull String dataElementName,
+                                               long value) {
+            return putEntry(nameSpaceName, dataElementName, Util.cborEncodeNumber(value));
+        }
+
+        /**
+         * Encode the given value as a boolean and adds it to the builder.
+         *
+         * @param nameSpaceName the name space name.
+         * @param dataElementName the data element name.
+         * @param value The value, as a {@code boolean}..
+         * @return the builder.
+         */
+        public @NonNull Builder putEntryBoolean(@NonNull String nameSpaceName,
+                                                @NonNull String dataElementName,
+                                                boolean value) {
+            return putEntry(nameSpaceName, dataElementName, Util.cborEncodeBoolean(value));
+        }
+
+        /**
+         * Builds a {@link NameSpacedData} from the builder
+         *
+         * @return a {@link NameSpacedData} instance.
+         */
+        public @NonNull NameSpacedData build() {
+            return new NameSpacedData(mMap);
+        }
+    }
+}

--- a/identity/src/test/java/com/android/identity/credential/CredentialStoreTest.java
+++ b/identity/src/test/java/com/android/identity/credential/CredentialStoreTest.java
@@ -1,0 +1,640 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity.credential;
+
+import com.android.identity.internal.Util;
+import com.android.identity.keystore.BouncyCastleKeystore;
+import com.android.identity.keystore.KeystoreEngine;
+import com.android.identity.keystore.KeystoreEngineRepository;
+import com.android.identity.storage.EphemeralStorageEngine;
+import com.android.identity.storage.StorageEngine;
+import com.android.identity.util.Timestamp;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.security.cert.X509Certificate;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+
+public class CredentialStoreTest {
+    StorageEngine mStorageEngine;
+
+    KeystoreEngine mKeystoreEngine;
+
+    KeystoreEngineRepository mKeystoreEngineRepository;
+
+    @Before
+    public void setup() {
+        mStorageEngine = new EphemeralStorageEngine();
+
+        mKeystoreEngineRepository = new KeystoreEngineRepository();
+        mKeystoreEngine = new BouncyCastleKeystore(mStorageEngine);
+        mKeystoreEngineRepository.addImplementation(mKeystoreEngine);
+    }
+
+    @Test
+    public void testListCredentials() {
+        mStorageEngine.deleteAll();
+        CredentialStore credentialStore = new CredentialStore(
+                mStorageEngine,
+                mKeystoreEngineRepository);
+
+        Assert.assertEquals(0, credentialStore.listCredentials().size());
+        for (int n = 0; n < 10; n++) {
+            credentialStore.createCredential(
+                    "testCred" + n,
+                    new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+        }
+        Assert.assertEquals(10, credentialStore.listCredentials().size());
+        credentialStore.deleteCredential("testCred1");
+        Assert.assertEquals(9, credentialStore.listCredentials().size());
+        for (int n = 0; n < 10; n++) {
+            if (n == 1) {
+                Assert.assertFalse(credentialStore.listCredentials().contains("testCred" + n));
+            } else {
+                Assert.assertTrue(credentialStore.listCredentials().contains("testCred" + n));
+            }
+        }
+    }
+
+    @Test
+    public void testCreationDeletion() {
+
+        CredentialStore credentialStore = new CredentialStore(
+                mStorageEngine,
+                mKeystoreEngineRepository);
+
+        Credential credential = credentialStore.createCredential(
+                "testCredential",
+                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+        Assert.assertEquals("testCredential", credential.getName());
+        List<X509Certificate> certChain = credential.getAttestation();
+        Assert.assertTrue(certChain.size() >= 1);
+
+        credential = credentialStore.lookupCredential("testCredential");
+        Assert.assertNotNull(credential);
+        Assert.assertEquals("testCredential", credential.getName());
+        List<X509Certificate> certChain2 = credential.getAttestation();
+        Assert.assertEquals(certChain.size(), certChain2.size());
+        for (int n = 0; n < certChain.size(); n++) {
+            Assert.assertEquals(certChain.get(n), certChain2.get(n));
+        }
+
+        Assert.assertNull(credentialStore.lookupCredential("nonExistingCredential"));
+
+        // Check creating a credential with an existing name overwrites the existing one
+        credential = credentialStore.createCredential(
+                "testCredential",
+                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+        Assert.assertEquals("testCredential", credential.getName());
+        // At least the leaf certificate should be different
+        List<X509Certificate> certChain3 = credential.getAttestation();
+        Assert.assertNotEquals(certChain3.get(0), certChain2.get(0));
+
+        credential = credentialStore.lookupCredential("testCredential");
+        Assert.assertNotNull(credential);
+        Assert.assertEquals("testCredential", credential.getName());
+
+        credentialStore.deleteCredential("testCredential");
+        Assert.assertNull(credentialStore.lookupCredential("testCredential"));
+    }
+
+    @Test
+    public void testNameSpacedData() {
+        CredentialStore credentialStore = new CredentialStore(
+                mStorageEngine,
+                mKeystoreEngineRepository);
+
+        Credential credential = credentialStore.createCredential(
+                "testCredential",
+                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+
+        // After creation, NameSpacedData is present but empty.
+        Assert.assertEquals(0, credential.getNameSpacedData().getNameSpaceNames().size());
+
+        NameSpacedData nameSpacedData = new NameSpacedData.Builder()
+                .putEntryString("ns1", "foo1", "bar1")
+                .putEntryString("ns1", "foo2", "bar2")
+                .putEntryString("ns1", "foo3", "bar3")
+                .putEntryString("ns2", "bar1", "foo1")
+                .putEntryString("ns2", "bar2", "foo2")
+                .build();
+        credential.setNameSpacedData(nameSpacedData);
+
+        Credential loadedCredential = credentialStore.lookupCredential("testCredential");
+        Assert.assertNotNull(loadedCredential);
+        Assert.assertEquals("testCredential", loadedCredential.getName());
+
+        // We check that NameSpacedData is preserved across loads by simply comparing the
+        // encoded data.
+        Assert.assertArrayEquals(
+                Util.cborEncode(credential.getNameSpacedData().toCbor()),
+                Util.cborEncode(loadedCredential.getNameSpacedData().toCbor()));
+    }
+
+    @Test
+    public void testAuthenticationKeyUsage() {
+        CredentialStore credentialStore = new CredentialStore(
+                mStorageEngine,
+                mKeystoreEngineRepository);
+
+        Credential credential = credentialStore.createCredential(
+                "testCredential",
+                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+
+        Timestamp timeBeforeValidity = Timestamp.ofEpochMilli(40);
+        Timestamp timeValidityBegin = Timestamp.ofEpochMilli(50);
+        Timestamp timeDuringValidity = Timestamp.ofEpochMilli(100);
+        Timestamp timeValidityEnd = Timestamp.ofEpochMilli(150);
+        Timestamp timeAfterValidity = Timestamp.ofEpochMilli(200);
+
+        // By default, we don't have any auth keys nor any pending auth keys.
+        Assert.assertEquals(0, credential.getAuthenticationKeys().size());
+        Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+
+        // Since none are certified or even pending yet, we can't present anything.
+        Assert.assertNull(credential.findAuthenticationKey(timeDuringValidity));
+
+        // Create ten authentication keys...
+        for (int n = 0; n < 10; n++) {
+            credential.createPendingAuthenticationKey(
+                    new BouncyCastleKeystore.CreateKeySettings.Builder().build(),
+                    null);
+        }
+        Assert.assertEquals(0, credential.getAuthenticationKeys().size());
+        Assert.assertEquals(10, credential.getPendingAuthenticationKeys().size());
+
+        // ... and certify all of them
+        int n = 0;
+        for (Credential.PendingAuthenticationKey pendingAuthenticationKey :
+                credential.getPendingAuthenticationKeys()) {
+            byte[] issuerProvidedAuthenticationData = {1, 2, (byte) n++};
+            pendingAuthenticationKey.certify(
+                    issuerProvidedAuthenticationData,
+                    timeValidityBegin,
+                    timeValidityEnd);
+        }
+        Assert.assertEquals(10, credential.getAuthenticationKeys().size());
+        Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+
+        // If at a time before anything is valid, should not be able to present
+        Assert.assertNull(credential.findAuthenticationKey(timeBeforeValidity));
+
+        // Ditto for right after
+        Assert.assertNull(credential.findAuthenticationKey(timeAfterValidity));
+
+        // Check we're able to present at a time when the auth keys are valid
+        Credential.AuthenticationKey authKey = credential.findAuthenticationKey(timeDuringValidity);
+        Assert.assertNotNull(authKey);
+
+        Assert.assertEquals(0, authKey.getUsageCount());
+
+        // B/c of how findAuthenticationKey() we know we get the first key. Match
+        // up with expected issuer signed data as per above.
+        Assert.assertEquals((byte) 0, authKey.getIssuerProvidedData()[2]);
+
+        Assert.assertEquals(0, authKey.getUsageCount());
+        authKey.increaseUsageCount();
+        Assert.assertEquals(1, authKey.getUsageCount());
+
+        // Simulate nine more presentations, all of them should now be used up
+        for (n = 0; n < 9; n++) {
+            authKey = credential.findAuthenticationKey(timeDuringValidity);
+            Assert.assertNotNull(authKey);
+
+            // B/c of how findAuthenticationKey() we know we get the keys after
+            // the first one in order. Match up with expected issuer signed data as per above.
+            Assert.assertEquals((byte) (n + 1), authKey.getIssuerProvidedData()[2]);
+
+            authKey.increaseUsageCount();
+        }
+
+        // All ten auth keys should now have a use count of 1.
+        for (Credential.AuthenticationKey authenticationKey : credential.getAuthenticationKeys()) {
+            Assert.assertEquals(1, authenticationKey.getUsageCount());
+        }
+
+        // Simulate ten more presentations
+        for (n = 0; n < 10; n++) {
+            authKey = credential.findAuthenticationKey(timeDuringValidity);
+            Assert.assertNotNull(authKey);
+            authKey.increaseUsageCount();
+        }
+
+        // All ten auth keys should now have a use count of 2.
+        for (Credential.AuthenticationKey authenticationKey : credential.getAuthenticationKeys()) {
+            Assert.assertEquals(2, authenticationKey.getUsageCount());
+        }
+
+        // Create and certify five replacements
+        for (n = 0; n < 5; n++) {
+            credential.createPendingAuthenticationKey(
+                    new BouncyCastleKeystore.CreateKeySettings.Builder().build(),
+                    null);
+        }
+        Assert.assertEquals(10, credential.getAuthenticationKeys().size());
+        Assert.assertEquals(5, credential.getPendingAuthenticationKeys().size());
+        for (Credential.PendingAuthenticationKey pendingAuthenticationKey :
+                credential.getPendingAuthenticationKeys()) {
+            pendingAuthenticationKey.certify(
+                    new byte[0],
+                    timeValidityBegin,
+                    timeValidityEnd);
+        }
+        Assert.assertEquals(15, credential.getAuthenticationKeys().size());
+        Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+
+        // Simulate ten presentations and check we get the newly created ones
+        for (n = 0; n < 10; n++) {
+            authKey = credential.findAuthenticationKey(timeDuringValidity);
+            Assert.assertNotNull(authKey);
+            Assert.assertEquals(0, authKey.getIssuerProvidedData().length);
+            authKey.increaseUsageCount();
+        }
+
+        // All fifteen auth keys should now have a use count of 2.
+        for (Credential.AuthenticationKey authenticationKey : credential.getAuthenticationKeys()) {
+            Assert.assertEquals(2, authenticationKey.getUsageCount());
+        }
+
+        // Simulate 15 more presentations
+        for (n = 0; n < 15; n++) {
+            authKey = credential.findAuthenticationKey(timeDuringValidity);
+            Assert.assertNotNull(authKey);
+            authKey.increaseUsageCount();
+        }
+
+        // All fifteen auth keys should now have a use count of 3. This shows that
+        // we're hitting the auth keys evenly (both old and new).
+        for (Credential.AuthenticationKey authenticationKey : credential.getAuthenticationKeys()) {
+            Assert.assertEquals(3, authenticationKey.getUsageCount());
+        }
+    }
+
+    @Test
+    public void testAuthenticationKeyPersistence() {
+        int n;
+
+        Timestamp timeValidityBegin = Timestamp.ofEpochMilli(50);
+        Timestamp timeValidityEnd = Timestamp.ofEpochMilli(150);
+
+        CredentialStore credentialStore = new CredentialStore(
+                mStorageEngine,
+                mKeystoreEngineRepository);
+
+        Credential credential = credentialStore.createCredential(
+                "testCredential",
+                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+
+        Assert.assertEquals(0, credential.getAuthenticationKeys().size());
+        Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+
+        // Create ten pending auth keys and certify four of them
+        for (n = 0; n < 4; n++) {
+            credential.createPendingAuthenticationKey(
+                    new BouncyCastleKeystore.CreateKeySettings.Builder().build(),
+                    null);
+        }
+        Assert.assertEquals(0, credential.getAuthenticationKeys().size());
+        Assert.assertEquals(4, credential.getPendingAuthenticationKeys().size());
+        n = 0;
+        for (Credential.PendingAuthenticationKey pendingAuthenticationKey :
+                credential.getPendingAuthenticationKeys()) {
+            // Because we check that we serialize things correctly below, make sure
+            // the data and validity times vary for each key...
+            Credential.AuthenticationKey authenticationKey =
+                    pendingAuthenticationKey.certify(
+                            new byte[]{1, 2, (byte) n},
+                            Timestamp.ofEpochMilli(timeValidityBegin.toEpochMilli() + n),
+                            Timestamp.ofEpochMilli(timeValidityEnd.toEpochMilli() + 2 * n));
+            for (int m = 0; m < n; m++) {
+                authenticationKey.increaseUsageCount();
+            }
+            Assert.assertEquals(n, authenticationKey.getUsageCount());
+        }
+        Assert.assertEquals(4, credential.getAuthenticationKeys().size());
+        Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+        for (n = 0; n < 6; n++) {
+            credential.createPendingAuthenticationKey(
+                    new BouncyCastleKeystore.CreateKeySettings.Builder().build(),
+                    null);
+        }
+        Assert.assertEquals(4, credential.getAuthenticationKeys().size());
+        Assert.assertEquals(6, credential.getPendingAuthenticationKeys().size());
+
+        Credential credential2 = credentialStore.lookupCredential("testCredential");
+        Assert.assertNotNull(credential2);
+        Assert.assertEquals(4, credential2.getAuthenticationKeys().size());
+        Assert.assertEquals(6, credential2.getPendingAuthenticationKeys().size());
+
+        // Now check that what we loaded matches what we created in-memory just above. We
+        // use the fact that the order of the keys are preserved across save/load.
+        Iterator<Credential.AuthenticationKey> it1 = credential.getAuthenticationKeys().iterator();
+        Iterator<Credential.AuthenticationKey> it2 = credential2.getAuthenticationKeys().iterator();
+        for (n = 0; n < 4; n++) {
+            Credential.AuthenticationKey key1 = it1.next();
+            Credential.AuthenticationKey key2 = it2.next();
+            Assert.assertEquals(key1.getAlias(), key2.getAlias());
+            Assert.assertEquals(key1.getValidFrom(), key2.getValidFrom());
+            Assert.assertEquals(key1.getValidUntil(), key2.getValidUntil());
+            Assert.assertEquals(key1.getUsageCount(), key2.getUsageCount());
+            Assert.assertArrayEquals(key1.getIssuerProvidedData(), key2.getIssuerProvidedData());
+            Assert.assertArrayEquals(key1.getAttestation().toArray(), key2.getAttestation().toArray());
+        }
+
+        Iterator<Credential.PendingAuthenticationKey> itp1 = credential.getPendingAuthenticationKeys().iterator();
+        Iterator<Credential.PendingAuthenticationKey> itp2 = credential2.getPendingAuthenticationKeys().iterator();
+        for (n = 0; n < 6; n++) {
+            Credential.PendingAuthenticationKey key1 = itp1.next();
+            Credential.PendingAuthenticationKey key2 = itp2.next();
+            Assert.assertEquals(key1.mAlias, key2.mAlias);
+            Assert.assertArrayEquals(key1.getAttestation().toArray(),
+                    key2.getAttestation().toArray());
+        }
+    }
+
+    @Test
+    public void testAuthenticationKeyValidity() {
+        CredentialStore credentialStore = new CredentialStore(
+                mStorageEngine,
+                mKeystoreEngineRepository);
+
+        Credential credential = credentialStore.createCredential(
+                "testCredential",
+                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+
+        // We want to check the behavior for when the holder has a birthday and the issuer
+        // carefully sends half the MSOs to be used before the birthday (with age_in_years set to
+        // 17) and half the MSOs for after the birthday (with age_in_years set to 18).
+        //
+        // The validity periods are carefully set so the MSOs for 17 are have validUntil set to
+        // to the holders birthday and the MSOs for 18 are set so validFrom starts at the birthday.
+        //
+
+        Timestamp timeValidityBegin = Timestamp.ofEpochMilli(50);
+        Timestamp timeOfUseBeforeBirthday = Timestamp.ofEpochMilli(80);
+        Timestamp timeOfBirthday = Timestamp.ofEpochMilli(100);
+        Timestamp timeOfUseAfterBirthday = Timestamp.ofEpochMilli(120);
+        Timestamp timeValidityEnd = Timestamp.ofEpochMilli(150);
+
+        // Create and certify ten auth keys. Put age_in_years as the issuer provided data so we can
+        // check it below.
+        int n;
+        for (n = 0; n < 10; n++) {
+            credential.createPendingAuthenticationKey(
+                    new BouncyCastleKeystore.CreateKeySettings.Builder().build(),
+                    null);
+        }
+        Assert.assertEquals(10, credential.getPendingAuthenticationKeys().size());
+
+        n = 0;
+        for (Credential.PendingAuthenticationKey pendingAuthenticationKey :
+                credential.getPendingAuthenticationKeys()) {
+            if (n < 5) {
+                pendingAuthenticationKey.certify(new byte[]{17}, timeValidityBegin, timeOfBirthday);
+            } else {
+                pendingAuthenticationKey.certify(new byte[]{18}, timeOfBirthday, timeValidityEnd);
+            }
+            n++;
+        }
+
+        // Simulate ten presentations before the birthday
+        for (n = 0; n < 10; n++) {
+            Credential.AuthenticationKey authenticationKey =
+                    credential.findAuthenticationKey(timeOfUseBeforeBirthday);
+            Assert.assertNotNull(authenticationKey);
+            // Check we got a key with age 17.
+            Assert.assertEquals((byte) 17, authenticationKey.getIssuerProvidedData()[0]);
+            authenticationKey.increaseUsageCount();
+        }
+
+        // Simulate twenty presentations after the birthday
+        for (n = 0; n < 20; n++) {
+            Credential.AuthenticationKey authenticationKey =
+                    credential.findAuthenticationKey(timeOfUseAfterBirthday);
+            Assert.assertNotNull(authenticationKey);
+            // Check we got a key with age 18.
+            Assert.assertEquals((byte) 18, authenticationKey.getIssuerProvidedData()[0]);
+            authenticationKey.increaseUsageCount();
+        }
+
+        // Examine the authentication keys. The first five should have use count 2, the
+        // latter five use count 4.
+        n = 0;
+        for (Credential.AuthenticationKey authenticationKey : credential.getAuthenticationKeys()) {
+            if (n++ < 5) {
+                Assert.assertEquals(2, authenticationKey.getUsageCount());
+            } else {
+                Assert.assertEquals(4, authenticationKey.getUsageCount());
+            }
+        }
+    }
+
+    @Test
+    public void testApplicationData() {
+        CredentialStore credentialStore = new CredentialStore(
+                mStorageEngine,
+                mKeystoreEngineRepository);
+
+        Credential credential = credentialStore.createCredential(
+                "testCredential",
+                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+
+        // After creation, NameSpacedData is present but empty.
+        Assert.assertEquals(0, credential.getNameSpacedData().getNameSpaceNames().size());
+
+        Assert.assertNull(credential.getApplicationData("key1"));
+        Assert.assertNull(credential.getApplicationData("key2"));
+
+        credential.setApplicationDataString("key1", "value1");
+        Assert.assertEquals("value1", credential.getApplicationDataString("key1"));
+
+        credential.setApplicationDataString("key2", "value2");
+        Assert.assertEquals("value2", credential.getApplicationDataString("key2"));
+
+        credential.setApplicationData("key3", new byte[]{1, 2, 3, 4});
+        Assert.assertArrayEquals(new byte[]{1, 2, 3, 4}, credential.getApplicationData("key3"));
+
+        credential.setApplicationData("key2", null);
+        Assert.assertNull(credential.getApplicationData("key2"));
+
+        // Load the credential again and check that data is still there
+        Credential loadedCredential = credentialStore.lookupCredential("testCredential");
+        Assert.assertNotNull(loadedCredential);
+        Assert.assertEquals("testCredential", loadedCredential.getName());
+
+        Assert.assertEquals("value1", credential.getApplicationDataString("key1"));
+        Assert.assertNull(credential.getApplicationData("key2"));
+        Assert.assertArrayEquals(new byte[]{1, 2, 3, 4}, credential.getApplicationData("key3"));
+    }
+
+    @Test
+    public void testAuthKeyApplicationData() {
+        CredentialStore credentialStore = new CredentialStore(
+                mStorageEngine,
+                mKeystoreEngineRepository);
+
+        Credential credential = credentialStore.createCredential(
+                "testCredential",
+                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+
+        KeystoreEngine.CreateKeySettings authKeySettings =
+                new BouncyCastleKeystore.CreateKeySettings.Builder()
+                        .build();
+        for (int n = 0; n < 10; n++) {
+            Credential.PendingAuthenticationKey pendingAuthKey =
+                    credential.createPendingAuthenticationKey(
+                            new BouncyCastleKeystore.CreateKeySettings.Builder().build(),
+                            null);
+            String value = String.format(Locale.US, "bar%02d", n);
+            pendingAuthKey.setApplicationDataString("foo", value);
+            pendingAuthKey.setApplicationData("bar", new byte[0]);
+            Assert.assertEquals(value, pendingAuthKey.getApplicationDataString("foo"));
+            Assert.assertEquals(0, pendingAuthKey.getApplicationDataString("bar").length());
+            Assert.assertNull(pendingAuthKey.getApplicationDataString("non-existent"));
+        }
+        Assert.assertEquals(10, credential.getPendingAuthenticationKeys().size());
+        Assert.assertEquals(0, credential.getAuthenticationKeys().size());
+
+        // Check that it's persisted to disk.
+        credential = credentialStore.lookupCredential("testCredential");
+        Assert.assertEquals(10, credential.getPendingAuthenticationKeys().size());
+        int n = 0;
+        for (Credential.PendingAuthenticationKey pendingAuthKey : credential.getPendingAuthenticationKeys()) {
+            String value = String.format(Locale.US, "bar%02d", n++);
+            Assert.assertEquals(value, pendingAuthKey.getApplicationDataString("foo"));
+            Assert.assertEquals(0, pendingAuthKey.getApplicationDataString("bar").length());
+            Assert.assertNull(pendingAuthKey.getApplicationDataString("non-existent"));
+        }
+
+        // Certify and check that data carries over from PendingAuthenticationKey
+        // to AuthenticationKey
+        n = 0;
+        for (Credential.PendingAuthenticationKey pendingAuthKey : credential.getPendingAuthenticationKeys()) {
+            String value = String.format(Locale.US, "bar%02d", n++);
+            Assert.assertEquals(value, pendingAuthKey.getApplicationDataString("foo"));
+            Assert.assertEquals(0, pendingAuthKey.getApplicationDataString("bar").length());
+            Assert.assertNull(pendingAuthKey.getApplicationDataString("non-existent"));
+            Credential.AuthenticationKey authKey = pendingAuthKey.certify(new byte[] {0, (byte) n},
+                    Timestamp.ofEpochMilli(100),
+                    Timestamp.ofEpochMilli(200));
+            Assert.assertEquals(value, authKey.getApplicationDataString("foo"));
+            Assert.assertEquals(0, authKey.getApplicationDataString("bar").length());
+            Assert.assertNull(authKey.getApplicationDataString("non-existent"));
+        }
+
+        // Check it's persisted to disk.
+        n = 0;
+        for (Credential.AuthenticationKey authKey : credential.getAuthenticationKeys()) {
+            String value = String.format(Locale.US, "bar%02d", n++);
+            Assert.assertEquals(value, authKey.getApplicationDataString("foo"));
+            Assert.assertEquals(0, authKey.getApplicationDataString("bar").length());
+            Assert.assertNull(authKey.getApplicationDataString("non-existent"));
+        }
+    }
+
+    @Test
+    public void testAuthKeyReplacement() {
+        CredentialStore credentialStore = new CredentialStore(
+                mStorageEngine,
+                mKeystoreEngineRepository);
+
+        Credential credential = credentialStore.createCredential(
+                "testCredential",
+                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+
+        Assert.assertEquals(0, credential.getAuthenticationKeys().size());
+        Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+
+        KeystoreEngine.CreateKeySettings authKeySettings =
+                new BouncyCastleKeystore.CreateKeySettings.Builder()
+                        .build();
+        for (int n = 0; n < 10; n++) {
+            Credential.PendingAuthenticationKey pendingAuthKey =
+                    credential.createPendingAuthenticationKey(
+                            new BouncyCastleKeystore.CreateKeySettings.Builder().build(),
+                            null);
+            pendingAuthKey.certify(new byte[] {0, (byte) n},
+                    Timestamp.ofEpochMilli(100),
+                    Timestamp.ofEpochMilli(200));
+        }
+        Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+        Assert.assertEquals(10, credential.getAuthenticationKeys().size());
+
+        // Now replace the fifth authentication key
+        Credential.AuthenticationKey keyToReplace = credential.getAuthenticationKeys().get(5);
+        Assert.assertArrayEquals(new byte[] {0, 5}, keyToReplace.getIssuerProvidedData());
+        Credential.PendingAuthenticationKey pendingAuthKey =
+                credential.createPendingAuthenticationKey(
+                        new BouncyCastleKeystore.CreateKeySettings.Builder().build(),
+                        keyToReplace);
+        // ... it's not replaced until certify() is called
+        Assert.assertEquals(1, credential.getPendingAuthenticationKeys().size());
+        Assert.assertEquals(10, credential.getAuthenticationKeys().size());
+        pendingAuthKey.certify(new byte[] {1, 0},
+                Timestamp.ofEpochMilli(100),
+                Timestamp.ofEpochMilli(200));
+        // ... now it shuold be gone.
+        Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+        Assert.assertEquals(10, credential.getAuthenticationKeys().size());
+
+        // Check that it was indeed the fifth key that was replaced inspecting issuer-provided data.
+        // We rely on some implementation details on how ordering works... also cross-reference
+        // with data passed into certify() functions above.
+        int count = 0;
+        for (Credential.AuthenticationKey authKey : credential.getAuthenticationKeys()) {
+            byte[][] expectedData = {
+                    new byte[] {0, 0},
+                    new byte[] {0, 1},
+                    new byte[] {0, 2},
+                    new byte[] {0, 3},
+                    new byte[] {0, 4},
+                    new byte[] {0, 6},
+                    new byte[] {0, 7},
+                    new byte[] {0, 8},
+                    new byte[] {0, 9},
+                    new byte[] {1, 0},
+            };
+            Assert.assertArrayEquals(expectedData[count++], authKey.getIssuerProvidedData());
+        }
+
+        // Test the case where the replacement key is prematurely deleted. The key
+        // being replaced should no longer reference it has a replacement...
+        Credential.AuthenticationKey toBeReplaced = credential.getAuthenticationKeys().get(0);
+        Credential.PendingAuthenticationKey replacement =
+                credential.createPendingAuthenticationKey(
+                        new BouncyCastleKeystore.CreateKeySettings.Builder().build(),
+                        toBeReplaced);
+        Assert.assertEquals(toBeReplaced, replacement.getReplacementFor());
+        Assert.assertEquals(replacement, toBeReplaced.getReplacement());
+        replacement.delete();
+        Assert.assertNull(toBeReplaced.getReplacement());
+
+        // Similarly, test the case where the key to be replaced is prematurely deleted.
+        // The replacement key should no longer indicate it's a replacement key.
+        replacement = credential.createPendingAuthenticationKey(
+                new BouncyCastleKeystore.CreateKeySettings.Builder().build(),
+                toBeReplaced);
+        Assert.assertEquals(toBeReplaced, replacement.getReplacementFor());
+        Assert.assertEquals(replacement, toBeReplaced.getReplacement());
+        toBeReplaced.delete();
+        Assert.assertNull(replacement.getReplacementFor());
+    }
+}

--- a/identity/src/test/java/com/android/identity/credential/CredentialUtilTest.java
+++ b/identity/src/test/java/com/android/identity/credential/CredentialUtilTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity.credential;
+
+import com.android.identity.keystore.BouncyCastleKeystore;
+import com.android.identity.keystore.KeystoreEngine;
+import com.android.identity.keystore.KeystoreEngineRepository;
+import com.android.identity.storage.EphemeralStorageEngine;
+import com.android.identity.storage.StorageEngine;
+import com.android.identity.util.Timestamp;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CredentialUtilTest {
+    StorageEngine mStorageEngine;
+
+    KeystoreEngine mKeystoreEngine;
+
+    KeystoreEngineRepository mKeystoreEngineRepository;
+
+    @Before
+    public void setup() {
+        mStorageEngine = new EphemeralStorageEngine();
+
+        mKeystoreEngineRepository = new KeystoreEngineRepository();
+        mKeystoreEngine = new BouncyCastleKeystore(mStorageEngine);
+        mKeystoreEngineRepository.addImplementation(mKeystoreEngine);
+    }
+
+    @Test
+    public void testManagedAuthenticationKeyHelper() {
+        CredentialStore credentialStore = new CredentialStore(
+                mStorageEngine,
+                mKeystoreEngineRepository);
+
+        Credential credential = credentialStore.createCredential(
+                "testCredential",
+                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+
+        Assert.assertEquals(0, credential.getAuthenticationKeys().size());
+        Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+
+        KeystoreEngine.CreateKeySettings authKeySettings =
+                new BouncyCastleKeystore.CreateKeySettings.Builder()
+                        .build();
+
+        int numAuthKeys = 10;
+        int maxUsesPerKey = 5;
+        long minValidTimeMillis = 10;
+        int count;
+        int numKeysCreated;
+        String managedKeyDomain = "managedAuthenticationKeys";
+
+        // Start the process at time 100 and certify all those keys so they're
+        // valid until time 200.
+        numKeysCreated = CredentialUtil.managedAuthenticationKeyHelper(
+                credential,
+                authKeySettings,
+                managedKeyDomain,
+                Timestamp.ofEpochMilli(100),
+                numAuthKeys,
+                maxUsesPerKey,
+                minValidTimeMillis);
+        Assert.assertEquals(numAuthKeys, numKeysCreated);
+        Assert.assertEquals(numAuthKeys, credential.getPendingAuthenticationKeys().size());
+        count = 0;
+        for (Credential.PendingAuthenticationKey pak : credential.getPendingAuthenticationKeys()) {
+            pak.certify(new byte[] {0, (byte) count++},
+                    Timestamp.ofEpochMilli(100),
+                    Timestamp.ofEpochMilli(200));
+        }
+        // We should now have |numAuthKeys| certified keys and none pending
+        Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+        Assert.assertEquals(numAuthKeys, credential.getAuthenticationKeys().size());
+
+        // Certifying again at this point should not make a difference.
+        numKeysCreated = CredentialUtil.managedAuthenticationKeyHelper(
+                credential,
+                authKeySettings,
+                managedKeyDomain,
+                Timestamp.ofEpochMilli(100),
+                numAuthKeys,
+                maxUsesPerKey,
+                minValidTimeMillis);
+        Assert.assertEquals(0, numKeysCreated);
+        Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+
+        // Use up until just before the limit, and check it doesn't make a difference
+        for (Credential.AuthenticationKey ak : credential.getAuthenticationKeys()) {
+            for (int n = 0; n < maxUsesPerKey - 1; n++) {
+                ak.increaseUsageCount();
+            }
+        }
+        numKeysCreated = CredentialUtil.managedAuthenticationKeyHelper(
+                credential,
+                authKeySettings,
+                managedKeyDomain,
+                Timestamp.ofEpochMilli(100),
+                numAuthKeys,
+                maxUsesPerKey,
+                minValidTimeMillis);
+        Assert.assertEquals(0, numKeysCreated);
+        Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+
+        // For the first 5, use one more time and check replacements are generated for those
+        // Let the replacements expire just a tad later
+        count = 0;
+        for (Credential.AuthenticationKey ak : credential.getAuthenticationKeys()) {
+            ak.increaseUsageCount();
+            if (++count >= 5) {
+                break;
+            }
+        }
+        numKeysCreated = CredentialUtil.managedAuthenticationKeyHelper(
+                credential,
+                authKeySettings,
+                managedKeyDomain,
+                Timestamp.ofEpochMilli(100),
+                numAuthKeys,
+                maxUsesPerKey,
+                minValidTimeMillis);
+        Assert.assertEquals(5, numKeysCreated);
+        Assert.assertEquals(5, credential.getPendingAuthenticationKeys().size());
+        count = 0;
+        for (Credential.PendingAuthenticationKey pak : credential.getPendingAuthenticationKeys()) {
+            pak.certify(new byte[] {1, (byte) count++},
+                    Timestamp.ofEpochMilli(100),
+                    Timestamp.ofEpochMilli(210));
+        }
+        // We should now have |numAuthKeys| certified keys and none pending
+        Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+        Assert.assertEquals(numAuthKeys, credential.getAuthenticationKeys().size());
+        // Check that the _right_ ones were removed by inspecting issuer-provided data.
+        // We rely on some implementation details on how ordering works... also cross-reference
+        // with data passed into certify() functions above.
+        count = 0;
+        for (Credential.AuthenticationKey authKey : credential.getAuthenticationKeys()) {
+            byte[][] expectedData = {
+                    new byte[] {0, 5},
+                    new byte[] {0, 6},
+                    new byte[] {0, 7},
+                    new byte[] {0, 8},
+                    new byte[] {0, 9},
+                    new byte[] {1, 0},
+                    new byte[] {1, 1},
+                    new byte[] {1, 2},
+                    new byte[] {1, 3},
+                    new byte[] {1, 4},
+            };
+            Assert.assertArrayEquals(expectedData[count++], authKey.getIssuerProvidedData());
+        }
+
+        // Now move close to the expiration date of the original five auth keys.
+        // This should trigger just them for replacement
+        numKeysCreated = CredentialUtil.managedAuthenticationKeyHelper(
+                credential,
+                authKeySettings,
+                managedKeyDomain,
+                Timestamp.ofEpochMilli(195),
+                numAuthKeys,
+                maxUsesPerKey,
+                minValidTimeMillis);
+        Assert.assertEquals(5, numKeysCreated);
+        Assert.assertEquals(5, credential.getPendingAuthenticationKeys().size());
+        count = 0;
+        for (Credential.PendingAuthenticationKey pak : credential.getPendingAuthenticationKeys()) {
+            pak.certify(new byte[] {2, (byte) count++},
+                    Timestamp.ofEpochMilli(100),
+                    Timestamp.ofEpochMilli(210));
+        }
+        // We should now have |numAuthKeys| certified keys and none pending
+        Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+        Assert.assertEquals(numAuthKeys, credential.getAuthenticationKeys().size());
+        // Check that the _right_ ones were removed by inspecting issuer-provided data.
+        // We rely on some implementation details on how ordering works... also cross-reference
+        // with data passed into certify() functions above.
+        count = 0;
+        for (Credential.AuthenticationKey authKey : credential.getAuthenticationKeys()) {
+            byte[][] expectedData = {
+                    new byte[] {1, 0},
+                    new byte[] {1, 1},
+                    new byte[] {1, 2},
+                    new byte[] {1, 3},
+                    new byte[] {1, 4},
+                    new byte[] {2, 0},
+                    new byte[] {2, 1},
+                    new byte[] {2, 2},
+                    new byte[] {2, 3},
+                    new byte[] {2, 4},
+            };
+            Assert.assertArrayEquals(expectedData[count++], authKey.getIssuerProvidedData());
+        }
+    }
+}

--- a/identity/src/test/java/com/android/identity/credential/NameSpacedDataTest.java
+++ b/identity/src/test/java/com/android/identity/credential/NameSpacedDataTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity.credential;
+
+import androidx.annotation.NonNull;
+
+import com.android.identity.util.CborUtil;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NameSpacedDataTest {
+
+    static void
+    checkNameSpaced(@NonNull NameSpacedData nameSpacedData) {
+        Assert.assertEquals(3, nameSpacedData.getNameSpaceNames().size());
+        Assert.assertEquals("ns1", nameSpacedData.getNameSpaceNames().get(0));
+        Assert.assertEquals("ns2", nameSpacedData.getNameSpaceNames().get(1));
+        Assert.assertEquals(3, nameSpacedData.getDataElementNames("ns1").size());
+        Assert.assertEquals("bar1", nameSpacedData.getDataElementString("ns1", "foo1"));
+        Assert.assertEquals("bar2", nameSpacedData.getDataElementString("ns1", "foo2"));
+        Assert.assertEquals("bar3", nameSpacedData.getDataElementString("ns1", "foo3"));
+        Assert.assertEquals(2, nameSpacedData.getDataElementNames("ns2").size());
+        Assert.assertEquals("foo1", nameSpacedData.getDataElementString("ns2", "bar1"));
+        Assert.assertEquals("foo2", nameSpacedData.getDataElementString("ns2", "bar2"));
+
+        Assert.assertEquals("a string", nameSpacedData.getDataElementString("test", "tstr"));
+        Assert.assertArrayEquals(new byte[] {1, 2}, nameSpacedData.getDataElementByteString("test", "bstr"));
+        Assert.assertEquals(42, nameSpacedData.getDataElementNumber("test", "pos"));
+        Assert.assertEquals(-42, nameSpacedData.getDataElementNumber("test", "neg"));
+        Assert.assertTrue(nameSpacedData.getDataElementBoolean("test", "true"));
+        Assert.assertFalse(nameSpacedData.getDataElementBoolean("test", "false"));
+
+        Assert.assertTrue(nameSpacedData.hasDataElement("ns1", "foo1"));
+        Assert.assertFalse(nameSpacedData.hasDataElement("ns1", "does_not_exist"));
+        Assert.assertFalse(nameSpacedData.hasDataElement("does_not_exist", "foo1"));
+    }
+
+    @Test
+    public void testNameSpacedData() {
+        NameSpacedData nameSpacedData = new NameSpacedData.Builder()
+                .putEntryString("ns1", "foo1", "bar1")
+                .putEntryString("ns1", "foo2", "bar2")
+                .putEntryString("ns1", "foo3", "bar3")
+                .putEntryString("ns2", "bar1", "foo1")
+                .putEntryString("ns2", "bar2", "foo2")
+                .putEntryString("test", "tstr", "a string")
+                .putEntryByteString("test", "bstr", new byte[] {1, 2})
+                .putEntryNumber("test", "pos", 42)
+                .putEntryNumber("test", "neg", -42)
+                .putEntryBoolean("test", "true", true)
+                .putEntryBoolean("test", "false", false)
+                .build();
+        byte[] asCbor = nameSpacedData.encodeAsCbor();
+        Assert.assertEquals("{\n" +
+                        "  \"ns1\": {\n" +
+                        "    \"foo1\": 24(<< \"bar1\" >>),\n" +
+                        "    \"foo2\": 24(<< \"bar2\" >>),\n" +
+                        "    \"foo3\": 24(<< \"bar3\" >>)\n" +
+                        "  },\n" +
+                        "  \"ns2\": {\n" +
+                        "    \"bar1\": 24(<< \"foo1\" >>),\n" +
+                        "    \"bar2\": 24(<< \"foo2\" >>)\n" +
+                        "  },\n" +
+                        "  \"test\": {\n" +
+                        "    \"tstr\": 24(<< \"a string\" >>),\n" +
+                        "    \"bstr\": 24(<< h'0102' >>),\n" +
+                        "    \"pos\": 24(<< 42 >>),\n" +
+                        "    \"neg\": 24(<< -42 >>),\n" +
+                        "    \"true\": 24(<< true >>),\n" +
+                        "    \"false\": 24(<< false >>)\n" +
+                        "  }\n" +
+                        "}",
+                CborUtil.toDiagnostics(asCbor,
+                        CborUtil.DIAGNOSTICS_FLAG_PRETTY_PRINT
+                                | CborUtil.DIAGNOSTICS_FLAG_EMBEDDED_CBOR));
+
+        checkNameSpaced(nameSpacedData);
+
+        NameSpacedData decoded = NameSpacedData.fromEncodedCbor(asCbor);
+        checkNameSpaced(decoded);
+    }
+
+}


### PR DESCRIPTION
This adds a new credential store, replacing IdentityCredentialStore.

The new credential store is built on top of StorageEngine and KeystoreEngine introduced in previous commits and as such can work in non-Android environments. Additionally, the credential store is generic in the sense that it is not tied to ISO/IEC 18013-5:2021 at all, it can work for any credential shape, regardless of data-model, presentation-protocol, or issuance-protocol.

A future commit will add ways to use this new credential store for 18013-5 presentations and also migrate credentials from IdentityCredentialStore, preserving key material and PII previously issued.

Test: New unit test and all unit tests pass.
