### PR TITLE
Ensuring StaticAuthDataParser meets API spec

### DIFF
--- a/identity-android/src/main/java/com/android/identity/android/legacy/Utility.java
+++ b/identity-android/src/main/java/com/android/identity/android/legacy/Utility.java
@@ -274,10 +274,10 @@ public class Utility {
                         + "issuerSignedMapping");
             } else {
                 Collection<String> entryNames = issuerSigned.getEntryNames(namespaceName);
-                for (byte[] encodedIssuerSignedItem : encodedIssuerSignedItemForNs) {
+                for (byte[] encodedTaggedIssuerSignedItem : encodedIssuerSignedItemForNs) {
+                    byte[] encodedIssuerSignedItem = Util.cborExtractTaggedCbor(encodedTaggedIssuerSignedItem);
                     DataItem issuerSignedItem = Util.cborDecode(encodedIssuerSignedItem);
-                    String elemName = Util
-                            .cborMapExtractString(issuerSignedItem, "elementIdentifier");
+                    String elemName = Util.cborMapExtractString(issuerSignedItem, "elementIdentifier");
 
                     if (!entryNames.contains(elemName)) {
                         continue;
@@ -287,7 +287,8 @@ public class Utility {
                         byte[] encodedIssuerSignedItemWithValue =
                                 Util.issuerSignedItemSetValue(encodedIssuerSignedItem, elemValue);
 
-                        newEncodedIssuerSignedItemForNs.add(encodedIssuerSignedItemWithValue);
+                        newEncodedIssuerSignedItemForNs.add(
+                                Util.cborEncode(Util.cborBuildTaggedByteString(encodedIssuerSignedItemWithValue)));
                     }
                 }
             }
@@ -311,7 +312,7 @@ public class Utility {
      * @param deviceResponseGenerator The generator to add the document to.
      * @param docType              The type of the document to send.
      * @param credentialDataResult The device- and issuer-signed data elements to include.
-     * @param issuerSignedMapping A mapping from namespaces to an array of IssuerSignedItem
+     * @param issuerSignedMapping A mapping from namespaces to an array of IssuerSignedItemBytes
      *                            CBOR for the namespace. The "elementValue" value in each
      *                            IssuerSignedItem CBOR must be set to the NULL value.
      * @param encodedIssuerAuth   the bytes of <code>COSE_Sign1</code> signed by the issuing

--- a/identity/src/main/java/com/android/identity/mdoc/mso/StaticAuthDataGenerator.java
+++ b/identity/src/main/java/com/android/identity/mdoc/mso/StaticAuthDataGenerator.java
@@ -76,7 +76,7 @@ public class StaticAuthDataGenerator {
      * Constructs a new {@link StaticAuthDataGenerator}.
      *
      * @param digestIDMapping A non-empty mapping between a <code>Namespace</code> and a list of
-     *                        <code>IssuerSignedItemBytes</code>.
+     *                        <code>IssuerSignedItemMetadataBytes</code>.
      * @param encodedIssuerAuth A COSE_Sign1 object with a payload of MobileSecurityObjectBytes.
      * @exception IllegalArgumentException if the <code>digestIDMapping</code> is empty.
      */

--- a/identity/src/main/java/com/android/identity/mdoc/mso/StaticAuthDataParser.java
+++ b/identity/src/main/java/com/android/identity/mdoc/mso/StaticAuthDataParser.java
@@ -84,7 +84,7 @@ public class StaticAuthDataParser {
 
         /**
          * Gets the mapping between <code>Namespace</code>s and a list of
-         * <code>IssuerSignedItemBytes</code> as set in the <code>StaticAuthData</code> CBOR.
+         * <code>IssuerSignedItemMetadataBytes</code> as set in the <code>StaticAuthData</code> CBOR.
          *
          * @return The digestID mapping.
          */
@@ -104,12 +104,9 @@ public class StaticAuthDataParser {
                     if (innerKey.getTag().getValue() != 24) {
                         throw new IllegalArgumentException("Inner key does not have tag 24");
                     }
-                    byte[] encodedIssuerSignedItemBytes = ((ByteString) innerKey).getBytes();
-
                     // Strictly not necessary but check that elementValue is NULL. This is to
                     // avoid applications (or issuers) sending the value in issuerSignedMapping
-                    // which is part of staticAuthData. This would be bad because then the
-                    // data element value would be available without any access control checks.
+                    // which is part of staticAuthData.
                     DataItem issuerSignedItem = Util.cborExtractTaggedAndEncodedCbor(innerKey);
                     DataItem value = Util.cborMapExtract(issuerSignedItem, "elementValue");
                     if (!(value instanceof SimpleValue)
@@ -118,8 +115,7 @@ public class StaticAuthDataParser {
                         throw new IllegalArgumentException("elementValue for nameSpace " + namespace
                                 + " elementName " + name + " is not NULL");
                     }
-
-                    innerArray.add(encodedIssuerSignedItemBytes);
+                    innerArray.add(Util.cborEncode(innerKey));
                 }
 
                 mDigestIdMapping.put(namespace, innerArray);

--- a/identity/src/main/java/com/android/identity/mdoc/response/DeviceResponseGenerator.java
+++ b/identity/src/main/java/com/android/identity/mdoc/response/DeviceResponseGenerator.java
@@ -56,12 +56,12 @@ public final class DeviceResponseGenerator {
     /**
      * Adds a new document to the device response.
      *
-     * <p>Issuer-signed data is provided in <code>issuerSignedData</code> which
-     * maps from namespaces into a list of bytes of IssuerSignedItem CBOR as
+     * <p>Issuer-signed data is provided in <code>issuerNameSpaces</code> which
+     * maps from namespaces into a list of bytes of IssuerSignedItemBytes CBOR as
      * defined in 18013-5 where each contains the digest-id, element name,
-     * issuer-generated random value and finally the element value. Each IssuerSignedItem
-     * must be encoded so the digest of them in a #6.24 bstr matches with the digests in
-     * the <code>MobileSecurityObject</code> in the <code>issuerAuth</code> parameter.
+     * issuer-generated random value and finally the element value. Each IssuerSignedItemBytes
+     * must be encoded so its digest matches with the digest in the
+     * <code>MobileSecurityObject</code> in the <code>issuerAuth</code> parameter.
      *
      * <p>The <code>encodedIssuerAuth</code> parameter contains the bytes of the
      * <code>IssuerAuth</code> CBOR as defined in <em>ISO/IEC 18013-5</em>
@@ -91,7 +91,7 @@ public final class DeviceResponseGenerator {
      * @param encodedDeviceNamespaces bytes of the <code>DeviceNameSpaces</code> CBOR.
      * @param encodedDeviceSignature bytes of a COSE_Sign1 for authenticating the device data.
      * @param encodedDeviceMac bytes of a COSE_Mac0 for authenticating the device data.
-     * @param issuerSignedData the map described above.
+     * @param issuerNameSpaces the map described above.
      * @param errors a map with errors as described above.
      * @param encodedIssuerAuth the bytes of the <code>COSE_Sign1</code> described above.
      * @return the passed-in {@link DeviceResponseGenerator}.
@@ -100,17 +100,16 @@ public final class DeviceResponseGenerator {
             @NonNull byte[] encodedDeviceNamespaces,
             @Nullable byte[] encodedDeviceSignature,
             @Nullable byte[] encodedDeviceMac,
-            @NonNull Map<String, List<byte[]>> issuerSignedData,
+            @NonNull Map<String, List<byte[]>> issuerNameSpaces,
             @Nullable Map<String, Map<String, Long>> errors,
             @NonNull byte[] encodedIssuerAuth) {
 
         CborBuilder issuerNameSpacesBuilder = new CborBuilder();
         MapBuilder<CborBuilder> insOuter = issuerNameSpacesBuilder.addMap();
-        for (String ns : issuerSignedData.keySet()) {
+        for (String ns : issuerNameSpaces.keySet()) {
             ArrayBuilder<MapBuilder<CborBuilder>> insInner = insOuter.putArray(ns);
-            for (byte[] encodedIssuerSignedItem : issuerSignedData.get(ns)) {
-                // We'll do the #6.24 wrapping here.
-                insInner.add(Util.cborBuildTaggedByteString(encodedIssuerSignedItem));
+            for (byte[] encodedIssuerSignedItemBytes : issuerNameSpaces.get(ns)) {
+                insInner.add(Util.cborDecode(encodedIssuerSignedItemBytes));
             }
             insInner.end();
         }

--- a/identity/src/test/java/com/android/identity/mdoc/mso/StaticAuthDataTest.java
+++ b/identity/src/test/java/com/android/identity/mdoc/mso/StaticAuthDataTest.java
@@ -188,21 +188,23 @@ public class StaticAuthDataTest {
         Assert.assertNotNull(list);
         Assert.assertEquals(2, list.size());
         Assert.assertEquals(
-                "{\n" +
+                "24(<< {\n" +
                         "  \"random\": h'505152',\n" +
                         "  \"digestID\": 42,\n" +
                         "  \"elementIdentifier\": \"dataElementName\",\n" +
                         "  \"elementValue\": null\n" +
-                        "}",
-                CborUtil.toDiagnostics(list.get(0), CborUtil.DIAGNOSTICS_FLAG_PRETTY_PRINT));
+                        "} >>)",
+                CborUtil.toDiagnostics(list.get(0), CborUtil.DIAGNOSTICS_FLAG_PRETTY_PRINT
+                        + CborUtil.DIAGNOSTICS_FLAG_EMBEDDED_CBOR));
         Assert.assertEquals(
-                "{\n" +
+                "24(<< {\n" +
                         "  \"digestID\": 43,\n" +
                         "  \"random\": h'535455',\n" +
                         "  \"elementIdentifier\": \"dataElementName2\",\n" +
                         "  \"elementValue\": null\n" +
-                        "}",
-                CborUtil.toDiagnostics(list.get(1), CborUtil.DIAGNOSTICS_FLAG_PRETTY_PRINT));
+                        "} >>)",
+                CborUtil.toDiagnostics(list.get(1), CborUtil.DIAGNOSTICS_FLAG_PRETTY_PRINT
+                        + CborUtil.DIAGNOSTICS_FLAG_EMBEDDED_CBOR));
 
         byte[] issuerAuth = decodedStaticAuthData.getIssuerAuth();
         Assert.assertArrayEquals(encodedIssuerAuth, issuerAuth);


### PR DESCRIPTION
When replacing parsing code in Utility.java with StaticAuthDataParser, the API spec was changed to return IssuerSignedItemMetadataBytes instead of IssuerSignedItemMetadata (ie. the unwrapped tag-24 data), but the parsing code was not updated. This updates the parsing routine, tester, and any dependencies of StaticAuthDataParser.

All tests pass.