### PR TITLE
Make PresentationSession optional.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
+++ b/appholder/src/main/java/com/android/mdl/app/util/NfcEngagementHandler.kt
@@ -33,6 +33,7 @@ import com.android.mdl.app.transfer.ConnectionSetup
 import com.android.mdl.app.transfer.CredentialStore
 import com.android.mdl.app.transfer.SessionSetup
 import com.android.mdl.app.transfer.TransferManager
+import java.security.PublicKey
 
 
 class NfcEngagementHandler : HostApduService() {
@@ -78,7 +79,7 @@ class NfcEngagementHandler : HostApduService() {
                 applicationContext,
                 presentationListener,
                 applicationContext.mainExecutor(),
-                session
+                session.ephemeralKeyPair
             )
             builder.useForwardEngagement(
                 transport,
@@ -99,6 +100,11 @@ class NfcEngagementHandler : HostApduService() {
     }
 
     private val presentationListener = object : DeviceRetrievalHelper.Listener {
+        override fun onEReaderKeyReceived(eReaderKey: PublicKey) {
+            log("DeviceRetrievalHelper Listener (NFC): OnEReaderKeyReceived")
+            session.setSessionTranscript(presentation!!.sessionTranscript)
+            session.setReaderEphemeralPublicKey(eReaderKey)
+        }
 
         override fun onDeviceRequest(deviceRequestBytes: ByteArray) {
             log("Presentation Listener: OnDeviceRequest")
@@ -127,7 +133,7 @@ class NfcEngagementHandler : HostApduService() {
         val connectionSetup = ConnectionSetup(applicationContext)
         val builder = NfcEngagementHelper.Builder(
             applicationContext,
-            session,
+            session.ephemeralKeyPair.public,
             connectionSetup.getConnectionOptions(),
             nfcEngagementListener,
             applicationContext.mainExecutor())

--- a/identity-android/src/androidTest/java/com/android/identity/android/legacy/DynamicAuthTest.java
+++ b/identity-android/src/androidTest/java/com/android/identity/android/legacy/DynamicAuthTest.java
@@ -200,7 +200,7 @@ public class DynamicAuthTest {
                         + "}",
                 pretty);
 
-        KeyPair readerEphemeralKeyPair = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+        KeyPair readerEphemeralKeyPair = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
 
         credential = store.getCredentialByName(credentialName,
                 IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
@@ -647,7 +647,7 @@ public class DynamicAuthTest {
             IdentityCredential tc = store.getCredentialByName(credentialName,
                     IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
             KeyPair ekp = tc.createEphemeralKeyPair();
-            KeyPair rekp = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+            KeyPair rekp = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
             tc.setReaderEphemeralPublicKey(rekp.getPublic());
             tc.setSessionTranscript(Util.buildSessionTranscript(ekp));
             Map<String, Collection<String>> etr = new LinkedHashMap<>();
@@ -676,7 +676,7 @@ public class DynamicAuthTest {
             IdentityCredential tc = store.getCredentialByName(credentialName,
                     IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
             KeyPair ekp = tc.createEphemeralKeyPair();
-            KeyPair rekp = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+            KeyPair rekp = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
             tc.setReaderEphemeralPublicKey(rekp.getPublic());
             tc.setSessionTranscript(Util.buildSessionTranscript(ekp));
             Map<String, Collection<String>> etr = new LinkedHashMap<>();
@@ -704,7 +704,7 @@ public class DynamicAuthTest {
                     IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
             tc.setAllowUsingExpiredKeys(true);   // <-- this is the call that makes the difference!
             KeyPair ekp = tc.createEphemeralKeyPair();
-            KeyPair rekp = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+            KeyPair rekp = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
             tc.setReaderEphemeralPublicKey(rekp.getPublic());
             tc.setSessionTranscript(Util.buildSessionTranscript(ekp));
             Map<String, Collection<String>> etr = new LinkedHashMap<>();
@@ -776,7 +776,7 @@ public class DynamicAuthTest {
             IdentityCredential tc = store.getCredentialByName(credentialName,
                     IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
             KeyPair ekp = tc.createEphemeralKeyPair();
-            KeyPair rekp = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+            KeyPair rekp = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
             tc.setReaderEphemeralPublicKey(rekp.getPublic());
             tc.setSessionTranscript(Util.buildSessionTranscript(ekp));
             Map<String, Collection<String>> etr = new LinkedHashMap<>();
@@ -808,7 +808,7 @@ public class DynamicAuthTest {
             IdentityCredential tc = store.getCredentialByName(credentialName,
                     IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
             KeyPair ekp = tc.createEphemeralKeyPair();
-            KeyPair rekp = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+            KeyPair rekp = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
             tc.setReaderEphemeralPublicKey(rekp.getPublic());
             tc.setSessionTranscript(Util.buildSessionTranscript(ekp));
             Map<String, Collection<String>> etr = new LinkedHashMap<>();
@@ -857,7 +857,7 @@ public class DynamicAuthTest {
             IdentityCredential tc = store.getCredentialByName(credentialName,
                     IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
             KeyPair ekp = tc.createEphemeralKeyPair();
-            KeyPair rekp = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+            KeyPair rekp = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
             tc.setReaderEphemeralPublicKey(rekp.getPublic());
             tc.setSessionTranscript(Util.buildSessionTranscript(ekp));
             Map<String, Collection<String>> etr = new LinkedHashMap<>();
@@ -888,7 +888,7 @@ public class DynamicAuthTest {
             IdentityCredential tc = store.getCredentialByName(credentialName,
                     IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
             KeyPair ekp = tc.createEphemeralKeyPair();
-            KeyPair rekp = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+            KeyPair rekp = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
             tc.setReaderEphemeralPublicKey(rekp.getPublic());
             tc.setSessionTranscript(Util.buildSessionTranscript(ekp));
             Map<String, Collection<String>> etr = new LinkedHashMap<>();
@@ -916,7 +916,7 @@ public class DynamicAuthTest {
                     IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
             tc.setAllowUsingExpiredKeys(true);   // <-- this is the call that makes the difference!
             KeyPair ekp = tc.createEphemeralKeyPair();
-            KeyPair rekp = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+            KeyPair rekp = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
             tc.setReaderEphemeralPublicKey(rekp.getPublic());
             tc.setSessionTranscript(Util.buildSessionTranscript(ekp));
             Map<String, Collection<String>> etr = new LinkedHashMap<>();
@@ -1040,7 +1040,7 @@ public class DynamicAuthTest {
         Map<String, Collection<String>> entriesToRequest = new LinkedHashMap<>();
         entriesToRequest.put("org.iso.18013-5.2019", Arrays.asList("First name", "Last name"));
         KeyPair ephemeralKeyPair = credential.createEphemeralKeyPair();
-        KeyPair readerEphemeralKeyPair = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+        KeyPair readerEphemeralKeyPair = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
         byte[] sessionTranscript = Util.buildSessionTranscript(ephemeralKeyPair);
         credential.setReaderEphemeralPublicKey(readerEphemeralKeyPair.getPublic());
         credential.setSessionTranscript(sessionTranscript);
@@ -1101,7 +1101,7 @@ public class DynamicAuthTest {
         Map<String, Collection<String>> entriesToRequest = new LinkedHashMap<>();
         entriesToRequest.put("org.iso.18013-5.2019", Arrays.asList("First name", "Last name"));
         KeyPair ephemeralKeyPair = credential.createEphemeralKeyPair();
-        KeyPair readerEphemeralKeyPair = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+        KeyPair readerEphemeralKeyPair = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
         byte[] sessionTranscript = Util.buildSessionTranscript(ephemeralKeyPair);
         credential.setReaderEphemeralPublicKey(readerEphemeralKeyPair.getPublic());
         credential.setSessionTranscript(sessionTranscript);
@@ -1124,7 +1124,7 @@ public class DynamicAuthTest {
         credential = store.getCredentialByName(credentialName,
                 IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
         ephemeralKeyPair = credential.createEphemeralKeyPair();
-        readerEphemeralKeyPair = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+        readerEphemeralKeyPair = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
         sessionTranscript = Util.buildSessionTranscript(ephemeralKeyPair);
         credential.setReaderEphemeralPublicKey(readerEphemeralKeyPair.getPublic());
         credential.setSessionTranscript(sessionTranscript);
@@ -1145,7 +1145,7 @@ public class DynamicAuthTest {
         credential = store.getCredentialByName(credentialName,
                 IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
         ephemeralKeyPair = credential.createEphemeralKeyPair();
-        readerEphemeralKeyPair = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+        readerEphemeralKeyPair = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
         sessionTranscript = Util.buildSessionTranscript(ephemeralKeyPair);
         credential.setReaderEphemeralPublicKey(readerEphemeralKeyPair.getPublic());
         credential.setSessionTranscript(sessionTranscript);

--- a/identity-android/src/androidTest/java/com/android/identity/android/legacy/MultiDocumentPresentationTest.java
+++ b/identity-android/src/androidTest/java/com/android/identity/android/legacy/MultiDocumentPresentationTest.java
@@ -207,7 +207,7 @@ public class MultiDocumentPresentationTest {
                 IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);
 
         KeyPair ephemeralKeyPair = session.getEphemeralKeyPair();
-        KeyPair readerEphemeralKeyPair = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+        KeyPair readerEphemeralKeyPair = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
         session.setReaderEphemeralPublicKey(readerEphemeralKeyPair.getPublic());
         byte[] sessionTranscript = Util.buildSessionTranscript(ephemeralKeyPair);
         session.setSessionTranscript(sessionTranscript);

--- a/identity-android/src/androidTest/java/com/android/identity/android/legacy/ProvisioningTest.java
+++ b/identity-android/src/androidTest/java/com/android/identity/android/legacy/ProvisioningTest.java
@@ -601,7 +601,7 @@ public class ProvisioningTest {
         }
 
         KeyPair ephemeralKeyPair = credential.createEphemeralKeyPair();
-        KeyPair readerEphemeralKeyPair = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+        KeyPair readerEphemeralKeyPair = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
         credential.setReaderEphemeralPublicKey(readerEphemeralKeyPair.getPublic());
         byte[] sessionTranscript = Util.buildSessionTranscript(ephemeralKeyPair);
 
@@ -621,7 +621,7 @@ public class ProvisioningTest {
 
         // Now try with a different (but still valid) sessionTranscript - this should fail with
         // a RuntimeException
-        KeyPair otherEphemeralKeyPair = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+        KeyPair otherEphemeralKeyPair = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
         byte[] otherSessionTranscript = Util.buildSessionTranscript(otherEphemeralKeyPair);
         try {
             credential.setSessionTranscript(otherSessionTranscript);

--- a/identity-android/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.java
+++ b/identity-android/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.java
@@ -52,6 +52,7 @@ import com.android.identity.mdoc.response.DeviceResponseParser;
 import com.android.identity.mdoc.sessionencryption.SessionEncryption;
 import com.android.identity.util.Constants;
 import com.android.identity.internal.Util;
+import com.android.identity.util.Logger;
 
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
@@ -63,8 +64,10 @@ import org.junit.runner.RunWith;
 
 import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
+import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.PublicKey;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.spec.ECGenParameterSpec;
@@ -208,7 +211,7 @@ public class DeviceRetrievalHelperTest {
                 };
         QrEngagementHelper qrHelper = new QrEngagementHelper.Builder(
                 context,
-                session,
+                session.getEphemeralKeyPair().getPublic(),
                 new DataTransportOptions.Builder().build(),
                 qrHelperListener,
                 executor)
@@ -218,7 +221,7 @@ public class DeviceRetrievalHelperTest {
         byte[] encodedDeviceEngagement = qrHelper.getDeviceEngagement();
 
         DataItem handover = SimpleValue.NULL;
-        KeyPair eReaderKeyPair = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+        KeyPair eReaderKeyPair = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
         byte[] encodedEReaderKeyPub = Util.cborEncode(Util.cborBuildCoseKey(eReaderKeyPair.getPublic()));
         byte[] encodedSessionTranscript = Util.cborEncode(new CborBuilder()
                 .addArray()
@@ -316,6 +319,16 @@ public class DeviceRetrievalHelperTest {
                 new DeviceRetrievalHelper.Listener() {
 
                     @Override
+                    public void onEReaderKeyReceived(@NonNull PublicKey eReaderKey) {
+                        try {
+                            session.setSessionTranscript(presentation[0].getSessionTranscript());
+                            session.setReaderEphemeralPublicKey(eReaderKey);
+                        } catch (InvalidKeyException e) {
+                            throw new AssertionError(e);
+                        }
+                    }
+
+                    @Override
                     public void onDeviceRequest(@NonNull byte[] deviceRequestBytes) {
                         DeviceRequestParser parser = new DeviceRequestParser();
                         parser.setDeviceRequest(deviceRequestBytes);
@@ -399,7 +412,7 @@ public class DeviceRetrievalHelperTest {
                 context,
                 listener,
                 context.getMainExecutor(),
-                session)
+                session.getEphemeralKeyPair())
                 .useForwardEngagement(proverTransport,
                         qrHelper.getDeviceEngagement(),
                         qrHelper.getHandover())
@@ -479,7 +492,7 @@ public class DeviceRetrievalHelperTest {
                 };
         QrEngagementHelper qrHelper = new QrEngagementHelper.Builder(
                 context,
-                session,
+                session.getEphemeralKeyPair().getPublic(),
                 new DataTransportOptions.Builder().build(),
                 qrHelperListener,
                 executor)
@@ -489,7 +502,7 @@ public class DeviceRetrievalHelperTest {
         byte[] encodedDeviceEngagement = qrHelper.getDeviceEngagement();
 
         DataItem handover = SimpleValue.NULL;
-        KeyPair eReaderKeyPair = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+        KeyPair eReaderKeyPair = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
         byte[] encodedEReaderKeyPub = Util.cborEncode(Util.cborBuildCoseKey(eReaderKeyPair.getPublic()));
         byte[] encodedSessionTranscript = Util.cborEncode(new CborBuilder()
                 .addArray()
@@ -563,6 +576,14 @@ public class DeviceRetrievalHelperTest {
         final DeviceRetrievalHelper[] presentation = {null};
         DeviceRetrievalHelper.Listener listener =
                 new DeviceRetrievalHelper.Listener() {
+                    @Override
+                    public void onEReaderKeyReceived(@NonNull PublicKey eReaderKey) {
+                        try {
+                            session.setReaderEphemeralPublicKey(eReaderKey);
+                        } catch (InvalidKeyException e) {
+                            throw new AssertionError(e);
+                        }
+                    }
 
                     @Override
                     public void onDeviceRequest(@NonNull byte[] deviceRequestBytes) {
@@ -586,7 +607,7 @@ public class DeviceRetrievalHelperTest {
                 context,
                 listener,
                 context.getMainExecutor(),
-                session)
+                session.getEphemeralKeyPair())
                 .useForwardEngagement(proverTransport,
                         qrHelper.getDeviceEngagement(),
                         qrHelper.getHandover())
@@ -648,7 +669,7 @@ public class DeviceRetrievalHelperTest {
                 };
         QrEngagementHelper qrHelper = new QrEngagementHelper.Builder(
                 context,
-                session,
+                session.getEphemeralKeyPair().getPublic(),
                 new DataTransportOptions.Builder().build(),
                 qrHelperListener,
                 executor)
@@ -658,7 +679,7 @@ public class DeviceRetrievalHelperTest {
         byte[] encodedDeviceEngagement = qrHelper.getDeviceEngagement();
 
         DataItem handover = SimpleValue.NULL;
-        KeyPair eReaderKeyPair = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+        KeyPair eReaderKeyPair = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
         byte[] encodedEReaderKeyPub = Util.cborEncode(Util.cborBuildCoseKey(eReaderKeyPair.getPublic()));
         byte[] encodedSessionTranscript = Util.cborEncode(new CborBuilder()
                 .addArray()
@@ -737,6 +758,14 @@ public class DeviceRetrievalHelperTest {
         final DeviceRetrievalHelper[] presentation = {null};
         DeviceRetrievalHelper.Listener listener =
                 new DeviceRetrievalHelper.Listener() {
+                    @Override
+                    public void onEReaderKeyReceived(@NonNull PublicKey eReaderKey) {
+                        try {
+                            session.setReaderEphemeralPublicKey(eReaderKey);
+                        } catch (InvalidKeyException e) {
+                            throw new AssertionError(e);
+                        }
+                    }
 
                     @Override
                     public void onDeviceRequest(@NonNull byte[] deviceRequestBytes) {
@@ -760,7 +789,7 @@ public class DeviceRetrievalHelperTest {
                 context,
                 listener,
                 context.getMainExecutor(),
-                session)
+                session.getEphemeralKeyPair())
                 .useForwardEngagement(proverTransport,
                         qrHelper.getDeviceEngagement(),
                         qrHelper.getHandover())
@@ -820,7 +849,7 @@ public class DeviceRetrievalHelperTest {
                 };
         QrEngagementHelper qrHelper = new QrEngagementHelper.Builder(
                 context,
-                session,
+                session.getEphemeralKeyPair().getPublic(),
                 new DataTransportOptions.Builder().build(),
                 qrHelperListener,
                 executor)
@@ -830,7 +859,7 @@ public class DeviceRetrievalHelperTest {
         byte[] encodedDeviceEngagement = qrHelper.getDeviceEngagement();
 
         byte[] encodedHandover = Util.cborEncode(SimpleValue.NULL);
-        KeyPair eReaderKeyPair = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+        KeyPair eReaderKeyPair = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
         byte[] encodedEReaderKeyPub = Util.cborEncode(Util.cborBuildCoseKey(eReaderKeyPair.getPublic()));
         byte[] encodedSessionTranscript = Util.cborEncode(new CborBuilder()
                 .addArray()
@@ -891,6 +920,15 @@ public class DeviceRetrievalHelperTest {
         DeviceRetrievalHelper.Listener listener =
                 new DeviceRetrievalHelper.Listener() {
                     @Override
+                    public void onEReaderKeyReceived(@NonNull PublicKey eReaderKey) {
+                        try {
+                            session.setReaderEphemeralPublicKey(eReaderKey);
+                        } catch (InvalidKeyException e) {
+                            throw new AssertionError(e);
+                        }
+                    }
+
+                    @Override
                     public void onDeviceRequest(@NonNull byte[] deviceRequestBytes) {
                         // Don't respond yet.. simulate the holder taking infinity to respond.
                         // instead, we'll simply wait for the verifier to disconnect instead.
@@ -912,7 +950,7 @@ public class DeviceRetrievalHelperTest {
                 context,
                 listener,
                 context.getMainExecutor(),
-                session)
+                session.getEphemeralKeyPair())
                 .useForwardEngagement(proverTransport,
                     qrHelper.getDeviceEngagement(),
                     qrHelper.getHandover())

--- a/identity-android/src/androidTest/java/com/android/identity/android/mdoc/engagement/NfcEnagementHelperTest.java
+++ b/identity-android/src/androidTest/java/com/android/identity/android/mdoc/engagement/NfcEnagementHelperTest.java
@@ -93,7 +93,7 @@ public class NfcEnagementHelperTest {
         Executor executor = Executors.newSingleThreadExecutor();
         NfcEngagementHelper.Builder builder = new NfcEngagementHelper.Builder(
                 context,
-                session,
+                session.getEphemeralKeyPair().getPublic(),
                 new DataTransportOptions.Builder().build(),
                 listener,
                 executor);
@@ -229,7 +229,7 @@ public class NfcEnagementHelperTest {
         Executor executor = Executors.newSingleThreadExecutor();
         NfcEngagementHelper.Builder builder = new NfcEngagementHelper.Builder(
                 context,
-                session,
+                session.getEphemeralKeyPair().getPublic(),
                 new DataTransportOptions.Builder().build(),
                 listener,
                 executor);

--- a/identity-android/src/androidTest/java/com/android/identity/mdoc/response/DeviceResponseGeneratorOnAndroidTest.java
+++ b/identity-android/src/androidTest/java/com/android/identity/mdoc/response/DeviceResponseGeneratorOnAndroidTest.java
@@ -244,7 +244,7 @@ public class DeviceResponseGeneratorOnAndroidTest {
                 Arrays.asList("given_name", "family_name", "some_number", "raw_cbor_1", "raw_cbor_2"));
         issuerSignedEntriesToRequest.put(AAMVA_NAMESPACE, Collections.singletonList("real_id"));
 
-        KeyPair readerEphemeralKeyPair = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+        KeyPair readerEphemeralKeyPair = Util.createEphemeralKeyPair(Constants.EC_CURVE_P256);
 
         PresentationSession session = store.createPresentationSession(
                 IdentityCredentialStore.CIPHERSUITE_ECDHE_HKDF_ECDSA_WITH_AES_256_GCM_SHA256);

--- a/identity-android/src/main/java/com/android/identity/android/legacy/Utility.java
+++ b/identity-android/src/main/java/com/android/identity/android/legacy/Utility.java
@@ -356,44 +356,4 @@ public class Utility {
         //return IdentityCredentialStore.getHardwareInstance(context);
         return IdentityCredentialStore.getKeystoreInstance(context, context.getNoBackupFilesDir());
     }
-
-    public static @NonNull KeyPair createEphemeralKeyPair(@Constants.EcCurve int curve) {
-        String stdName;
-        switch (curve) {
-            case Constants.EC_CURVE_P256:
-                stdName = "secp256r1";
-                break;
-            case Constants.EC_CURVE_P384:
-                stdName = "secp384r1";
-                break;
-            case Constants.EC_CURVE_P521:
-                stdName = "secp521r1";
-                break;
-            case Constants.EC_CURVE_BRAINPOOLP256R1:
-                stdName = "brainpoolP256r1";
-                break;
-            case Constants.EC_CURVE_BRAINPOOLP320R1:
-                stdName = "brainpoolP320r1";
-                break;
-            case Constants.EC_CURVE_BRAINPOOLP384R1:
-                stdName = "brainpoolP384r1";
-                break;
-            case Constants.EC_CURVE_BRAINPOOLP512R1:
-                stdName = "brainpoolP512r1";
-                break;
-            default:
-                throw new IllegalArgumentException("curve provided is not one of the supported curves");
-        }
-
-        try {
-            KeyPairGenerator kpg = KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_EC);
-            ECGenParameterSpec ecSpec = new ECGenParameterSpec(stdName);
-            kpg.initialize(ecSpec);
-            KeyPair keyPair = kpg.generateKeyPair();
-            return keyPair;
-        } catch (NoSuchAlgorithmException
-                 | InvalidAlgorithmParameterException e) {
-            throw new IllegalStateException("Error generating ephemeral key-pair", e);
-        }
-    }
 }

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.java
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.java
@@ -30,6 +30,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import com.android.identity.keystore.KeystoreEngine;
 import com.android.identity.mdoc.sessionencryption.SessionEncryption;
 import com.android.identity.android.legacy.Utility;
 import com.android.identity.android.mdoc.transport.DataTransport;
@@ -1264,7 +1265,7 @@ public class VerificationHelper {
             mHelper.mContext = context;
             mHelper.mListener = listener;
             mHelper.mListenerExecutor = executor;
-            mHelper.mEphemeralKeyPair = Utility.createEphemeralKeyPair(Constants.EC_CURVE_P256);
+            mHelper.mEphemeralKeyPair = Util.createEphemeralKeyPair(KeystoreEngine.EC_CURVE_P256);
         }
 
         /**

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/engagement/QrEngagementHelper.java
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/engagement/QrEngagementHelper.java
@@ -7,7 +7,6 @@ import android.util.Base64;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.android.identity.android.legacy.PresentationSession;
 import com.android.identity.android.mdoc.transport.DataTransport;
 import com.android.identity.android.mdoc.transport.DataTransportOptions;
 import com.android.identity.mdoc.connectionmethod.ConnectionMethod;
@@ -15,19 +14,38 @@ import com.android.identity.mdoc.engagement.EngagementGenerator;
 import com.android.identity.util.Logger;
 import com.android.identity.internal.Util;
 
-import java.security.KeyPair;
+import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 
 import co.nstant.in.cbor.model.SimpleValue;
 
+/**
+ * Helper used for QR engagement.
+ *
+ * <p>This implements QR engagement as defined in ISO/IEC 18013-5:2021.
+ *
+ * <p>Applications can instantiate a {@link QrEngagementHelper} using
+ * {@link QrEngagementHelper.Builder}, specifying which device retrieval methods
+ * to support using {@link QrEngagementHelper.Builder#setConnectionMethods(List)}
+ * or {@link QrEngagementHelper.Builder#setTransports(List)}.
+ *
+ * <p>When {@link Listener#onDeviceEngagementReady()} is called, the application can
+ * call {@link #getDeviceEngagement()} and display this as a QR code in the user
+ * interface and instruct the user to show this QR code to a remote mdoc reader.
+ *
+ * <p>When a remote mdoc reader connects to one of the advertised transports, the
+ * {@link Listener#onDeviceConnected(DataTransport)} is called and the application
+ * can use the passed-in {@link DataTransport} to create a
+ * {@link com.android.identity.android.mdoc.deviceretrieval.DeviceRetrievalHelper}
+ * to start the transaction.
+ */
 public class QrEngagementHelper {
     private static final String TAG = "QrEngagementHelper";
 
-    private final PresentationSession mPresentationSession;
     private final Context mContext;
-    private final KeyPair mEphemeralKeyPair;
+    private final PublicKey mEDeviceKey;
     private final DataTransportOptions mOptions;
     private final Listener mListener;
     private final Executor mExecutor;
@@ -39,21 +57,20 @@ public class QrEngagementHelper {
     private boolean mReportedDeviceConnecting;
 
     QrEngagementHelper(@NonNull Context context,
-                       @NonNull PresentationSession presentationSession,
+                       @NonNull PublicKey eDeviceKey,
                        @Nullable List<ConnectionMethod> connectionMethods,
                        @Nullable List<DataTransport> transports,
                        @NonNull DataTransportOptions options,
                        @NonNull Listener listener,
                        @NonNull Executor executor) {
         mContext = context;
-        mPresentationSession = presentationSession;
+        mEDeviceKey = eDeviceKey;
         mListener = listener;
         mExecutor = executor;
-        mEphemeralKeyPair = mPresentationSession.getEphemeralKeyPair();
         mOptions = options;
 
         byte[] encodedEDeviceKeyBytes = Util.cborEncode(Util.cborBuildTaggedByteString(
-                Util.cborEncode(Util.cborBuildCoseKey(mEphemeralKeyPair.getPublic()))));
+                Util.cborEncode(Util.cborBuildCoseKey(eDeviceKey))));
 
         // Set EDeviceKey for transports we were given.
         if (transports != null) {
@@ -144,6 +161,13 @@ public class QrEngagementHelper {
     }
 
 
+    /**
+     * Close all transports currently being listened on.
+     *
+     * <p>No callbacks will be done on a listener after calling this.
+     *
+     * <p>This method is idempotent so it is safe to call multiple times.
+     */
     public void close() {
         mInhibitCallbacks = true;
         if (mTransports != null) {
@@ -171,8 +195,7 @@ public class QrEngagementHelper {
         // TODO: Figure out when we need to use version "1.1".
         //
         EngagementGenerator engagementGenerator =
-                new EngagementGenerator(mEphemeralKeyPair.getPublic(),
-                        EngagementGenerator.ENGAGEMENT_VERSION_1_0);
+                new EngagementGenerator(mEDeviceKey, EngagementGenerator.ENGAGEMENT_VERSION_1_0);
         engagementGenerator.setConnectionMethods(connectionMethods);
         mEncodedDeviceEngagement = engagementGenerator.generate();
         mEncodedHandover = Util.cborEncode(SimpleValue.NULL);
@@ -182,6 +205,18 @@ public class QrEngagementHelper {
         reportDeviceEngagementReady();
     }
 
+    /**
+     * Gets {@code DeviceEngagement} as as a URI-encoded string.
+     *
+     * <p>This is like {@link #getDeviceEngagement()} except that it encodes the
+     * {@code DeviceEngagement} according to ISO/IEC 18013-5:2021 section 8.2.2.3,
+     * that is with "mdoc:" as scheme and the bytes of the {@code DeviceEngagement}
+     * CBOR encoded using base64url-without-padding, according to RFC 4648, as path.
+     *
+     * <p>This can only be called after {@link Listener#onDeviceEngagementReady()} has been called.
+     *
+     * @return the {@code DeviceEngagement} CBOR encoded as an URI string.
+     */
     public @NonNull
     String getDeviceEngagementUriEncoded() {
         String base64EncodedDeviceEngagement =
@@ -196,11 +231,31 @@ public class QrEngagementHelper {
         return uriString;
     }
 
+    /**
+     * Gets the bytes of the {@code DeviceEngagement} CBOR.
+     *
+     * <p>This returns the bytes of the {@code DeviceEngagement} CBOR according to
+     * ISO/IEC 18013-5:2021 section 8.2.1.1 with the device retrieval methods
+     * specified using {@link QrEngagementHelper.Builder}.
+     *
+     * <p>This can only be called after {@link Listener#onDeviceEngagementReady()} has been called.
+     *
+     * @return the bytes of the {@code DeviceEngagement} CBOR.
+     */
     public @NonNull
     byte[] getDeviceEngagement() {
         return mEncodedDeviceEngagement;
     }
 
+    /**
+     * Gets the bytes of the {@code Handover} CBOR.
+     *
+     * <p>This returns the bytes of the {@code Handover} CBOR according to
+     * ISO/IEC 18013-5:2021 section 9.1.5.1. For QR Code the Handover is
+     * always defined as CBOR with the {@code null} value.
+     *
+     * @return the Handover used for QR code.
+     */
     public @NonNull
     byte[] getHandover() {
         return mEncodedHandover;
@@ -269,48 +324,113 @@ public class QrEngagementHelper {
         }
     }
 
+    /**
+     * Listener interface for {@link QrEngagementHelper}.
+     */
     public interface Listener {
+        /**
+         * Called when the {@code DeviceEngagement} CBOR is ready.
+         *
+         * <p>After this method is called it's permissible to call {@link #getDeviceEngagement()}
+         * or {@link #getDeviceEngagementUriEncoded()}.
+         */
         void onDeviceEngagementReady();
+
+        /**
+         * Called when a remote mdoc reader is starting to connect.
+         */
         void onDeviceConnecting();
-        void onDeviceConnected(DataTransport transport);
+
+        /**
+         * Called when a remote mdoc reader has connected.
+         *
+         * <p>The application should use the passed-in {@link DataTransport} with
+         * {@link com.android.identity.android.mdoc.deviceretrieval.DeviceRetrievalHelper}
+         * to start the transaction.
+         *
+         * <p>After this is called, no more callbacks will be done on listener and all other
+         * listening transports will be closed. Calling {@link #close()} will not close the
+         * passed-in transport.
+         *
+         * @param transport a {@link DataTransport} for the connection to the remote mdoc reader.
+         */
+        void onDeviceConnected(@NonNull DataTransport transport);
+
+        /**
+         * Called when an irrecoverable error has occurred.
+         *
+         * @param error details of what error has occurred.
+         */
         void onError(@NonNull Throwable error);
     }
 
+    /**
+     * A builder for {@link QrEngagementHelper}.
+     */
     public static class Builder {
 
         private final Context mContext;
-        private final PresentationSession mPresentationSession;
+        private final PublicKey mEDeviceKey;
         private final DataTransportOptions mOptions;
         private final Listener mListener;
         private final Executor mExecutor;
         private List<ConnectionMethod> mConnectionMethods;
         private List<DataTransport> mTransports;
 
+        /**
+         * Creates a new builder for {@link QrEngagementHelper}.
+         *
+         * @param context application context.
+         * @param eDeviceKey the public part of {@code EDeviceKey} for <em>mdoc session
+         *                   encryption</em> according to ISO/IEC 18013-5:2021 section 9.1.1.4.
+         * @param options set of options for creating {@link DataTransport} instances.
+         * @param listener the listener.
+         * @param executor a {@link Executor} to use with the listener.
+         */
         public Builder(@NonNull Context context,
-                       @NonNull PresentationSession presentationSession,
+                       @NonNull PublicKey eDeviceKey,
                        @NonNull DataTransportOptions options,
                        @NonNull Listener listener,
                        @NonNull Executor executor) {
             mContext = context;
-            mPresentationSession = presentationSession;
+            mEDeviceKey = eDeviceKey;
             mOptions = options;
             mListener = listener;
             mExecutor = executor;
         }
 
+        /**
+         * Sets the connection methods to use.
+         *
+         * <p>This is used to indicate which connection methods should be used for QR engagement.
+         *
+         * @param connectionMethods a list of {@link ConnectionMethod} instances.
+         * @return the builder.
+         */
         public @NonNull Builder setConnectionMethods(@NonNull List<ConnectionMethod> connectionMethods) {
             mConnectionMethods = connectionMethods;
             return this;
         }
 
+        /**
+         * Sets data transports to use.
+         *
+         * @param transports a list of {@link DataTransport} instances.
+         * @return the builder.
+         */
         public @NonNull Builder setTransports(@NonNull List<DataTransport> transports) {
             mTransports = transports;
             return this;
         }
 
+        /**
+         * Builds the {@link QrEngagementHelper} and starts listening for connections.
+         *
+         * @return the helper, ready to be used.
+         */
         public @NonNull QrEngagementHelper build() {
             return new QrEngagementHelper(mContext,
-                    mPresentationSession,
+                    mEDeviceKey,
                     mConnectionMethods,
                     mTransports,
                     mOptions,

--- a/identity/src/main/java/com/android/identity/internal/Util.java
+++ b/identity/src/main/java/com/android/identity/internal/Util.java
@@ -41,9 +41,11 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.AlgorithmParameters;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.MessageDigest;
@@ -1936,6 +1938,46 @@ public class Util {
                     + "characteristic value size", mtuSize, characteristicValueSize));
         }
         return characteristicValueSize;
+    }
+
+    public static @NonNull KeyPair createEphemeralKeyPair(@KeystoreEngine.EcCurve int curve) {
+        String stdName;
+        switch (curve) {
+            case KeystoreEngine.EC_CURVE_P256:
+                stdName = "secp256r1";
+                break;
+            case KeystoreEngine.EC_CURVE_P384:
+                stdName = "secp384r1";
+                break;
+            case KeystoreEngine.EC_CURVE_P521:
+                stdName = "secp521r1";
+                break;
+            case KeystoreEngine.EC_CURVE_BRAINPOOLP256R1:
+                stdName = "brainpoolP256r1";
+                break;
+            case KeystoreEngine.EC_CURVE_BRAINPOOLP320R1:
+                stdName = "brainpoolP320r1";
+                break;
+            case KeystoreEngine.EC_CURVE_BRAINPOOLP384R1:
+                stdName = "brainpoolP384r1";
+                break;
+            case KeystoreEngine.EC_CURVE_BRAINPOOLP512R1:
+                stdName = "brainpoolP512r1";
+                break;
+            default:
+                throw new IllegalArgumentException("curve provided is not one of the supported curves");
+        }
+
+        try {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+            ECGenParameterSpec ecSpec = new ECGenParameterSpec(stdName);
+            kpg.initialize(ecSpec);
+            KeyPair keyPair = kpg.generateKeyPair();
+            return keyPair;
+        } catch (NoSuchAlgorithmException
+                 | InvalidAlgorithmParameterException e) {
+            throw new IllegalStateException("Error generating ephemeral key-pair", e);
+        }
     }
 
 }

--- a/identity/src/main/java/com/android/identity/util/Constants.java
+++ b/identity/src/main/java/com/android/identity/util/Constants.java
@@ -172,28 +172,4 @@ public class Constants {
             })
     public @interface BleDataRetrievalOption {
     }
-
-    // TODO: Replace using KeystoreEngine.EcCurve once the keystore-abstraction branch lands
-    /**
-     * An annotation used to specify allowed curve identifiers.
-     *
-     * <p>All curve identifiers are from the
-     * <a href="https://www.iana.org/assignments/cose/cose.xhtml">
-     * IANA COSE registry</a>.
-     */
-    @Retention(SOURCE)
-    @IntDef(value = {
-            EC_CURVE_P256,
-            EC_CURVE_P384,
-            EC_CURVE_P521,
-            EC_CURVE_BRAINPOOLP256R1,
-            EC_CURVE_BRAINPOOLP320R1,
-            EC_CURVE_BRAINPOOLP384R1,
-            EC_CURVE_BRAINPOOLP512R1,
-            EC_CURVE_ED25519,
-            EC_CURVE_ED448
-    })
-    public @interface EcCurve {
-    }
-
 }

--- a/identity/src/test/java/com/android/identity/TestUtilities.java
+++ b/identity/src/test/java/com/android/identity/TestUtilities.java
@@ -72,44 +72,4 @@ public class TestUtilities {
             throw new IllegalStateException("Error generating self-signed certificate", e);
         }
     }
-
-    public static @NonNull KeyPair createEphemeralKeyPair(@Constants.EcCurve int curve) {
-        String stdName;
-        switch (curve) {
-            case Constants.EC_CURVE_P256:
-                stdName = "secp256r1";
-                break;
-            case Constants.EC_CURVE_P384:
-                stdName = "secp384r1";
-                break;
-            case Constants.EC_CURVE_P521:
-                stdName = "secp521r1";
-                break;
-            case Constants.EC_CURVE_BRAINPOOLP256R1:
-                stdName = "brainpoolP256r1";
-                break;
-            case Constants.EC_CURVE_BRAINPOOLP320R1:
-                stdName = "brainpoolP320r1";
-                break;
-            case Constants.EC_CURVE_BRAINPOOLP384R1:
-                stdName = "brainpoolP384r1";
-                break;
-            case Constants.EC_CURVE_BRAINPOOLP512R1:
-                stdName = "brainpoolP512r1";
-                break;
-            default:
-                throw new IllegalArgumentException("curve provided is not one of the supported curves");
-        }
-
-        try {
-            KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
-            ECGenParameterSpec ecSpec = new ECGenParameterSpec(stdName);
-            kpg.initialize(ecSpec);
-            KeyPair keyPair = kpg.generateKeyPair();
-            return keyPair;
-        } catch (NoSuchAlgorithmException
-                 | InvalidAlgorithmParameterException e) {
-            throw new IllegalStateException("Error generating ephemeral key-pair", e);
-        }
-    }
 }

--- a/identity/src/test/java/com/android/identity/mdoc/sessionencryption/SessionEncryptionTest.java
+++ b/identity/src/test/java/com/android/identity/mdoc/sessionencryption/SessionEncryptionTest.java
@@ -19,6 +19,7 @@ package com.android.identity.mdoc.sessionencryption;
 import com.android.identity.TestUtilities;
 import com.android.identity.TestVectors;
 import com.android.identity.internal.Util;
+import com.android.identity.keystore.KeystoreEngine;
 import com.android.identity.mdoc.engagement.EngagementParser;
 import com.android.identity.util.Constants;
 
@@ -157,10 +158,10 @@ public class SessionEncryptionTest {
                 sessionEncryptionDevice.encryptMessage(null, OptionalLong.of(20)));
     }
 
-    private void testCurve(@Constants.EcCurve int curve) {
-        KeyPair eReaderKeyPair = TestUtilities.createEphemeralKeyPair(curve);
+    private void testCurve(@KeystoreEngine.EcCurve int curve) {
+        KeyPair eReaderKeyPair = Util.createEphemeralKeyPair(curve);
         PublicKey eReaderKeyPublic = eReaderKeyPair.getPublic();
-        KeyPair eDeviceKeyPair = TestUtilities.createEphemeralKeyPair(curve);
+        KeyPair eDeviceKeyPair = Util.createEphemeralKeyPair(curve);
         PublicKey eDeviceKeyPublic = eDeviceKeyPair.getPublic();
         PrivateKey eDeviceKeyPrivate = eDeviceKeyPair.getPrivate();
 
@@ -240,7 +241,7 @@ public class SessionEncryptionTest {
         testCurve(Constants.EC_CURVE_BRAINPOOLP512R1);
     }
 
-    // TODO add these back in after Keystore abstraction is merged
+    // TODO: remove @Ignore once ED25519 / ED448 is no longer buggy
     @Ignore
     @Test
     public void testEd25519() {


### PR DESCRIPTION
With PresentationSession now in the 'legacy' package it would be helpful if an application could just pass a KeyPair and PublicKey which can be used for mdoc session authentication.

Also remove EC Curve constants from Constants class since these are already available in KeystoreEngine interface

Test: All unit tests pass.
Test: Manually tested.
