### PR TITLE
DeviceRetrievalHelper: Gracefully handle malformed EReaderKey.

### DIFF
--- a/identity/src/main/java/com/android/identity/internal/Util.java
+++ b/identity/src/main/java/com/android/identity/internal/Util.java
@@ -1155,6 +1155,11 @@ public class Util {
         return item;
     }
 
+    public static
+    @KeystoreEngine.EcCurve int coseKeyGetCurve(@NonNull DataItem coseKey) {
+        return (int) cborMapExtractNumber(coseKey, COSE_KEY_EC2_CRV);
+    }
+
     public static @NonNull
     PublicKey coseKeyDecode(@NonNull DataItem coseKey) {
         long kty = cborMapExtractNumber(coseKey, COSE_KEY_KTY);


### PR DESCRIPTION
If the verifier sends a malformed EReaderKey send back an appropriate error code (10 or 11) instead of throwing an exception and letting the application deal with it.

Fixes Issue #115 and Issue #330.

Test: Manually tested
