### PR TITLE
Fix remaining unit tests in Java 17

### DIFF
--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -18,9 +18,9 @@ java {
 dependencies {
     implementation("androidx.annotation:annotation:1.5.0")
     implementation "co.nstant.in:cbor:0.9"
-    implementation "org.bouncycastle:bcprov-jdk15on:1.67"
-    implementation("org.bouncycastle:bcpkix-jdk15on:1.67")
+    implementation "org.bouncycastle:bcprov-jdk15on:1.69"
+    implementation("org.bouncycastle:bcpkix-jdk15on:1.69")
 
     testImplementation "junit:junit:4.13.2"
-    testImplementation "org.bouncycastle:bcprov-jdk15on:1.67"
+    testImplementation "org.bouncycastle:bcprov-jdk15on:1.69"
 }

--- a/identity/src/test/java/com/android/identity/TestUtilities.java
+++ b/identity/src/test/java/com/android/identity/TestUtilities.java
@@ -102,7 +102,7 @@ public class TestUtilities {
         }
 
         try {
-            KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", new BouncyCastleProvider());
             ECGenParameterSpec ecSpec = new ECGenParameterSpec(stdName);
             kpg.initialize(ecSpec);
             KeyPair keyPair = kpg.generateKeyPair();

--- a/identity/src/test/java/com/android/identity/internal/UtilTest.java
+++ b/identity/src/test/java/com/android/identity/internal/UtilTest.java
@@ -76,7 +76,7 @@ public class UtilTest {
 
     @Before
     public void setUp() {
-        Security.addProvider(new BouncyCastleProvider());
+        Security.insertProviderAt(new BouncyCastleProvider(), 1);
     }
 
     @After

--- a/identity/src/test/java/com/android/identity/keystore/BouncyCastleKeystoreTest.java
+++ b/identity/src/test/java/com/android/identity/keystore/BouncyCastleKeystoreTest.java
@@ -45,7 +45,7 @@ public class BouncyCastleKeystoreTest {
 
     @Before
     public void setup() {
-        Security.addProvider(new BouncyCastleProvider());
+        Security.insertProviderAt(new BouncyCastleProvider(), 1);
     }
 
     @Test

--- a/identity/src/test/java/com/android/identity/mdoc/request/DeviceRequestParserTest.java
+++ b/identity/src/test/java/com/android/identity/mdoc/request/DeviceRequestParserTest.java
@@ -56,7 +56,7 @@ public class DeviceRequestParserTest {
 
     @Before
     public void setUp() {
-        Security.addProvider(new BouncyCastleProvider());
+        Security.insertProviderAt(new BouncyCastleProvider(), 1);
     }
 
     @After

--- a/identity/src/test/java/com/android/identity/mdoc/sessionencryption/SessionEncryptionTest.java
+++ b/identity/src/test/java/com/android/identity/mdoc/sessionencryption/SessionEncryptionTest.java
@@ -22,7 +22,10 @@ import com.android.identity.internal.Util;
 import com.android.identity.mdoc.engagement.EngagementParser;
 import com.android.identity.util.Constants;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -30,6 +33,7 @@ import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.Security;
 import java.util.OptionalLong;
 
 import co.nstant.in.cbor.model.Array;
@@ -37,6 +41,16 @@ import co.nstant.in.cbor.model.ByteString;
 import co.nstant.in.cbor.model.DataItem;
 
 public class SessionEncryptionTest {
+
+    @Before
+    public void setUp() {
+        Security.insertProviderAt(new BouncyCastleProvider(), 1);
+    }
+
+    @After
+    public void tearDown() {
+        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+    }
 
     @Test
     public void testReaderAgainstVectors() {


### PR DESCRIPTION
Apparently the `secp256k1` curve wasn't the only thing that was removed from later versions of Java, as fixed in #335. The brainpool curves are no longer usable either. Unfortunately the Security subsystem is not able to fallback to different provider when the default provider is unable to provide these curves. Therefore use the BouncyCastle provider as the default provider in unit tests to provide them. Update BouncyCastle to 1.69 because there appears to be a compatibility issue with the previous version and `BouncyCastleKeystoreTest.testEcKeySigningWithLockedKey()`.

Fixes #337.