### PR TITLE
Fix Java 17 compatibility

### DIFF
--- a/identity/src/test/java/com/android/identity/internal/UtilTest.java
+++ b/identity/src/test/java/com/android/identity/internal/UtilTest.java
@@ -392,7 +392,7 @@ public class UtilTest {
 
     private KeyPair generateKeyPair() throws Exception {
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
-        kpg.initialize(new ECGenParameterSpec("secp256k1"));
+        kpg.initialize(new ECGenParameterSpec("secp256r1"));
         return kpg.generateKeyPair();
     }
 


### PR DESCRIPTION
Change the curve of the EC key used in unit tests from `secp256k1` to NIST P-256 `secp256r1` as it is no longer supported in current Java versions.

Fixes #334.