### PR TITLE
Introduce ApplicationData interface

### DIFF
--- a/identity/src/main/java/com/android/identity/credential/Credential.java
+++ b/identity/src/main/java/com/android/identity/credential/Credential.java
@@ -23,15 +23,17 @@ import com.android.identity.internal.Util;
 import com.android.identity.keystore.KeystoreEngine;
 import com.android.identity.keystore.KeystoreEngineRepository;
 import com.android.identity.storage.StorageEngine;
+import com.android.identity.util.ApplicationData;
 import com.android.identity.util.Logger;
+import com.android.identity.util.SimpleApplicationData;
 import com.android.identity.util.Timestamp;
 
 import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import co.nstant.in.cbor.CborBuilder;
 import co.nstant.in.cbor.CborDecoder;
@@ -39,6 +41,7 @@ import co.nstant.in.cbor.CborException;
 import co.nstant.in.cbor.builder.ArrayBuilder;
 import co.nstant.in.cbor.builder.MapBuilder;
 import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.ByteString;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnicodeString;
 
@@ -59,8 +62,8 @@ import co.nstant.in.cbor.model.UnicodeString;
  * set and get using {@link #setNameSpacedData(NameSpacedData)} and
  * {@link #getNameSpacedData()}. Typically this is sent by the issuer at
  * credential creation and when data in the credential has changed. Additionally,
- * the application can set/get any data of data it wants using
- * {@link #setApplicationData(String, byte[])} and {@link #getApplicationData(String)}.
+ * the application can set/get any data of data it wants by using
+ * {@link #getApplicationData()} and modifying the returned {@link ApplicationData}.
  * Both kinds of data is persisted for the life-time of the application.
  *
  * <p>Each credential may have a number of <em>Authentication Keys</em>
@@ -105,7 +108,7 @@ public class Credential {
 
     private NameSpacedData mNameSpacedData = new NameSpacedData.Builder().build();
     private KeystoreEngine mKeystoreEngine;
-    private LinkedHashMap<String, byte[]> mApplicationData = new LinkedHashMap<>();
+    private SimpleApplicationData mApplicationData = new SimpleApplicationData(this::saveCredential);
 
     private List<PendingAuthenticationKey> mPendingAuthenticationKeys = new ArrayList<>();
     private List<AuthenticationKey> mAuthenticationKeys = new ArrayList<>();
@@ -147,12 +150,7 @@ public class Credential {
         map.put("credentialKeyAlias", mCredentialKeyAlias);
         map.put(new UnicodeString("nameSpacedData"), mNameSpacedData.toCbor());
 
-        MapBuilder<MapBuilder<CborBuilder>> applicationDataBuilder =
-                map.putMap("applicationData");
-        for (String key : mApplicationData.keySet()) {
-            byte[] value = mApplicationData.get(key);
-            applicationDataBuilder.put(key, value);
-        }
+        map.put("applicationData", mApplicationData.encodeAsCbor());
 
         ArrayBuilder<MapBuilder<CborBuilder>> pendingAuthenticationKeysArrayBuilder =
                 map.putArray("pendingAuthenticationKeys");
@@ -216,16 +214,12 @@ public class Credential {
         }
         mNameSpacedData = NameSpacedData.fromCbor(nameSpacedDataItem);
 
-        mApplicationData = new LinkedHashMap<>();
         DataItem applicationDataDataItem = map.get(new UnicodeString("applicationData"));
-        if (!(applicationDataDataItem instanceof co.nstant.in.cbor.model.Map)) {
-            throw new IllegalStateException("applicationData not found or not map");
+        if (!(applicationDataDataItem instanceof co.nstant.in.cbor.model.ByteString)) {
+            throw new IllegalStateException("applicationData not found or not byte[]");
         }
-        for (DataItem keyItem : ((co.nstant.in.cbor.model.Map) applicationDataDataItem).getKeys()) {
-            String key = ((UnicodeString) keyItem).getString();
-            byte[] value = Util.cborMapExtractByteString(applicationDataDataItem, key);
-            mApplicationData.put(key, value);
-        }
+        mApplicationData = SimpleApplicationData.decodeFromCbor(
+                ((ByteString) applicationDataDataItem).getBytes(), this::saveCredential);
 
         mPendingAuthenticationKeys = new ArrayList<>();
         DataItem pendingAuthenticationKeysDataItem = map.get(new UnicodeString("pendingAuthenticationKeys"));
@@ -329,71 +323,17 @@ public class Credential {
     }
 
     /**
-     * Sets application specific data.
-     *
-     * <p>This allows applications to store additional data it wants to associate with the
-     * credential, for example the document type (e.g. DocType for 18013-5 credentials),
-     * user-visible name, logos/background, state, and so on.
-     *
-     * <p>Use {@link #getApplicationData(String)} to read the data back.
-     *
-     * @param key the key for the data.
-     * @param value the value or {@code null} to remove.
-     */
-    public void setApplicationData(@NonNull String key, @Nullable byte[] value) {
-        if (value == null) {
-            mApplicationData.remove(key);
-        } else {
-            mApplicationData.put(key, value);
-        }
-        saveCredential();
-    }
-
-    /**
-     * Sets application specific data as a string.
-     *
-     * <p>Like {@link #setApplicationData(String, byte[])} but encodes the given value
-     * as an UTF-8 string before storing it.
-     *
-     * @param key the key for the data.
-     * @param value the value or {@code null} to remove.
-     */
-    public void setApplicationDataString(@NonNull String key, @Nullable String value) {
-        if (value == null) {
-            mApplicationData.remove(key);
-        } else {
-            mApplicationData.put(key, value.getBytes(StandardCharsets.UTF_8));
-        }
-        saveCredential();
-    }
-
-    /**
      * Gets application specific data.
      *
-     * <p>Gets data previously stored with {@link #getApplicationData(String)}.
+     * <p>Use this object to store additional data an application may want to associate with the
+     * credential, for example the document type (e.g. DocType for 18013-5 credentials),
+     * user-visible name, logos/background, state, and so on. Setters and associated getters are
+     * enumerated in the {@link ApplicationData} interface.
      *
-     * @param key the key for the data.
-     * @return the value or {@code null} if there is no value for the given key.
+     * @return application specific data.
      */
-    public @Nullable byte[] getApplicationData(@NonNull String key) {
-        return mApplicationData.get(key);
-    }
-
-    /**
-     * Gets application specific data as a string.
-     *
-     * <p>Like {@link #getApplicationData(String)} but decodes the value as
-     * an UTF-8 string before returning it.
-     *
-     * @param key the key for the data.
-     * @return the value or {@code null} if there is no value for the given key.
-     */
-    public @Nullable String getApplicationDataString(@NonNull String key) {
-        byte[] value = mApplicationData.get(key);
-        if (value == null) {
-            return null;
-        }
-        return new String(value, StandardCharsets.UTF_8);
+    public @NonNull ApplicationData getApplicationData() {
+        return mApplicationData;
     }
 
     /**
@@ -447,7 +387,7 @@ public class Credential {
         private Credential mCredential;
         private String mKeystoreEngineName;
         private String mReplacementAlias;
-        private LinkedHashMap<String, byte[]> mApplicationData = new LinkedHashMap<>();
+        private SimpleApplicationData mApplicationData;
 
         static AuthenticationKey create(
                 @NonNull PendingAuthenticationKey pendingAuthenticationKey,
@@ -577,13 +517,8 @@ public class Credential {
                     .put("usageCount", mUsageCount)
                     .put("data", mData)
                     .put("validFrom", mValidFrom.toEpochMilli())
-                    .put("validUntil", mValidUntil.toEpochMilli());
-            MapBuilder<MapBuilder<CborBuilder>> applicationDataBuilder =
-                    mapBuilder.putMap("applicationData");
-            for (String key : mApplicationData.keySet()) {
-                byte[] value = mApplicationData.get(key);
-                applicationDataBuilder.put(key, value);
-            }
+                    .put("validUntil", mValidUntil.toEpochMilli())
+                    .put("applicationData", mApplicationData.encodeAsCbor());
             if (mReplacementAlias != null) {
                 mapBuilder.put("replacementAlias", mReplacementAlias);
             }
@@ -602,17 +537,14 @@ public class Credential {
             if (Util.cborMapHasKey(dataItem, "replacementAlias")) {
                 ret.mReplacementAlias = Util.cborMapExtractString(dataItem, "replacementAlias");
             }
-            ret.mApplicationData = new LinkedHashMap<>();
-            DataItem applicationDataDataItem = Util.cborMapExtractMap(dataItem, "applicationData");
-            if (!(applicationDataDataItem instanceof co.nstant.in.cbor.model.Map)) {
-                throw new IllegalStateException("applicationData not found or not map");
-            }
-            for (DataItem keyItem : ((co.nstant.in.cbor.model.Map) applicationDataDataItem).getKeys()) {
-                String key = ((UnicodeString) keyItem).getString();
-                byte[] value = Util.cborMapExtractByteString(applicationDataDataItem, key);
-                ret.mApplicationData.put(key, value);
+            DataItem applicationDataDataItem = Util.cborMapExtract(dataItem, "applicationData");
+            if (!(applicationDataDataItem instanceof co.nstant.in.cbor.model.ByteString)) {
+                throw new IllegalStateException("applicationData not found or not byte[]");
             }
             ret.mCredential = credential;
+            ret.mApplicationData = SimpleApplicationData.decodeFromCbor(
+                    ((ByteString) applicationDataDataItem).getBytes(),
+                    () -> ret.mCredential.saveCredential());
             return ret;
         }
 
@@ -643,70 +575,16 @@ public class Credential {
         }
 
         /**
-         * Sets application specific data.
-         *
-         * <p>This allows applications to store additional data it wants to associate with the
-         * pending authentication key.
-         *
-         * <p>Use {@link #getApplicationData(String)} to read the data back.
-         *
-         * @param key the key for the data.
-         * @param value the value or {@code null} to remove.
-         */
-        public void setApplicationData(@NonNull String key, @Nullable byte[] value) {
-            if (value == null) {
-                mApplicationData.remove(key);
-            } else {
-                mApplicationData.put(key, value);
-            }
-            mCredential.saveCredential();
-        }
-
-        /**
-         * Sets application specific data as a string.
-         *
-         * <p>Like {@link #setApplicationData(String, byte[])} but encodes the given value
-         * as an UTF-8 string before storing it.
-         *
-         * @param key the key for the data.
-         * @param value the value or {@code null} to remove.
-         */
-        public void setApplicationDataString(@NonNull String key, @Nullable String value) {
-            if (value == null) {
-                mApplicationData.remove(key);
-            } else {
-                mApplicationData.put(key, value.getBytes(StandardCharsets.UTF_8));
-            }
-            mCredential.saveCredential();
-        }
-
-        /**
          * Gets application specific data.
          *
-         * <p>Gets data previously stored with {@link #getApplicationData(String)}.
+         * <p>Use this object to store additional data an application may want to associate
+         * with the authentication key. Setters and associated getters are
+         * enumerated in the {@link ApplicationData} interface.
          *
-         * @param key the key for the data.
-         * @return the value or {@code null} if there is no value for the given key.
+         * @return application specific data.
          */
-        public @Nullable byte[] getApplicationData(@NonNull String key) {
-            return mApplicationData.get(key);
-        }
-
-        /**
-         * Gets application specific data as a string.
-         *
-         * <p>Like {@link #getApplicationData(String)} but decodes the value as
-         * an UTF-8 string before returning it.
-         *
-         * @param key the key for the data.
-         * @return the value or {@code null} if there is no value for the given key.
-         */
-        public @Nullable String getApplicationDataString(@NonNull String key) {
-            byte[] value = mApplicationData.get(key);
-            if (value == null) {
-                return null;
-            }
-            return new String(value, StandardCharsets.UTF_8);
+        public @NonNull ApplicationData getApplicationData() {
+            return mApplicationData;
         }
     }
 
@@ -730,7 +608,7 @@ public class Credential {
         String mAlias;
         Credential mCredential;
         private String mReplacementForAlias;
-        private LinkedHashMap<String, byte[]> mApplicationData = new LinkedHashMap<>();
+        private SimpleApplicationData mApplicationData;
 
         static @NonNull PendingAuthenticationKey create(
                 @NonNull String alias,
@@ -750,6 +628,7 @@ public class Credential {
                 ret.mReplacementForAlias = asReplacementFor.getAlias();
             }
             ret.mCredential = credential;
+            ret.mApplicationData = new SimpleApplicationData(() -> ret.mCredential.saveCredential());
             return ret;
         }
 
@@ -844,12 +723,7 @@ public class Credential {
             if (mReplacementForAlias != null) {
                 mapBuilder.put("replacementForAlias", mReplacementForAlias);
             }
-            MapBuilder<MapBuilder<CborBuilder>> applicationDataBuilder =
-                    mapBuilder.putMap("applicationData");
-            for (String key : mApplicationData.keySet()) {
-                byte[] value = mApplicationData.get(key);
-                applicationDataBuilder.put(key, value);
-            }
+            mapBuilder.put("applicationData", mApplicationData.encodeAsCbor());
             return builder.build().get(0);
         }
 
@@ -861,17 +735,14 @@ public class Credential {
             if (Util.cborMapHasKey(dataItem, "replacementForAlias")) {
                 ret.mReplacementForAlias = Util.cborMapExtractString(dataItem, "replacementForAlias");
             }
-            ret.mApplicationData = new LinkedHashMap<>();
-            DataItem applicationDataDataItem = Util.cborMapExtractMap(dataItem, "applicationData");
-            if (!(applicationDataDataItem instanceof co.nstant.in.cbor.model.Map)) {
-                throw new IllegalStateException("applicationData not found or not map");
-            }
-            for (DataItem keyItem : ((co.nstant.in.cbor.model.Map) applicationDataDataItem).getKeys()) {
-                String key = ((UnicodeString) keyItem).getString();
-                byte[] value = Util.cborMapExtractByteString(applicationDataDataItem, key);
-                ret.mApplicationData.put(key, value);
+            DataItem applicationDataDataItem = Util.cborMapExtract(dataItem, "applicationData");
+            if (!(applicationDataDataItem instanceof co.nstant.in.cbor.model.ByteString)) {
+                throw new IllegalStateException("applicationData not found or not byte[]");
             }
             ret.mCredential = credential;
+            ret.mApplicationData = SimpleApplicationData.decodeFromCbor(
+                    ((ByteString) applicationDataDataItem).getBytes(),
+                    () -> ret.mCredential.saveCredential());
             return ret;
         }
 
@@ -896,70 +767,16 @@ public class Credential {
         }
 
         /**
-         * Sets application specific data.
-         *
-         * <p>This allows applications to store additional data it wants to associate with the
-         * authentication key.
-         *
-         * <p>Use {@link #getApplicationData(String)} to read the data back.
-         *
-         * @param key the key for the data.
-         * @param value the value or {@code null} to remove.
-         */
-        public void setApplicationData(@NonNull String key, @Nullable byte[] value) {
-            if (value == null) {
-                mApplicationData.remove(key);
-            } else {
-                mApplicationData.put(key, value);
-            }
-            mCredential.saveCredential();
-        }
-
-        /**
-         * Sets application specific data as a string.
-         *
-         * <p>Like {@link #setApplicationData(String, byte[])} but encodes the given value
-         * as an UTF-8 string before storing it.
-         *
-         * @param key the key for the data.
-         * @param value the value or {@code null} to remove.
-         */
-        public void setApplicationDataString(@NonNull String key, @Nullable String value) {
-            if (value == null) {
-                mApplicationData.remove(key);
-            } else {
-                mApplicationData.put(key, value.getBytes(StandardCharsets.UTF_8));
-            }
-            mCredential.saveCredential();
-        }
-
-        /**
          * Gets application specific data.
          *
-         * <p>Gets data previously stored with {@link #getApplicationData(String)}.
+         * <p>Use this object to store additional data an application may want to associate
+         * with the pending authentication key. Setters and associated getters are
+         * enumerated in the {@link ApplicationData} interface.
          *
-         * @param key the key for the data.
-         * @return the value or {@code null} if there is no value for the given key.
+         * @return application specific data.
          */
-        public @Nullable byte[] getApplicationData(@NonNull String key) {
-            return mApplicationData.get(key);
-        }
-
-        /**
-         * Gets application specific data as a string.
-         *
-         * <p>Like {@link #getApplicationData(String)} but decodes the value as
-         * an UTF-8 string before returning it.
-         *
-         * @param key the key for the data.
-         * @return the value or {@code null} if there is no value for the given key.
-         */
-        public @Nullable String getApplicationDataString(@NonNull String key) {
-            byte[] value = mApplicationData.get(key);
-            if (value == null) {
-                return null;
-            }
-            return new String(value, StandardCharsets.UTF_8);
+        public @NonNull ApplicationData getApplicationData() {
+            return mApplicationData;
         }
     }
 

--- a/identity/src/main/java/com/android/identity/credential/CredentialUtil.java
+++ b/identity/src/main/java/com/android/identity/credential/CredentialUtil.java
@@ -72,7 +72,7 @@ public class CredentialUtil {
             boolean keyExceededUseCount = false;
             boolean keyBeyondExpirationDate = false;
 
-            if (authKey.getApplicationData(managedKeyDomain) == null) {
+            if (!authKey.getApplicationData().keyExists(managedKeyDomain)) {
                 // not one of ours...
                 continue;
             }
@@ -91,7 +91,7 @@ public class CredentialUtil {
                 if (authKey.getReplacement() == null) {
                     Credential.PendingAuthenticationKey pendingKey =
                             credential.createPendingAuthenticationKey(createKeySettings, authKey);
-                    pendingKey.setApplicationData(managedKeyDomain, new byte[0]);
+                    pendingKey.getApplicationData().setBoolean(managedKeyDomain, true);
                     numReplacementsGenerated++;
                     continue;
                 }
@@ -107,7 +107,7 @@ public class CredentialUtil {
             for (int n = 0; n < numNonReplacementsToGenerate; n++) {
                 Credential.PendingAuthenticationKey pendingKey =
                         credential.createPendingAuthenticationKey(createKeySettings, null);
-                pendingKey.setApplicationData(managedKeyDomain, new byte[0]);
+                pendingKey.getApplicationData().setBoolean(managedKeyDomain, true);
             }
         }
         return numReplacementsGenerated + numNonReplacementsToGenerate;

--- a/identity/src/main/java/com/android/identity/internal/Util.java
+++ b/identity/src/main/java/com/android/identity/internal/Util.java
@@ -245,7 +245,13 @@ public class Util {
     }
 
     public static boolean cborDecodeBoolean(@NonNull byte[] data) {
-        SimpleValue simple = (SimpleValue) cborDecode(data);
+        SimpleValue simple;
+        try {
+            simple = (SimpleValue) cborDecode(data);
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException("Data given cannot be cast into a boolean.", e);
+        }
+
         return simple.getSimpleValueType() == SimpleValueType.TRUE;
     }
 

--- a/identity/src/main/java/com/android/identity/util/ApplicationData.java
+++ b/identity/src/main/java/com/android/identity/util/ApplicationData.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity.util;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.android.identity.credential.Credential;
+
+/**
+ * An interface to an object storing application data in a key-value pair manner.
+ *
+ * <p>This interface exists to support applications which wish to store additional data it wants to
+ * associate with any object, such as a {@link Credential} or {@link Credential.AuthenticationKey}.
+ * For example, on a {@link Credential} object one could use this to store the document
+ * type (e.g. DocType for 18013-5 credentials), user-visible name, logos/background, state,
+ * and so on.
+ */
+public interface ApplicationData {
+
+    /**
+     * Sets application specific data.
+     *
+     * <p>Use {@link #getData(String)} to read the data back.
+     *
+     * @param key   the key for the data.
+     * @param value the value or {@code null} to remove.
+     * @return      the modified {@link ApplicationData}.
+     */
+    @NonNull ApplicationData setData(@NonNull String key, @Nullable byte[] value);
+
+    /**
+     * Sets application specific data as a string.
+     *
+     * <p>Like {@link #setData(String, byte[])} but encodes the given value
+     * using <a href="http://cbor.io/">CBOR</a> before storing it.
+     *
+     * @param key   the key for the data.
+     * @param value the value
+     * @return      the modified {@link ApplicationData}.
+     */
+    @NonNull ApplicationData setString(@NonNull String key, @NonNull String value);
+
+    /**
+     * Sets application specific data as a {@code long}.
+     *
+     * <p>Like {@link #setData(String, byte[])} but encodes the given value
+     * using <a href="http://cbor.io/">CBOR</a> before storing it.
+     *
+     * @param key   the key for the data.
+     * @param value the value.
+     * @return      the modified {@link ApplicationData}.
+     */
+    @NonNull ApplicationData setNumber(@NonNull String key, long value);
+
+    /**
+     * Sets application specific data as a boolean.
+     *
+     * <p>Like {@link #setData(String, byte[])} but encodes the given value
+     * using <a href="http://cbor.io/">CBOR</a> before storing it.
+     *
+     * @param key   the key for the data.
+     * @param value the value.
+     * @return      the modified {@link ApplicationData}.
+     */
+    @NonNull ApplicationData setBoolean(@NonNull String key, boolean value);
+
+    /**
+     * Returns whether the {@link ApplicationData} has a value for the key provided.
+     *
+     * @param key the key for the data.
+     * @return    true if the key exists, false else.
+     */
+    boolean keyExists(@NonNull String key);
+
+    /**
+     * Gets application specific data.
+     *
+     * <p>Gets data previously stored with {@link #setData(String, byte[])}.
+     *
+     * @param  key the key for the data.
+     * @return the value.
+     * @throws IllegalArgumentException if the data element does not exist.
+     */
+    @NonNull byte[] getData(@NonNull String key);
+
+    /**
+     * Gets application specific data as a string.
+     *
+     * <p>Takes the data returned by {@link #getData(String)} and decodes it as a CBOR string.
+     *
+     * @param  key the key for the data.
+     * @return the value.
+     * @throws IllegalArgumentException if the data element does not exist.
+     * @throws IllegalArgumentException if the data isn't a CBOR encoded string.
+     */
+    @NonNull String getString(@NonNull String key);
+
+    /**
+     * Gets application specific data as a {@code long}.
+     *
+     * <p>Takes the data returned by {@link #getData(String)} and decodes it as a {@code long}.
+     *
+     * @param  key the key for the data.
+     * @return the value.
+     * @throws IllegalArgumentException if the data element does not exist.
+     * @throws IllegalArgumentException if the data isn't a CBOR encoded {@code long}.
+     */
+    long getNumber(@NonNull String key);
+
+    /**
+     * Gets application specific data as a {@code boolean}.
+     *
+     * <p>Takes the data returned by {@link #getData(String)} and decodes it as a {@code boolean}.
+     *
+     * @param  key the key for the data.
+     * @return the value.
+     * @throws IllegalArgumentException if the data element does not exist.
+     * @throws IllegalArgumentException if the data isn't a CBOR encoded {@code boolean}.
+     */
+    boolean getBoolean(@NonNull String key);
+}

--- a/identity/src/main/java/com/android/identity/util/SimpleApplicationData.java
+++ b/identity/src/main/java/com/android/identity/util/SimpleApplicationData.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity.util;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.android.identity.internal.Util;
+
+import java.io.ByteArrayInputStream;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+import co.nstant.in.cbor.CborBuilder;
+import co.nstant.in.cbor.CborDecoder;
+import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.builder.MapBuilder;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.SimpleValue;
+import co.nstant.in.cbor.model.UnicodeString;
+
+/**
+ * An implementation of {@link ApplicationData} using a LinkedHashMap to back the key-value pairs.
+ */
+public class SimpleApplicationData implements ApplicationData {
+    private Map<String, byte[]> mApplicationData = new LinkedHashMap<>();
+    private Listener mListener;
+
+    /**
+     * Creates a new SimpleApplicationData and sets the listener to be used for notification
+     * when changes are made to the {@link SimpleApplicationData}.
+     *
+     * @param listener the listener or <code>null</code> if this functionality is not needed.
+     */
+    public SimpleApplicationData(@Nullable Listener listener) {
+        mListener = listener;
+    }
+
+    @NonNull
+    @Override
+    public ApplicationData setData(@NonNull String key, @Nullable byte[] value) {
+        if (value == null) {
+            mApplicationData.remove(key);
+        } else {
+            mApplicationData.put(key, value);
+        }
+
+        if (mListener != null) {
+            mListener.onDataSet();
+        }
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public ApplicationData setString(@NonNull String key, @NonNull String value) {
+        return this.setData(key, Util.cborEncodeString(value));
+    }
+
+    @NonNull
+    @Override
+    public ApplicationData setNumber(@NonNull String key, long value) {
+        return this.setData(key, Util.cborEncodeNumber(value));
+    }
+
+    @NonNull
+    @Override
+    public ApplicationData setBoolean(@NonNull String key, boolean value) {
+        return this.setData(key, Util.cborEncodeBoolean(value));
+    }
+
+    @Override
+    public boolean keyExists(@NonNull String key) {
+        return mApplicationData.get(key) != null;
+    }
+
+    @NonNull
+    @Override
+    public byte[] getData(@NonNull String key) {
+        byte[] value = mApplicationData.get(key);
+        if (value == null) {
+            throw new IllegalArgumentException("This key is not present in the ApplicationData.");
+        }
+        return value;
+    }
+
+    @NonNull
+    @Override
+    public String getString(@NonNull String key) {
+        byte[] value = this.getData(key);
+        return Util.cborDecodeString(value);
+    }
+
+    @Override
+    public long getNumber(@NonNull String key) {
+        byte[] value = this.getData(key);
+        return Util.cborDecodeLong(value);
+    }
+
+    @Override
+    public boolean getBoolean(@NonNull String key) {
+        byte[] value = this.getData(key);
+        return Util.cborDecodeBoolean(value);
+    }
+
+    /**
+     * Encode the {@link ApplicationData} as a byte[] using <a href="http://cbor.io/">CBOR</a>.
+     *
+     * @return a byte[] of the encoded app data.
+     */
+    public @NonNull byte[] encodeAsCbor() {
+        CborBuilder appDataBuilder = new CborBuilder();
+        MapBuilder<CborBuilder> appDataMapBuilder = appDataBuilder.addMap();
+        for (String key : mApplicationData.keySet()) {
+            appDataMapBuilder.put(key, mApplicationData.get(key));
+        }
+        appDataMapBuilder.end();
+        return Util.cborEncode(appDataBuilder.build().get(0));
+    }
+
+    /**
+     * Returns a fully populated SimpleApplicationData from a CBOR-encoded byte[] and sets the
+     * listener to be used for notification when changes are made to the {@link SimpleApplicationData}.
+     *
+     * <p> To encode a SimpleApplicationData, use {@link #encodeAsCbor()}.
+     *
+     * @param encodedApplicationData The byte array resulting from {@link #encodeAsCbor()}.
+     * @param listener the listener or <code>null</code> if this functionality is not needed.
+     * @return A SimpleApplicationData with the correct key, value pairs.
+     */
+    public static @NonNull SimpleApplicationData decodeFromCbor(
+            @NonNull byte[] encodedApplicationData, @Nullable Listener listener) {
+        ByteArrayInputStream bais = new ByteArrayInputStream(encodedApplicationData);
+        List<DataItem> dataItems;
+        try {
+            dataItems = new CborDecoder(bais).decode();
+        } catch (CborException e) {
+            throw new IllegalStateException("Error decoded CBOR", e);
+        }
+        if (dataItems.size() != 1) {
+            throw new IllegalStateException("Expected 1 item, found " + dataItems.size());
+        }
+        if (!(dataItems.get(0) instanceof co.nstant.in.cbor.model.Map)) {
+            throw new IllegalStateException("Item is not a map");
+        }
+        DataItem applicationDataDataItem = dataItems.get(0);
+
+        SimpleApplicationData appData = new SimpleApplicationData(listener);
+        for (DataItem keyItem : ((co.nstant.in.cbor.model.Map) applicationDataDataItem).getKeys()) {
+            String key = ((UnicodeString) keyItem).getString();
+            byte[] value = Util.cborMapExtractByteString(applicationDataDataItem, key);
+            appData.setData(key, value);
+        }
+        return appData;
+    }
+
+    /**
+     * Interface for listening for changes to the data in the {@link SimpleApplicationData}.
+     *
+     * <p>The {@link Listener#onDataSet()}  callback will be called every time the data stored
+     * is modified (e.g. adding a key-value pair, changing a value, or removing a key-value pair).
+     */
+    public interface Listener {
+
+        /**
+         * Called when the data inside the {@link SimpleApplicationData} is changed
+         */
+        void onDataSet();
+    }
+}

--- a/identity/src/test/java/com/android/identity/credential/CredentialUtilTest.java
+++ b/identity/src/test/java/com/android/identity/credential/CredentialUtilTest.java
@@ -81,6 +81,7 @@ public class CredentialUtilTest {
         Assert.assertEquals(numAuthKeys, credential.getPendingAuthenticationKeys().size());
         count = 0;
         for (Credential.PendingAuthenticationKey pak : credential.getPendingAuthenticationKeys()) {
+            Assert.assertTrue(pak.getApplicationData().getBoolean(managedKeyDomain));
             pak.certify(new byte[] {0, (byte) count++},
                     Timestamp.ofEpochMilli(100),
                     Timestamp.ofEpochMilli(200));
@@ -139,6 +140,7 @@ public class CredentialUtilTest {
         Assert.assertEquals(5, credential.getPendingAuthenticationKeys().size());
         count = 0;
         for (Credential.PendingAuthenticationKey pak : credential.getPendingAuthenticationKeys()) {
+            Assert.assertTrue(pak.getApplicationData().getBoolean(managedKeyDomain));
             pak.certify(new byte[] {1, (byte) count++},
                     Timestamp.ofEpochMilli(100),
                     Timestamp.ofEpochMilli(210));
@@ -180,6 +182,7 @@ public class CredentialUtilTest {
         Assert.assertEquals(5, credential.getPendingAuthenticationKeys().size());
         count = 0;
         for (Credential.PendingAuthenticationKey pak : credential.getPendingAuthenticationKeys()) {
+            Assert.assertTrue(pak.getApplicationData().getBoolean(managedKeyDomain));
             pak.certify(new byte[] {2, (byte) count++},
                     Timestamp.ofEpochMilli(100),
                     Timestamp.ofEpochMilli(210));

--- a/identity/src/test/java/com/android/identity/internal/UtilTest.java
+++ b/identity/src/test/java/com/android/identity/internal/UtilTest.java
@@ -761,6 +761,18 @@ public class UtilTest {
     }
 
     @Test
+    public void encodeDecodeString() {
+        assertEquals("abc", Util.cborDecodeString(Util.cborEncodeString("abc")));
+        assertEquals("", Util.cborDecodeString(Util.cborEncodeString("")));
+        assertThrows(IllegalArgumentException.class,
+                () -> Util.cborDecodeString(Util.cborEncodeNumber(0L)));
+        assertThrows(IllegalArgumentException.class,
+                () -> Util.cborDecodeString(Util.cborEncodeBytestring(new byte[] {0x53, 0x54, 0x55})));
+        assertThrows(IllegalArgumentException.class,
+                () -> Util.cborDecodeString(Util.cborEncodeBoolean(true)));
+    }
+
+    @Test
     public void checkedLongValue() {
         final DataItem dataItem = new co.nstant.in.cbor.model.UnsignedInteger(8675309);
         assertEquals(8675309, Util.checkedLongValue(dataItem));
@@ -794,6 +806,30 @@ public class UtilTest {
         final BigInteger tooSmall = lowerLimit.subtract(BigInteger.ONE);
         assertThrows(ArithmeticException.class,
             () -> Util.checkedLongValue(new co.nstant.in.cbor.model.NegativeInteger(tooSmall)));
+    }
+
+    @Test
+    public void encodeDecodeLong() {
+        assertEquals(83L, Util.cborDecodeLong(Util.cborEncodeNumber(83L)));
+        assertEquals(0L, Util.cborDecodeLong(Util.cborEncodeNumber(0L)));
+        assertThrows(IllegalArgumentException.class,
+                () -> Util.cborDecodeLong(Util.cborEncodeString("0L")));
+        assertThrows(IllegalArgumentException.class,
+                () -> Util.cborDecodeLong(Util.cborEncodeBytestring(new byte[] {0x53, 0x54, 0x55})));
+        assertThrows(IllegalArgumentException.class,
+                () -> Util.cborDecodeLong(Util.cborEncodeBoolean(true)));
+    }
+
+    @Test
+    public void encodeDecodeBoolean() {
+        assertTrue(Util.cborDecodeBoolean(Util.cborEncodeBoolean(true)));
+        assertFalse(Util.cborDecodeBoolean(Util.cborEncodeBoolean(false)));
+        assertThrows(IllegalArgumentException.class,
+                () -> Util.cborDecodeBoolean(Util.cborEncodeString("test")));
+        assertThrows(IllegalArgumentException.class,
+                () -> Util.cborDecodeBoolean(Util.cborEncodeBytestring(new byte[] {0x53, 0x54, 0x55})));
+        assertThrows(IllegalArgumentException.class,
+                () -> Util.cborDecodeBoolean(Util.cborEncodeNumber(83L)));
     }
 
     // TODO: Replace with Assert.assertThrows() once we use a recent enough version of JUnit.

--- a/identity/src/test/java/com/android/identity/util/SimpleApplicationDataTest.java
+++ b/identity/src/test/java/com/android/identity/util/SimpleApplicationDataTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity.util;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SimpleApplicationDataTest {
+
+    private void testEncodingConsistency(SimpleApplicationData original,
+                                          SimpleApplicationData other) {
+        assertArrayEquals(original.encodeAsCbor(), other.encodeAsCbor());
+    }
+
+    @Test
+    public void testOverrides() {
+        SimpleApplicationData appData = new SimpleApplicationData(null);
+        assertFalse(appData.keyExists("testkey"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getData("testkey"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getString("testkey"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getNumber("testkey"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getBoolean("testkey"));
+
+        appData.setData("foo", new byte[] {0x50, 0x51, 0x52});
+        assertArrayEquals(new byte[] {0x50, 0x51, 0x52}, appData.getData("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        // do the same thing and assert nothing changes
+        appData.setData("foo", new byte[] {0x50, 0x51, 0x52});
+        assertArrayEquals(new byte[] {0x50, 0x51, 0x52}, appData.getData("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        appData.setString("foo", "testString");
+        assertEquals("testString", appData.getString("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        appData.setNumber("foo", 792L);
+        assertEquals(792L, (long) appData.getNumber("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        appData.setBoolean("foo", false);
+        assertEquals(false, appData.getBoolean("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        // remove by nulling
+        appData.setData("foo", (byte[]) null);
+        assertFalse(appData.keyExists("testkey"));
+    }
+
+    @Test
+    public void testByteArrays() {
+        SimpleApplicationData appData = new SimpleApplicationData(null);
+
+        appData.setData("foo", new byte[] {0x50, 0x51, 0x52});
+        assertArrayEquals(new byte[] {0x50, 0x51, 0x52}, appData.getData("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        appData.setData("bar", new byte[] {0x53, 0x54, 0x55});
+        assertArrayEquals(new byte[] {0x50, 0x51, 0x52}, appData.getData("foo"));
+        assertArrayEquals(new byte[] {0x53, 0x54, 0x55}, appData.getData("bar"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        // remove by nulling
+        appData.setData("bar", (byte[]) null);
+        assertArrayEquals(new byte[] {0x50, 0x51, 0x52}, appData.getData("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+        assertFalse(appData.keyExists("bar"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getData("bar"));
+    }
+
+    @Test
+    public void testStringValues() {
+        SimpleApplicationData appData = new SimpleApplicationData(null);
+
+        appData.setString("foo", "abc");
+        assertEquals("abc", appData.getString("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        appData.setString("bar", "foo");
+        assertEquals("abc", appData.getString("foo"));
+        assertEquals("foo", appData.getString("bar"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        // remove by nulling
+        appData.setData("bar", (byte[]) null);
+        assertEquals("abc", appData.getString("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+        assertFalse(appData.keyExists("bar"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getString("bar"));
+
+        // empty string
+        appData.setString("bar", "");
+        assertEquals("abc", appData.getString("foo"));
+        assertEquals("", appData.getString("bar"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        // non-String values being read as a String
+        appData.setNumber("bar", 0L);
+        assertEquals("abc", appData.getString("foo"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getString("bar"));
+
+        appData.setData("bar", new byte[] {0x53, 0x54, 0x55});
+        assertEquals("abc", appData.getString("foo"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getString("bar"));
+
+        appData.setData("bar", new byte[0]);
+        assertEquals("abc", appData.getString("foo"));
+        assertEquals(0, appData.getData("bar").length);
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        appData.setBoolean("bar", true);
+        assertThrows(IllegalArgumentException.class, () -> appData.getString("bar"));
+    }
+
+    @Test
+    public void testNumberValues() {
+        SimpleApplicationData appData = new SimpleApplicationData(null);
+
+        appData.setNumber("foo", 83L);
+        assertEquals(83L, (long) appData.getNumber("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        appData.setNumber("bar", 0L);
+        assertEquals(83L, (long) appData.getNumber("foo"));
+        assertEquals(0L, (long) appData.getNumber("bar"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        // remove by nulling
+        appData.setData("bar", (byte[]) null);
+        assertEquals(83L, (long) appData.getNumber("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+        assertFalse(appData.keyExists("bar"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getString("bar"));
+
+        // non-Number values being read as a Number
+        appData.setData("bar", new byte[] {0x53, 0x54, 0x55});
+        assertEquals(83L, (long) appData.getNumber("foo"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getNumber("bar"));
+
+        appData.setData("bar", new byte[0]);
+        assertEquals(83L, (long) appData.getNumber("foo"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getNumber("bar"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        appData.setString("bar", "abc");
+        assertEquals(83L, (long) appData.getNumber("foo"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getNumber("bar"));
+
+        appData.setBoolean("bar", true);
+        assertEquals(83L, (long) appData.getNumber("foo"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getNumber("bar"));
+    }
+
+    @Test
+    public void checkedLongValueEdgeCases() {
+        SimpleApplicationData appData = new SimpleApplicationData(null);
+
+        appData.setNumber("foo", Long.MAX_VALUE);
+        assertEquals(Long.MAX_VALUE, (long) appData.getNumber("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        appData.setNumber("bar", Long.MIN_VALUE);
+        assertEquals(Long.MAX_VALUE, (long) appData.getNumber("foo"));
+        assertEquals(Long.MIN_VALUE, (long) appData.getNumber("bar"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        // remove by nulling
+        appData.setData("bar", (byte[]) null);
+        assertEquals(Long.MAX_VALUE, (long) appData.getNumber("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+        assertFalse(appData.keyExists("bar"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getString("bar"));
+    }
+
+    @Test
+    public void testBooleanValues() {
+        SimpleApplicationData appData = new SimpleApplicationData(null);
+
+        appData.setBoolean("foo", true);
+        assertEquals(true, appData.getBoolean("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        appData.setBoolean("bar", false);
+        assertEquals(true, appData.getBoolean("foo"));
+        assertEquals(false, appData.getBoolean("bar"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        // remove by nulling
+        appData.setData("bar", (byte[]) null);
+        assertEquals(true, appData.getBoolean("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+        assertFalse(appData.keyExists("bar"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getString("bar"));
+
+        // non-boolean values being read as a boolean
+        appData.setData("bar", new byte[] {0x53, 0x54, 0x55});
+        assertEquals(true, appData.getBoolean("foo"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getBoolean("bar"));
+
+        appData.setData("bar", new byte[0]);
+        assertEquals(true, appData.getBoolean("foo"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getBoolean("bar"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        appData.setString("bar", "abc");
+        assertEquals(true, appData.getBoolean("foo"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getBoolean("bar"));
+
+        appData.setNumber("bar", 82L);
+        assertEquals(true, appData.getBoolean("foo"));
+        assertThrows(IllegalArgumentException.class, () -> appData.getBoolean("bar"));
+    }
+
+    @Test
+    public void testMixedValues() {
+        SimpleApplicationData appData = new SimpleApplicationData(null);
+
+        appData.setData("foo", new byte[] {0x50, 0x51, 0x52});
+        assertArrayEquals(new byte[] {0x50, 0x51, 0x52}, appData.getData("foo"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        appData.setString("bar", "abc");
+        assertArrayEquals(new byte[] {0x50, 0x51, 0x52}, appData.getData("foo"));
+        assertEquals("abc", appData.getString("bar"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        appData.setNumber("c", 601L);
+        assertArrayEquals(new byte[] {0x50, 0x51, 0x52}, appData.getData("foo"));
+        assertEquals("abc", appData.getString("bar"));
+        assertEquals(601L, (long) appData.getNumber("c"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        appData.setBoolean("a", false);
+        assertArrayEquals(new byte[] {0x50, 0x51, 0x52}, appData.getData("foo"));
+        assertEquals("abc", appData.getString("bar"));
+        assertEquals(601L, (long) appData.getNumber("c"));
+        assertEquals(false, appData.getBoolean("a"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+
+        // override the "foo" key with a String
+        appData.setString("foo", "bar");
+        assertEquals("bar", appData.getString("foo"));
+        assertEquals("abc", appData.getString("bar"));
+        assertEquals(601L, (long) appData.getNumber("c"));
+        assertEquals(false, appData.getBoolean("a"));
+        testEncodingConsistency(appData, SimpleApplicationData.decodeFromCbor(appData.encodeAsCbor(), null));
+    }
+}


### PR DESCRIPTION
Created an ApplicationData interface and basic implementation (SimpleApplicationData) to reduce copied code related to application data between Credential, Credential.PendingAuthKey, and Credential.AuthenticationKey classes and increase modularity. Introduced the ability to save additional types (long, Timestamp, Boolean) to the ApplicationData. Tested using SimpleApplicationDataTest and slight modifications to CredentialStoreTest.

Fixes #324 

- [x ] Tests pass