### PR TITLE
Fix up NFC negotiated handover unit tests.

### DIFF
--- a/identity-android/src/androidTest/java/com/android/identity/android/mdoc/engagement/NfcEnagementHelperTest.java
+++ b/identity-android/src/androidTest/java/com/android/identity/android/mdoc/engagement/NfcEnagementHelperTest.java
@@ -314,8 +314,8 @@ public class NfcEnagementHelperTest {
         Assert.assertEquals(0x10, spr.tnepVersion);
         Assert.assertEquals("urn:nfc:sn:handover", spr.serviceNameUri);
         Assert.assertEquals(0x00, spr.tnepCommunicationMode);
-        Assert.assertEquals(0.5, spr.tWaitMillis, 0.001);
-        Assert.assertEquals(0, spr.nWait);
+        Assert.assertEquals(8.0, spr.tWaitMillis, 0.001);
+        Assert.assertEquals(15, spr.nWait);
 
         // Keep the following code in sync with verificationHelper.startNegotiatedHandover()
 


### PR DESCRIPTION
Forgot to update the unit tests when landing the changes to NFC negotiated handover in
https://github.com/google/identity-credential/commit/c4f18ecd03958974fa72fb2ac435a84276e07cdd

Test: All unit tests pass
