### PR TITLE
Rename KeystoreEngine to SecureArea.

### DIFF
--- a/appholder/src/main/java/com/android/mdl/app/transfer/QrCommunicationSetup.kt
+++ b/appholder/src/main/java/com/android/mdl/app/transfer/QrCommunicationSetup.kt
@@ -5,7 +5,6 @@ import com.android.identity.android.mdoc.transport.DataTransport
 import com.android.identity.android.mdoc.deviceretrieval.DeviceRetrievalHelper
 import com.android.identity.android.legacy.PresentationSession
 import com.android.identity.android.mdoc.engagement.QrEngagementHelper
-import com.android.identity.keystore.KeystoreEngine
 import com.android.mdl.app.util.log
 import com.android.mdl.app.util.mainExecutor
 import java.security.PublicKey

--- a/identity-android/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.java
+++ b/identity-android/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.java
@@ -779,7 +779,8 @@ public class DeviceRetrievalHelperTest {
 
                     @Override
                     public void onError(@NonNull Throwable error) {
-                        Assert.assertEquals("Error decoding EReaderKey in SessionEstablishment",
+                        Assert.assertEquals(
+                                "Error decoding EReaderKey in SessionEstablishment, returning status 10",
                                 error.getMessage());
                         condVarDecryptionErrorReceived.open();
                     }

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelper.java
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelper.java
@@ -21,13 +21,9 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.android.identity.keystore.KeystoreEngine;
+import com.android.identity.securearea.SecureArea;
 import com.android.identity.mdoc.sessionencryption.SessionEncryption;
 import com.android.identity.android.mdoc.transport.TransmissionProgressListener;
-import com.android.identity.android.legacy.CredentialDataRequest;
-import com.android.identity.android.legacy.IdentityCredential;
-import com.android.identity.android.legacy.IdentityCredentialStore;
-import com.android.identity.android.legacy.WritableIdentityCredential;
 import com.android.identity.android.mdoc.engagement.NfcEngagementHelper;
 import com.android.identity.android.mdoc.engagement.QrEngagementHelper;
 import com.android.identity.android.mdoc.transport.DataTransport;
@@ -271,17 +267,17 @@ public class DeviceRetrievalHelper {
             }
         }
         DataItem eReaderKeyDataItem = Util.cborDecode(encodedEReaderKey);
-        @KeystoreEngine.EcCurve int curve;
+        @SecureArea.EcCurve int curve;
         try {
             curve = Util.coseKeyGetCurve(eReaderKeyDataItem);
         } catch (IllegalArgumentException e) {
             Logger.w(TAG, "No curve identifier in COSE_Key", e);
             return OptionalLong.of(Constants.SESSION_DATA_STATUS_ERROR_SESSION_ENCRYPTION);
         }
-        if (curve != KeystoreEngine.EC_CURVE_P256) {
+        if (curve != SecureArea.EC_CURVE_P256) {
             Logger.w(TAG,
                     String.format(Locale.US, "Expected curve P-256 (%d) but got %d",
-                            KeystoreEngine.EC_CURVE_P256, curve));
+                            SecureArea.EC_CURVE_P256, curve));
             return OptionalLong.of(Constants.SESSION_DATA_STATUS_ERROR_SESSION_ENCRYPTION);
         }
         try {

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.java
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.java
@@ -30,9 +30,8 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
-import com.android.identity.keystore.KeystoreEngine;
+import com.android.identity.securearea.SecureArea;
 import com.android.identity.mdoc.sessionencryption.SessionEncryption;
-import com.android.identity.android.legacy.Utility;
 import com.android.identity.android.mdoc.transport.DataTransport;
 import com.android.identity.android.mdoc.transport.DataTransportBle;
 import com.android.identity.android.mdoc.transport.DataTransportBleCentralClientMode;
@@ -1265,7 +1264,7 @@ public class VerificationHelper {
             mHelper.mContext = context;
             mHelper.mListener = listener;
             mHelper.mListenerExecutor = executor;
-            mHelper.mEphemeralKeyPair = Util.createEphemeralKeyPair(KeystoreEngine.EC_CURVE_P256);
+            mHelper.mEphemeralKeyPair = Util.createEphemeralKeyPair(SecureArea.EC_CURVE_P256);
         }
 
         /**

--- a/identity/src/main/java/com/android/identity/credential/CredentialStore.java
+++ b/identity/src/main/java/com/android/identity/credential/CredentialStore.java
@@ -19,8 +19,8 @@ package com.android.identity.credential;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.android.identity.keystore.KeystoreEngine;
-import com.android.identity.keystore.KeystoreEngineRepository;
+import com.android.identity.securearea.SecureArea;
+import com.android.identity.securearea.SecureAreaRepository;
 import com.android.identity.storage.StorageEngine;
 
 import java.util.ArrayList;
@@ -34,8 +34,8 @@ import java.util.List;
  * not tied to that specific credential shape and is designed to hold any kind of
  * credential, regardless of shape, presentation-, or issuance-protocol used.
  *
- * <p>This code relies on a Secure Keystore for keys and this dependency is abstracted
- * by the {@link KeystoreEngine} interface and allows the use of different implementations
+ * <p>This code relies on a Secure Area for keys and this dependency is abstracted
+ * by the {@link SecureArea} interface and allows the use of different implementations
  * on a per-credential basis. Persistent storage of credentials is abstracted via
  * the {@link StorageEngine} interface which provides a simple key/value store.
  *
@@ -44,19 +44,19 @@ import java.util.List;
  */
 public class CredentialStore {
     private final StorageEngine mStorageEngine;
-    private final KeystoreEngineRepository mKeystoreEngineRepository;
+    private final SecureAreaRepository mSecureAreaRepository;
 
     /**
      * Creates a new credential store.
      *
      * @param storageEngine the {@link StorageEngine} to use for storing/retrieving credentials.
-     * @param keystoreEngineRepository the repository of configured {@link KeystoreEngine} that can
+     * @param secureAreaRepository the repository of configured {@link SecureArea} that can
      *                                 be used.
      */
     public CredentialStore(@NonNull StorageEngine storageEngine,
-                           @NonNull KeystoreEngineRepository keystoreEngineRepository) {
+                           @NonNull SecureAreaRepository secureAreaRepository) {
         mStorageEngine = storageEngine;
-        mKeystoreEngineRepository = keystoreEngineRepository;
+        mSecureAreaRepository = secureAreaRepository;
     }
 
     /**
@@ -70,9 +70,9 @@ public class CredentialStore {
      * @return A newly created credential.
      */
     public @NonNull Credential createCredential(@NonNull String name,
-                                                @NonNull KeystoreEngine.CreateKeySettings credentialKeySettings) {
+                                                @NonNull SecureArea.CreateKeySettings credentialKeySettings) {
         return Credential.create(mStorageEngine,
-                mKeystoreEngineRepository,
+                mSecureAreaRepository,
                 name,
                 credentialKeySettings);
     }
@@ -84,7 +84,7 @@ public class CredentialStore {
      * @return the credential or {@code null} if not found.
      */
     public @Nullable Credential lookupCredential(@NonNull String name) {
-        return Credential.lookup(mStorageEngine, mKeystoreEngineRepository, name);
+        return Credential.lookup(mStorageEngine, mSecureAreaRepository, name);
     }
 
     /**

--- a/identity/src/main/java/com/android/identity/credential/CredentialUtil.java
+++ b/identity/src/main/java/com/android/identity/credential/CredentialUtil.java
@@ -18,7 +18,7 @@ package com.android.identity.credential;
 
 import androidx.annotation.NonNull;
 
-import com.android.identity.keystore.KeystoreEngine;
+import com.android.identity.securearea.SecureArea;
 import com.android.identity.util.Timestamp;
 
 /**
@@ -35,7 +35,7 @@ public class CredentialUtil {
      *     <li>If a key is used more than {@code maxUsesPerKey} times, a replacement is generated.</li>
      *     <li>If a key expires within {@code minValidTimeMillis} milliseconds, a replacement is generated.</li>
      * </ul>
-     * <p>This is all implemented on top of {@link Credential#createPendingAuthenticationKey(KeystoreEngine.CreateKeySettings, Credential.AuthenticationKey)}
+     * <p>This is all implemented on top of {@link Credential#createPendingAuthenticationKey(SecureArea.CreateKeySettings, Credential.AuthenticationKey)}
      * and {@link Credential.PendingAuthenticationKey#certify(byte[], Timestamp, Timestamp)}.
      * The application should examine the return value and if positive, collect the
      * pending authentication keys via {@link Credential#getPendingAuthenticationKeys()},
@@ -59,7 +59,7 @@ public class CredentialUtil {
      */
     public static int managedAuthenticationKeyHelper(
             @NonNull Credential credential,
-            @NonNull KeystoreEngine.CreateKeySettings createKeySettings,
+            @NonNull SecureArea.CreateKeySettings createKeySettings,
             @NonNull String managedKeyDomain,
             @NonNull Timestamp now,
             int numAuthenticationKeys,

--- a/identity/src/main/java/com/android/identity/internal/Util.java
+++ b/identity/src/main/java/com/android/identity/internal/Util.java
@@ -21,7 +21,7 @@ import androidx.annotation.Nullable;
 
 import androidx.annotation.VisibleForTesting;
 
-import com.android.identity.keystore.KeystoreEngine;
+import com.android.identity.securearea.SecureArea;
 import com.android.identity.util.Logger;
 import com.android.identity.util.Timestamp;
 import org.bouncycastle.asn1.ASN1Encodable;
@@ -617,14 +617,14 @@ public class Util {
     }
 
     public static @NonNull
-    DataItem coseSign1Sign(@NonNull KeystoreEngine keystoreEngine,
+    DataItem coseSign1Sign(@NonNull SecureArea secureArea,
                            @NonNull String alias,
-                           @KeystoreEngine.Algorithm int signatureAlgorithm,
-                           @Nullable KeystoreEngine.KeyUnlockData keyUnlockData,
+                           @SecureArea.Algorithm int signatureAlgorithm,
+                           @Nullable SecureArea.KeyUnlockData keyUnlockData,
                            @Nullable byte[] data,
                            @Nullable byte[] detachedContent,
                            @Nullable Collection<X509Certificate> certificateChain)
-            throws KeystoreEngine.KeyLockedException {
+            throws SecureArea.KeyLockedException {
 
         int dataLen = (data != null ? data.length : 0);
         int detachedContentLen = (detachedContent != null ? detachedContent.length : 0);
@@ -638,7 +638,7 @@ public class Util {
         byte[] protectedHeadersBytes = cborEncode(protectedHeaders.build().get(0));
 
         byte[] toBeSigned = coseBuildToBeSigned(protectedHeadersBytes, data, detachedContent);
-        byte[] derSignature = keystoreEngine.sign(alias, signatureAlgorithm, toBeSigned, keyUnlockData);
+        byte[] derSignature = secureArea.sign(alias, signatureAlgorithm, toBeSigned, keyUnlockData);
         byte[] coseSignature = signatureDerToCose(derSignature, 32); // TODO: infer from alias
 
         CborBuilder builder = new CborBuilder();
@@ -1164,7 +1164,7 @@ public class Util {
     }
 
     public static
-    @KeystoreEngine.EcCurve int coseKeyGetCurve(@NonNull DataItem coseKey) {
+    @SecureArea.EcCurve int coseKeyGetCurve(@NonNull DataItem coseKey) {
         return (int) cborMapExtractNumber(coseKey, COSE_KEY_EC2_CRV);
     }
 
@@ -1946,28 +1946,28 @@ public class Util {
         return characteristicValueSize;
     }
 
-    public static @NonNull KeyPair createEphemeralKeyPair(@KeystoreEngine.EcCurve int curve) {
+    public static @NonNull KeyPair createEphemeralKeyPair(@SecureArea.EcCurve int curve) {
         String stdName;
         switch (curve) {
-            case KeystoreEngine.EC_CURVE_P256:
+            case SecureArea.EC_CURVE_P256:
                 stdName = "secp256r1";
                 break;
-            case KeystoreEngine.EC_CURVE_P384:
+            case SecureArea.EC_CURVE_P384:
                 stdName = "secp384r1";
                 break;
-            case KeystoreEngine.EC_CURVE_P521:
+            case SecureArea.EC_CURVE_P521:
                 stdName = "secp521r1";
                 break;
-            case KeystoreEngine.EC_CURVE_BRAINPOOLP256R1:
+            case SecureArea.EC_CURVE_BRAINPOOLP256R1:
                 stdName = "brainpoolP256r1";
                 break;
-            case KeystoreEngine.EC_CURVE_BRAINPOOLP320R1:
+            case SecureArea.EC_CURVE_BRAINPOOLP320R1:
                 stdName = "brainpoolP320r1";
                 break;
-            case KeystoreEngine.EC_CURVE_BRAINPOOLP384R1:
+            case SecureArea.EC_CURVE_BRAINPOOLP384R1:
                 stdName = "brainpoolP384r1";
                 break;
-            case KeystoreEngine.EC_CURVE_BRAINPOOLP512R1:
+            case SecureArea.EC_CURVE_BRAINPOOLP512R1:
                 stdName = "brainpoolP512r1";
                 break;
             default:

--- a/identity/src/main/java/com/android/identity/securearea/SecureArea.java
+++ b/identity/src/main/java/com/android/identity/securearea/SecureArea.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.android.identity.keystore;
+package com.android.identity.securearea;
 
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
@@ -28,12 +28,13 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * An interface to a Secure Keystore.
+ * An interface to a Secure Area.
  *
- * <p>This interface exists to abstract the underlying hardware-backed keystore
- * used for creation of key material.
+ * <p>This interface exists to abstract the underlying secure area used
+ * used for creation of key material and other security objects related
+ * to credentials.
  */
-public interface KeystoreEngine {
+public interface SecureArea {
 
     /** The curve identifier for P-256 */
     int EC_CURVE_P256 = 1;
@@ -121,7 +122,9 @@ public interface KeystoreEngine {
     int KEY_PURPOSE_AGREE_KEY = 1<<1;
 
     /**
-     * An annotation used to the purpose of a key.
+     * An annotation used for indicating the purpose of a key.
+     *
+     * <p>A key may have multiple purposes.
      */
     @Retention(RetentionPolicy.SOURCE)
     @IntDef(flag = true,
@@ -138,7 +141,7 @@ public interface KeystoreEngine {
      * is exposed to the user of this interface.
      *
      * <p>The key is attested to and the generated certificate-chain depends on
-     * the specific Keystore Implementation used and the only guarantee is that
+     * the specific Secure Area used and the only guarantee is that
      * the leaf certificate contains the public key of the created key. Usually
      * a list of certificates chaining up to a well-known root is returned along
      * with platform specific information in the leaf certificate. The attestation
@@ -149,7 +152,7 @@ public interface KeystoreEngine {
      *
      * @param alias             A unique string to identify the newly created key.
      * @param createKeySettings A {@link CreateKeySettings} object.
-     * @throws IllegalArgumentException if the underlying Keystore Implementation
+     * @throws IllegalArgumentException if the underlying Secure Area Implementation
      *                                  does not support the requested creation
      *                                  settings, for example the EC curve to use.
      */
@@ -208,7 +211,7 @@ public interface KeystoreEngine {
      */
     @NonNull byte[] keyAgreement(@NonNull String alias,
                                  @NonNull PublicKey otherKey,
-                                 @Nullable KeystoreEngine.KeyUnlockData keyUnlockData)
+                                 @Nullable SecureArea.KeyUnlockData keyUnlockData)
             throws KeyLockedException;
 
     /**
@@ -224,7 +227,7 @@ public interface KeystoreEngine {
     /**
      * Class with information about a key.
      *
-     * <p>Concrete {@link KeystoreEngine} implementations may subclass this to provide
+     * <p>Concrete {@link SecureArea} implementations may subclass this to provide
      * implementation-specific information about the key.
      */
     class KeyInfo {
@@ -329,24 +332,24 @@ public interface KeystoreEngine {
     /**
      *  Abstract type used to indicate key creation settings (authentication
      *  required, nonce/challenge for remote attestation, etc.) and which
-     *  {@link KeystoreEngine} to use.
+     *  {@link SecureArea} to use.
      */
     abstract class CreateKeySettings {
 
-        private final Class<?> mKeystoreEngineClass;
+        private final Class<?> mSecureAreaClass;
 
-        protected CreateKeySettings(@NonNull Class<?> keystoreEngineClass) {
-            mKeystoreEngineClass = keystoreEngineClass;
+        protected CreateKeySettings(@NonNull Class<?> secureAreaClass) {
+            mSecureAreaClass = secureAreaClass;
         }
 
         /**
-         * Returns the class of the {@link KeystoreEngine} these settings are for.
+         * Returns the class of the {@link SecureArea} these settings are for.
          *
-         * @return A {@link KeystoreEngine}-derived type.
+         * @return A {@link SecureArea}-derived type.
          */
         public @NonNull
-        Class<?> getKeystoreEngineClass() {
-            return mKeystoreEngineClass;
+        Class<?> getSecureAreaClass() {
+            return mSecureAreaClass;
         }
     }
 }

--- a/identity/src/main/java/com/android/identity/securearea/SecureAreaRepository.java
+++ b/identity/src/main/java/com/android/identity/securearea/SecureAreaRepository.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.android.identity.keystore;
+package com.android.identity.securearea;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -24,38 +24,38 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * A repository of {@link KeystoreEngine} implementations.
+ * A repository of {@link SecureArea} implementations.
  *
- * <p>This is used by to provide fine-grained control for which {@link KeystoreEngine}
- * implementation to use when loading keys using different implementations.
+ * <p>This is used by to provide fine-grained control for which {@link SecureArea}
+ * implementation to use when loading keys and objects using different implementations.
  */
-public class KeystoreEngineRepository {
+public class SecureAreaRepository {
 
-    List<KeystoreEngine> mImplementations = new ArrayList<>();
+    List<SecureArea> mImplementations = new ArrayList<>();
 
     /**
      * Constructs a new object.
      */
-    public KeystoreEngineRepository() {
+    public SecureAreaRepository() {
     }
 
     /**
      * Gets all implementations in the repository.
      *
-     * @return A list of {@link KeystoreEngine} implementations in the repository.
+     * @return A list of {@link SecureArea} implementations in the repository.
      */
-    public @NonNull List<KeystoreEngine> getImplementations() {
+    public @NonNull List<SecureArea> getImplementations() {
         return Collections.unmodifiableList(mImplementations);
     }
 
     /**
-     * Gets a {@link KeystoreEngine} for a specific classname.
+     * Gets a {@link SecureArea} for a specific classname.
      *
      * @param className the classname for an implementation.
      * @return the implementation or {@code null} if no implementation has been registered.
      */
-    public @Nullable KeystoreEngine getImplementation(@NonNull String className) {
-        for (KeystoreEngine implementation : mImplementations) {
+    public @Nullable SecureArea getImplementation(@NonNull String className) {
+        for (SecureArea implementation : mImplementations) {
             if (implementation.getClass().getName().equals(className)) {
                 return implementation;
             }
@@ -64,11 +64,11 @@ public class KeystoreEngineRepository {
     }
 
     /**
-     * Adds a {@link KeystoreEngine} to the repository.
+     * Adds a {@link SecureArea} to the repository.
      *
-     * @param keystoreEngine an instance of a type implementing the {@link KeystoreEngine} interface.
+     * @param secureArea an instance of a type implementing the {@link SecureArea} interface.
      */
-    public void addImplementation(@NonNull KeystoreEngine keystoreEngine) {
-        mImplementations.add(keystoreEngine);
+    public void addImplementation(@NonNull SecureArea secureArea) {
+        mImplementations.add(secureArea);
     }
 }

--- a/identity/src/test/java/com/android/identity/credential/CredentialUtilTest.java
+++ b/identity/src/test/java/com/android/identity/credential/CredentialUtilTest.java
@@ -16,9 +16,9 @@
 
 package com.android.identity.credential;
 
-import com.android.identity.keystore.BouncyCastleKeystore;
-import com.android.identity.keystore.KeystoreEngine;
-import com.android.identity.keystore.KeystoreEngineRepository;
+import com.android.identity.securearea.BouncyCastleSecureArea;
+import com.android.identity.securearea.SecureArea;
+import com.android.identity.securearea.SecureAreaRepository;
 import com.android.identity.storage.EphemeralStorageEngine;
 import com.android.identity.storage.StorageEngine;
 import com.android.identity.util.Timestamp;
@@ -30,34 +30,34 @@ import org.junit.Test;
 public class CredentialUtilTest {
     StorageEngine mStorageEngine;
 
-    KeystoreEngine mKeystoreEngine;
+    SecureArea mSecureArea;
 
-    KeystoreEngineRepository mKeystoreEngineRepository;
+    SecureAreaRepository mSecureAreaRepository;
 
     @Before
     public void setup() {
         mStorageEngine = new EphemeralStorageEngine();
 
-        mKeystoreEngineRepository = new KeystoreEngineRepository();
-        mKeystoreEngine = new BouncyCastleKeystore(mStorageEngine);
-        mKeystoreEngineRepository.addImplementation(mKeystoreEngine);
+        mSecureAreaRepository = new SecureAreaRepository();
+        mSecureArea = new BouncyCastleSecureArea(mStorageEngine);
+        mSecureAreaRepository.addImplementation(mSecureArea);
     }
 
     @Test
     public void testManagedAuthenticationKeyHelper() {
         CredentialStore credentialStore = new CredentialStore(
                 mStorageEngine,
-                mKeystoreEngineRepository);
+                mSecureAreaRepository);
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
 
         Assert.assertEquals(0, credential.getAuthenticationKeys().size());
         Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
 
-        KeystoreEngine.CreateKeySettings authKeySettings =
-                new BouncyCastleKeystore.CreateKeySettings.Builder()
+        SecureArea.CreateKeySettings authKeySettings =
+                new BouncyCastleSecureArea.CreateKeySettings.Builder()
                         .build();
 
         int numAuthKeys = 10;

--- a/identity/src/test/java/com/android/identity/mdoc/response/DeviceResponseGeneratorTest.java
+++ b/identity/src/test/java/com/android/identity/mdoc/response/DeviceResponseGeneratorTest.java
@@ -21,9 +21,9 @@ import com.android.identity.credential.CredentialRequest;
 import com.android.identity.credential.CredentialStore;
 import com.android.identity.credential.NameSpacedData;
 import com.android.identity.internal.Util;
-import com.android.identity.keystore.BouncyCastleKeystore;
-import com.android.identity.keystore.KeystoreEngine;
-import com.android.identity.keystore.KeystoreEngineRepository;
+import com.android.identity.securearea.BouncyCastleSecureArea;
+import com.android.identity.securearea.SecureArea;
+import com.android.identity.securearea.SecureAreaRepository;
 import com.android.identity.mdoc.mso.MobileSecurityObjectGenerator;
 import com.android.identity.mdoc.mso.StaticAuthDataGenerator;
 import com.android.identity.mdoc.mso.StaticAuthDataParser;
@@ -60,9 +60,9 @@ public class DeviceResponseGeneratorTest {
 
     StorageEngine mStorageEngine;
 
-    KeystoreEngine mKeystoreEngine;
+    SecureArea mSecureArea;
 
-    KeystoreEngineRepository mKeystoreEngineRepository;
+    SecureAreaRepository mSecureAreaRepository;
 
     static final String DOC_TYPE = "com.example.credential_xyz";
     private Credential.AuthenticationKey mAuthKey;
@@ -108,9 +108,9 @@ public class DeviceResponseGeneratorTest {
     public void setup() throws Exception {
         mStorageEngine = new EphemeralStorageEngine();
 
-        mKeystoreEngineRepository = new KeystoreEngineRepository();
-        mKeystoreEngine = new BouncyCastleKeystore(mStorageEngine);
-        mKeystoreEngineRepository.addImplementation(mKeystoreEngine);
+        mSecureAreaRepository = new SecureAreaRepository();
+        mSecureArea = new BouncyCastleSecureArea(mStorageEngine);
+        mSecureAreaRepository.addImplementation(mSecureArea);
 
         provisionCredential();
     }
@@ -118,12 +118,12 @@ public class DeviceResponseGeneratorTest {
     private void provisionCredential() throws Exception {
         CredentialStore credentialStore = new CredentialStore(
                 mStorageEngine,
-                mKeystoreEngineRepository);
+                mSecureAreaRepository);
 
         // Create the credential...
         mCredential = credentialStore.createCredential(
                 "testCredential",
-                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
         NameSpacedData nameSpacedData = new NameSpacedData.Builder()
                 .putEntryString("ns1", "foo1", "bar1")
                 .putEntryString("ns1", "foo2", "bar2")
@@ -141,9 +141,9 @@ public class DeviceResponseGeneratorTest {
         mTimeValidityEnd = Timestamp.ofEpochMilli(nowMillis + 10 * 86400 * 1000);
         Credential.PendingAuthenticationKey pendingAuthKey =
                 mCredential.createPendingAuthenticationKey(
-                        new BouncyCastleKeystore.CreateKeySettings.Builder()
-                                .setKeyPurposes(KeystoreEngine.KEY_PURPOSE_SIGN
-                                        | KeystoreEngine.KEY_PURPOSE_AGREE_KEY)
+                        new BouncyCastleSecureArea.CreateKeySettings.Builder()
+                                .setKeyPurposes(SecureArea.KEY_PURPOSE_SIGN
+                                        | SecureArea.KEY_PURPOSE_AGREE_KEY)
                                 .build(),
                         null);
 
@@ -228,10 +228,10 @@ public class DeviceResponseGeneratorTest {
                         .setIssuerNamespaces(mergedIssuerNamespaces)
                         .setDeviceNamespacesSignature(
                                 new NameSpacedData.Builder().build(),
-                                mAuthKey.getKeystoreEngine(),
+                                mAuthKey.getSecureArea(),
                                 mAuthKey.getAlias(),
                                 null,
-                                KeystoreEngine.ALGORITHM_ES256)
+                                SecureArea.ALGORITHM_ES256)
                         .generate());
         byte[] encodedDeviceResponse = deviceResponseGenerator.generate();
 
@@ -316,7 +316,7 @@ public class DeviceResponseGeneratorTest {
                         .setIssuerNamespaces(mergedIssuerNamespaces)
                         .setDeviceNamespacesMac(
                                 new NameSpacedData.Builder().build(),
-                                mAuthKey.getKeystoreEngine(),
+                                mAuthKey.getSecureArea(),
                                 mAuthKey.getAlias(),
                                 null,
                                 eReaderKeyPair.getPublic())
@@ -374,10 +374,10 @@ public class DeviceResponseGeneratorTest {
                         .setIssuerNamespaces(mergedIssuerNamespaces)
                         .setDeviceNamespacesSignature(
                                 deviceSignedData,
-                                mAuthKey.getKeystoreEngine(),
+                                mAuthKey.getSecureArea(),
                                 mAuthKey.getAlias(),
                                 null,
-                                KeystoreEngine.ALGORITHM_ES256)
+                                SecureArea.ALGORITHM_ES256)
                         .generate());
         byte[] encodedDeviceResponse = deviceResponseGenerator.generate();
         DeviceResponseParser parser = new DeviceResponseParser();
@@ -448,10 +448,10 @@ public class DeviceResponseGeneratorTest {
                 new DocumentGenerator(DOC_TYPE, staticAuthData.getIssuerAuth(), encodedSessionTranscript)
                         .setDeviceNamespacesSignature(
                                 deviceSignedData,
-                                mAuthKey.getKeystoreEngine(),
+                                mAuthKey.getSecureArea(),
                                 mAuthKey.getAlias(),
                                 null,
-                                KeystoreEngine.ALGORITHM_ES256)
+                                SecureArea.ALGORITHM_ES256)
                         .generate());
         byte[] encodedDeviceResponse = deviceResponseGenerator.generate();
         DeviceResponseParser parser = new DeviceResponseParser();
@@ -512,10 +512,10 @@ public class DeviceResponseGeneratorTest {
                         .setIssuerNamespaces(mergedIssuerNamespaces)
                         .setDeviceNamespacesSignature(
                                 new NameSpacedData.Builder().build(),
-                                mAuthKey.getKeystoreEngine(),
+                                mAuthKey.getSecureArea(),
                                 mAuthKey.getAlias(),
                                 null,
-                                KeystoreEngine.ALGORITHM_ES256)
+                                SecureArea.ALGORITHM_ES256)
                         .generate());
         byte[] encodedDeviceResponse = deviceResponseGenerator.generate();
 

--- a/identity/src/test/java/com/android/identity/mdoc/sessionencryption/SessionEncryptionTest.java
+++ b/identity/src/test/java/com/android/identity/mdoc/sessionencryption/SessionEncryptionTest.java
@@ -16,10 +16,9 @@
 
 package com.android.identity.mdoc.sessionencryption;
 
-import com.android.identity.TestUtilities;
 import com.android.identity.TestVectors;
 import com.android.identity.internal.Util;
-import com.android.identity.keystore.KeystoreEngine;
+import com.android.identity.securearea.SecureArea;
 import com.android.identity.mdoc.engagement.EngagementParser;
 import com.android.identity.util.Constants;
 
@@ -172,7 +171,7 @@ public class SessionEncryptionTest {
                 sessionEncryptionDevice.encryptMessage(null, OptionalLong.of(20)));
     }
 
-    private void testCurve(@KeystoreEngine.EcCurve int curve) {
+    private void testCurve(@SecureArea.EcCurve int curve) {
         KeyPair eReaderKeyPair = Util.createEphemeralKeyPair(curve);
         PublicKey eReaderKeyPublic = eReaderKeyPair.getPublic();
         KeyPair eDeviceKeyPair = Util.createEphemeralKeyPair(curve);

--- a/identity/src/test/java/com/android/identity/securearea/BouncyCastleSecureAreaTest.java
+++ b/identity/src/test/java/com/android/identity/securearea/BouncyCastleSecureAreaTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.android.identity.keystore;
+package com.android.identity.securearea;
 
 import com.android.identity.storage.EphemeralStorageEngine;
 
@@ -39,9 +39,9 @@ import java.util.List;
 
 import javax.crypto.KeyAgreement;
 
-public class BouncyCastleKeystoreTest {
+public class BouncyCastleSecureAreaTest {
 
-    private static final String TAG = "BouncyCastleKeystoreTest";
+    private static final String TAG = "BouncyCastleSATest";  // limit to <= 23 chars
 
     @Before
     public void setup() {
@@ -51,11 +51,11 @@ public class BouncyCastleKeystoreTest {
     @Test
     public void testEcKeyDeletion() {
         EphemeralStorageEngine storage = new EphemeralStorageEngine();
-        BouncyCastleKeystore ks = new BouncyCastleKeystore(storage);
+        BouncyCastleSecureArea ks = new BouncyCastleSecureArea(storage);
 
         // First create the key...
-        ks.createKey("testKey", new BouncyCastleKeystore.CreateKeySettings.Builder().build());
-        BouncyCastleKeystore.KeyInfo keyInfo = ks.getKeyInfo("testKey");
+        ks.createKey("testKey", new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+        BouncyCastleSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
         List<X509Certificate> certChain = keyInfo.getAttestation();
         Assert.assertTrue(certChain.size() >= 1);
 
@@ -64,11 +64,11 @@ public class BouncyCastleKeystoreTest {
 
         // Now that we know the key doesn't exist, check that ecKeySign() throws
         try {
-            ks.sign("testKey", KeystoreEngine.ALGORITHM_ES256, new byte[] {1, 2}, null);
+            ks.sign("testKey", SecureArea.ALGORITHM_ES256, new byte[] {1, 2}, null);
             Assert.fail();
         } catch (IllegalArgumentException e) {
             // Expected path.
-        } catch (KeystoreEngine.KeyLockedException e) {
+        } catch (SecureArea.KeyLockedException e) {
             throw new AssertionError(e);
         }
 
@@ -79,15 +79,15 @@ public class BouncyCastleKeystoreTest {
     @Test
     public void testEcKeySigning() {
         EphemeralStorageEngine storage = new EphemeralStorageEngine();
-        BouncyCastleKeystore ks = new BouncyCastleKeystore(storage);
+        BouncyCastleSecureArea ks = new BouncyCastleSecureArea(storage);
 
-        ks.createKey("testKey", new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+        ks.createKey("testKey", new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
 
-        BouncyCastleKeystore.KeyInfo keyInfo = ks.getKeyInfo("testKey");
+        BouncyCastleSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
         Assert.assertNotNull(keyInfo);
         Assert.assertTrue(keyInfo.getAttestation().size() >= 1);
-        Assert.assertEquals(KeystoreEngine.KEY_PURPOSE_SIGN, keyInfo.getKeyPurposes());
-        Assert.assertEquals(KeystoreEngine.EC_CURVE_P256, keyInfo.getEcCurve());
+        Assert.assertEquals(SecureArea.KEY_PURPOSE_SIGN, keyInfo.getKeyPurposes());
+        Assert.assertEquals(SecureArea.EC_CURVE_P256, keyInfo.getEcCurve());
         Assert.assertFalse(keyInfo.isHardwareBacked());
         Assert.assertFalse(keyInfo.isPassphraseProtected());
         Assert.assertNull(keyInfo.getAttestationKeyAlias());
@@ -95,8 +95,8 @@ public class BouncyCastleKeystoreTest {
         byte[] dataToSign = new byte[] {4, 5, 6};
         byte[] derSignature;
         try {
-            derSignature = ks.sign("testKey", KeystoreEngine.ALGORITHM_ES256, dataToSign, null);
-        } catch (KeystoreEngine.KeyLockedException e) {
+            derSignature = ks.sign("testKey", SecureArea.ALGORITHM_ES256, dataToSign, null);
+        } catch (SecureArea.KeyLockedException e) {
             throw new AssertionError(e);
         }
 
@@ -115,15 +115,15 @@ public class BouncyCastleKeystoreTest {
     @Test
     public void testEcKeyCreate() {
         EphemeralStorageEngine storage = new EphemeralStorageEngine();
-        BouncyCastleKeystore ks = new BouncyCastleKeystore(storage);
+        BouncyCastleSecureArea ks = new BouncyCastleSecureArea(storage);
 
-        ks.createKey("testKey", new BouncyCastleKeystore.CreateKeySettings.Builder().build());
+        ks.createKey("testKey", new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
 
-        BouncyCastleKeystore.KeyInfo keyInfo = ks.getKeyInfo("testKey");
+        BouncyCastleSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
         Assert.assertNotNull(keyInfo);
         Assert.assertTrue(keyInfo.getAttestation().size() >= 1);
-        Assert.assertEquals(KeystoreEngine.KEY_PURPOSE_SIGN, keyInfo.getKeyPurposes());
-        Assert.assertEquals(KeystoreEngine.EC_CURVE_P256, keyInfo.getEcCurve());
+        Assert.assertEquals(SecureArea.KEY_PURPOSE_SIGN, keyInfo.getKeyPurposes());
+        Assert.assertEquals(SecureArea.EC_CURVE_P256, keyInfo.getEcCurve());
         Assert.assertFalse(keyInfo.isHardwareBacked());
         Assert.assertFalse(keyInfo.isPassphraseProtected());
         Assert.assertNull(keyInfo.getAttestationKeyAlias());
@@ -143,24 +143,24 @@ public class BouncyCastleKeystoreTest {
     @Test
     public void testEcKeyCreateWithAttestationKey() {
         EphemeralStorageEngine storage = new EphemeralStorageEngine();
-        BouncyCastleKeystore ks = new BouncyCastleKeystore(storage);
+        BouncyCastleSecureArea ks = new BouncyCastleSecureArea(storage);
 
         ks.createKey("attestationKey",
-                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
-        BouncyCastleKeystore.KeyInfo aKeyInfo = ks.getKeyInfo("attestationKey");
+                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+        BouncyCastleSecureArea.KeyInfo aKeyInfo = ks.getKeyInfo("attestationKey");
         List<X509Certificate> attestationKeyCertChain = aKeyInfo.getAttestation();
         Assert.assertTrue(attestationKeyCertChain.size() >= 1);
 
         ks.createKey("testKey",
-                new BouncyCastleKeystore.CreateKeySettings.Builder()
+                new BouncyCastleSecureArea.CreateKeySettings.Builder()
                         .setAttestationKeyAlias("attestationKey")
                         .build());
 
-        BouncyCastleKeystore.KeyInfo keyInfo = ks.getKeyInfo("testKey");
+        BouncyCastleSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
         Assert.assertNotNull(keyInfo);
         Assert.assertTrue(keyInfo.getAttestation().size() >= 1);
-        Assert.assertEquals(KeystoreEngine.KEY_PURPOSE_SIGN, keyInfo.getKeyPurposes());
-        Assert.assertEquals(KeystoreEngine.EC_CURVE_P256, keyInfo.getEcCurve());
+        Assert.assertEquals(SecureArea.KEY_PURPOSE_SIGN, keyInfo.getKeyPurposes());
+        Assert.assertEquals(SecureArea.EC_CURVE_P256, keyInfo.getEcCurve());
         Assert.assertFalse(keyInfo.isHardwareBacked());
         Assert.assertFalse(keyInfo.isPassphraseProtected());
         Assert.assertEquals("attestationKey", keyInfo.getAttestationKeyAlias());
@@ -180,24 +180,24 @@ public class BouncyCastleKeystoreTest {
     @Test
     public void testEcKeySigningWithKeyWithoutCorrectPurpose() {
         EphemeralStorageEngine storage = new EphemeralStorageEngine();
-        BouncyCastleKeystore ks = new BouncyCastleKeystore(storage);
+        BouncyCastleSecureArea ks = new BouncyCastleSecureArea(storage);
 
         ks.createKey("attestationKey",
-                new BouncyCastleKeystore.CreateKeySettings.Builder()
+                new BouncyCastleSecureArea.CreateKeySettings.Builder()
                         .build());
 
         ks.createKey("testKey",
-                new BouncyCastleKeystore.CreateKeySettings.Builder()
-                        .setKeyPurposes(KeystoreEngine.KEY_PURPOSE_AGREE_KEY)
+                new BouncyCastleSecureArea.CreateKeySettings.Builder()
+                        .setKeyPurposes(SecureArea.KEY_PURPOSE_AGREE_KEY)
                         .setAttestationKeyAlias("attestationKey")
                         .build());
         byte[] dataToSign = new byte[] {4, 5, 6};
         try {
-            ks.sign("testKey", KeystoreEngine.ALGORITHM_ES256, dataToSign, null);
+            ks.sign("testKey", SecureArea.ALGORITHM_ES256, dataToSign, null);
             Assert.fail("Signing shouldn't work with a key w/o KEY_PURPOSE_SIGN");
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("Key does not have purpose KEY_PURPOSE_SIGN", e.getMessage());
-        } catch (KeystoreEngine.KeyLockedException e) {
+        } catch (SecureArea.KeyLockedException e) {
             throw new AssertionError(e);
         }
     }
@@ -205,7 +205,7 @@ public class BouncyCastleKeystoreTest {
     @Test
     public void testEcdh() {
         EphemeralStorageEngine storage = new EphemeralStorageEngine();
-        BouncyCastleKeystore ks = new BouncyCastleKeystore(storage);
+        BouncyCastleSecureArea ks = new BouncyCastleSecureArea(storage);
 
         KeyPair otherKeyPair;
         try {
@@ -217,20 +217,20 @@ public class BouncyCastleKeystoreTest {
         }
 
         ks.createKey("attestationKey",
-                new BouncyCastleKeystore.CreateKeySettings.Builder()
+                new BouncyCastleSecureArea.CreateKeySettings.Builder()
                         .build());
 
         ks.createKey("testKey",
-                new BouncyCastleKeystore.CreateKeySettings.Builder()
-                        .setKeyPurposes(KeystoreEngine.KEY_PURPOSE_AGREE_KEY)
+                new BouncyCastleSecureArea.CreateKeySettings.Builder()
+                        .setKeyPurposes(SecureArea.KEY_PURPOSE_AGREE_KEY)
                         .setAttestationKeyAlias("attestationKey")
                         .build());
 
-        BouncyCastleKeystore.KeyInfo keyInfo = ks.getKeyInfo("testKey");
+        BouncyCastleSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
         Assert.assertNotNull(keyInfo);
         Assert.assertTrue(keyInfo.getAttestation().size() >= 1);
-        Assert.assertEquals(KeystoreEngine.KEY_PURPOSE_AGREE_KEY, keyInfo.getKeyPurposes());
-        Assert.assertEquals(KeystoreEngine.EC_CURVE_P256, keyInfo.getEcCurve());
+        Assert.assertEquals(SecureArea.KEY_PURPOSE_AGREE_KEY, keyInfo.getKeyPurposes());
+        Assert.assertEquals(SecureArea.EC_CURVE_P256, keyInfo.getEcCurve());
         Assert.assertFalse(keyInfo.isHardwareBacked());
         Assert.assertFalse(keyInfo.isPassphraseProtected());
         Assert.assertEquals("attestationKey", keyInfo.getAttestationKeyAlias());
@@ -239,7 +239,7 @@ public class BouncyCastleKeystoreTest {
         byte[] ourSharedSecret;
         try {
             ourSharedSecret = ks.keyAgreement("testKey", otherKeyPair.getPublic(), null);
-        } catch (KeystoreEngine.KeyLockedException e) {
+        } catch (SecureArea.KeyLockedException e) {
             throw new AssertionError(e);
         }
 
@@ -262,7 +262,7 @@ public class BouncyCastleKeystoreTest {
     @Test
     public void testEcdhAndSigning() {
         EphemeralStorageEngine storage = new EphemeralStorageEngine();
-        BouncyCastleKeystore ks = new BouncyCastleKeystore(storage);
+        BouncyCastleSecureArea ks = new BouncyCastleSecureArea(storage);
 
         KeyPair otherKeyPair;
         try {
@@ -274,17 +274,17 @@ public class BouncyCastleKeystoreTest {
         }
 
         ks.createKey("testKey",
-                new BouncyCastleKeystore.CreateKeySettings.Builder()
-                        .setKeyPurposes(KeystoreEngine.KEY_PURPOSE_AGREE_KEY
-                                | KeystoreEngine.KEY_PURPOSE_SIGN)
+                new BouncyCastleSecureArea.CreateKeySettings.Builder()
+                        .setKeyPurposes(SecureArea.KEY_PURPOSE_AGREE_KEY
+                                | SecureArea.KEY_PURPOSE_SIGN)
                         .build());
 
-        BouncyCastleKeystore.KeyInfo keyInfo = ks.getKeyInfo("testKey");
+        BouncyCastleSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
         Assert.assertNotNull(keyInfo);
         Assert.assertTrue(keyInfo.getAttestation().size() >= 1);
-        Assert.assertEquals(KeystoreEngine.KEY_PURPOSE_SIGN
-                | KeystoreEngine.KEY_PURPOSE_AGREE_KEY, keyInfo.getKeyPurposes());
-        Assert.assertEquals(KeystoreEngine.EC_CURVE_P256, keyInfo.getEcCurve());
+        Assert.assertEquals(SecureArea.KEY_PURPOSE_SIGN
+                | SecureArea.KEY_PURPOSE_AGREE_KEY, keyInfo.getKeyPurposes());
+        Assert.assertEquals(SecureArea.EC_CURVE_P256, keyInfo.getEcCurve());
         Assert.assertFalse(keyInfo.isHardwareBacked());
         Assert.assertFalse(keyInfo.isPassphraseProtected());
         Assert.assertNull(keyInfo.getAttestationKeyAlias());
@@ -293,7 +293,7 @@ public class BouncyCastleKeystoreTest {
         byte[] ourSharedSecret;
         try {
             ourSharedSecret = ks.keyAgreement("testKey", otherKeyPair.getPublic(), null);
-        } catch (KeystoreEngine.KeyLockedException e) {
+        } catch (SecureArea.KeyLockedException e) {
             throw new AssertionError(e);
         }
 
@@ -315,8 +315,8 @@ public class BouncyCastleKeystoreTest {
         byte[] dataToSign = new byte[] {4, 5, 6};
         byte[] derSignature;
         try {
-            derSignature = ks.sign("testKey", KeystoreEngine.ALGORITHM_ES256, dataToSign, null);
-        } catch (KeystoreEngine.KeyLockedException e) {
+            derSignature = ks.sign("testKey", SecureArea.ALGORITHM_ES256, dataToSign, null);
+        } catch (SecureArea.KeyLockedException e) {
             throw new AssertionError(e);
         }
 
@@ -335,7 +335,7 @@ public class BouncyCastleKeystoreTest {
     @Test
     public void testEcdhWithoutCorrectPurpose() {
         EphemeralStorageEngine storage = new EphemeralStorageEngine();
-        BouncyCastleKeystore ks = new BouncyCastleKeystore(storage);
+        BouncyCastleSecureArea ks = new BouncyCastleSecureArea(storage);
 
         KeyPair otherKeyPair;
         try {
@@ -347,14 +347,14 @@ public class BouncyCastleKeystoreTest {
         }
 
         ks.createKey("testKey",
-                new BouncyCastleKeystore.CreateKeySettings.Builder()
-                        //.setKeyPurpose(KeystoreEngine.KEY_PURPOSE_AGREE_KEY)
+                new BouncyCastleSecureArea.CreateKeySettings.Builder()
+                        //.setKeyPurpose(SecureArea.KEY_PURPOSE_AGREE_KEY)
                         .build());
 
         try {
             ks.keyAgreement("testKey", otherKeyPair.getPublic(), null);
             Assert.fail("ECDH shouldn't work with a key w/o KEY_PURPOSE_AGREE_KEY");
-        } catch (KeystoreEngine.KeyLockedException e) {
+        } catch (SecureArea.KeyLockedException e) {
             throw new AssertionError(e);
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("Key does not have purpose KEY_PURPOSE_AGREE_KEY", e.getMessage());
@@ -365,19 +365,19 @@ public class BouncyCastleKeystoreTest {
     @Test
     public void testEcKeySigningWithLockedKey() {
         EphemeralStorageEngine storage = new EphemeralStorageEngine();
-        BouncyCastleKeystore ks = new BouncyCastleKeystore(storage);
+        BouncyCastleSecureArea ks = new BouncyCastleSecureArea(storage);
 
         String passphrase = "verySekrit";
         ks.createKey("testKey",
-                new BouncyCastleKeystore.CreateKeySettings.Builder()
+                new BouncyCastleSecureArea.CreateKeySettings.Builder()
                         .setPassphraseRequired(true, passphrase)
                         .build());
 
-        BouncyCastleKeystore.KeyInfo keyInfo = ks.getKeyInfo("testKey");
+        BouncyCastleSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
         Assert.assertNotNull(keyInfo);
         Assert.assertTrue(keyInfo.getAttestation().size() >= 1);
-        Assert.assertEquals(KeystoreEngine.KEY_PURPOSE_SIGN, keyInfo.getKeyPurposes());
-        Assert.assertEquals(KeystoreEngine.EC_CURVE_P256, keyInfo.getEcCurve());
+        Assert.assertEquals(SecureArea.KEY_PURPOSE_SIGN, keyInfo.getKeyPurposes());
+        Assert.assertEquals(SecureArea.EC_CURVE_P256, keyInfo.getEcCurve());
         Assert.assertFalse(keyInfo.isHardwareBacked());
         Assert.assertTrue(keyInfo.isPassphraseProtected());
         Assert.assertNull(keyInfo.getAttestationKeyAlias());
@@ -386,32 +386,32 @@ public class BouncyCastleKeystoreTest {
         byte[] derSignature = new byte[0];
         try {
             derSignature = ks.sign("testKey",
-                    KeystoreEngine.ALGORITHM_ES256,
+                    SecureArea.ALGORITHM_ES256,
                     dataToSign,
                     null);
             Assert.fail();
-        } catch (KeystoreEngine.KeyLockedException e) {
+        } catch (SecureArea.KeyLockedException e) {
             // This is the expected path.
         }
 
         // Try with the wrong passphrase. This should fail.
         try {
             derSignature = ks.sign("testKey",
-                    KeystoreEngine.ALGORITHM_ES256,
+                    SecureArea.ALGORITHM_ES256,
                     dataToSign,
-                    new BouncyCastleKeystore.KeyUnlockData("wrongPassphrase"));
+                    new BouncyCastleSecureArea.KeyUnlockData("wrongPassphrase"));
             Assert.fail();
-        } catch (KeystoreEngine.KeyLockedException e) {
+        } catch (SecureArea.KeyLockedException e) {
             // This is the expected path.
         }
 
         // ... and with the right passphrase. This should work.
         try {
             derSignature = ks.sign("testKey",
-                    KeystoreEngine.ALGORITHM_ES256,
+                    SecureArea.ALGORITHM_ES256,
                     dataToSign,
-                    new BouncyCastleKeystore.KeyUnlockData(passphrase));
-        } catch (KeystoreEngine.KeyLockedException e) {
+                    new BouncyCastleSecureArea.KeyUnlockData(passphrase));
+        } catch (SecureArea.KeyLockedException e) {
             throw new AssertionError(e);
         }
 
@@ -431,24 +431,24 @@ public class BouncyCastleKeystoreTest {
     @Test
     public void testEcKeyCreationOverridesExistingAlias() {
         EphemeralStorageEngine storage = new EphemeralStorageEngine();
-        BouncyCastleKeystore ks = new BouncyCastleKeystore(storage);
+        BouncyCastleSecureArea ks = new BouncyCastleSecureArea(storage);
 
         ks.createKey("testKey",
-                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
-        BouncyCastleKeystore.KeyInfo keyInfoOld = ks.getKeyInfo("testKey");
+                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+        BouncyCastleSecureArea.KeyInfo keyInfoOld = ks.getKeyInfo("testKey");
         List<X509Certificate> certChainOld = keyInfoOld.getAttestation();
         Assert.assertTrue(certChainOld.size() >= 1);
 
         ks.createKey("testKey",
-                new BouncyCastleKeystore.CreateKeySettings.Builder().build());
-        BouncyCastleKeystore.KeyInfo keyInfo = ks.getKeyInfo("testKey");
+                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+        BouncyCastleSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
         List<X509Certificate> certChain = keyInfo.getAttestation();
         Assert.assertTrue(certChain.size() >= 1);
         byte[] dataToSign = new byte[] {4, 5, 6};
         byte[] derSignature = new byte[0];
         try {
-            derSignature = ks.sign("testKey", KeystoreEngine.ALGORITHM_ES256, dataToSign, null);
-        } catch (KeystoreEngine.KeyLockedException e) {
+            derSignature = ks.sign("testKey", SecureArea.ALGORITHM_ES256, dataToSign, null);
+        } catch (SecureArea.KeyLockedException e) {
             throw new AssertionError(e);
         }
 
@@ -473,84 +473,84 @@ public class BouncyCastleKeystoreTest {
     @Test
     public void testEcKeySigningAllCurves() {
         EphemeralStorageEngine storage = new EphemeralStorageEngine();
-        BouncyCastleKeystore ks = new BouncyCastleKeystore(storage);
+        BouncyCastleSecureArea ks = new BouncyCastleSecureArea(storage);
 
         int[] knownEcCurves = new int[] {
-                KeystoreEngine.EC_CURVE_P256,
-                KeystoreEngine.EC_CURVE_P384,
-                KeystoreEngine.EC_CURVE_P521,
-                KeystoreEngine.EC_CURVE_BRAINPOOLP256R1,
-                KeystoreEngine.EC_CURVE_BRAINPOOLP320R1,
-                KeystoreEngine.EC_CURVE_BRAINPOOLP384R1,
-                KeystoreEngine.EC_CURVE_BRAINPOOLP512R1,
+                SecureArea.EC_CURVE_P256,
+                SecureArea.EC_CURVE_P384,
+                SecureArea.EC_CURVE_P521,
+                SecureArea.EC_CURVE_BRAINPOOLP256R1,
+                SecureArea.EC_CURVE_BRAINPOOLP320R1,
+                SecureArea.EC_CURVE_BRAINPOOLP384R1,
+                SecureArea.EC_CURVE_BRAINPOOLP512R1,
                 // TODO: Edwards curve keys requires work in how private key is saved/loaded
-                //KeystoreEngine.EC_CURVE_ED25519,
-                //KeystoreEngine.EC_CURVE_ED448,
+                //SecureArea.EC_CURVE_ED25519,
+                //SecureArea.EC_CURVE_ED448,
         };
 
-        for (@KeystoreEngine.EcCurve int ecCurve : knownEcCurves) {
+        for (@SecureArea.EcCurve int ecCurve : knownEcCurves) {
             ks.createKey("testKey",
-                    new BouncyCastleKeystore.CreateKeySettings.Builder()
+                    new BouncyCastleSecureArea.CreateKeySettings.Builder()
                             .setEcCurve(ecCurve)
                             .build());
 
-            BouncyCastleKeystore.KeyInfo keyInfo = ks.getKeyInfo("testKey");
+            BouncyCastleSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
             Assert.assertNotNull(keyInfo);
             Assert.assertTrue(keyInfo.getAttestation().size() >= 1);
-            Assert.assertEquals(KeystoreEngine.KEY_PURPOSE_SIGN, keyInfo.getKeyPurposes());
+            Assert.assertEquals(SecureArea.KEY_PURPOSE_SIGN, keyInfo.getKeyPurposes());
             Assert.assertEquals(ecCurve, keyInfo.getEcCurve());
             Assert.assertFalse(keyInfo.isHardwareBacked());
             Assert.assertFalse(keyInfo.isPassphraseProtected());
             Assert.assertNull(keyInfo.getAttestationKeyAlias());
 
-            @KeystoreEngine.Algorithm int[] signatureAlgorithms = new int[0];
+            @SecureArea.Algorithm int[] signatureAlgorithms = new int[0];
             switch (ecCurve) {
-                case KeystoreEngine.EC_CURVE_P256:
-                case KeystoreEngine.EC_CURVE_P384:
-                case KeystoreEngine.EC_CURVE_P521:
-                case KeystoreEngine.EC_CURVE_BRAINPOOLP256R1:
-                case KeystoreEngine.EC_CURVE_BRAINPOOLP320R1:
-                case KeystoreEngine.EC_CURVE_BRAINPOOLP384R1:
-                case KeystoreEngine.EC_CURVE_BRAINPOOLP512R1:
+                case SecureArea.EC_CURVE_P256:
+                case SecureArea.EC_CURVE_P384:
+                case SecureArea.EC_CURVE_P521:
+                case SecureArea.EC_CURVE_BRAINPOOLP256R1:
+                case SecureArea.EC_CURVE_BRAINPOOLP320R1:
+                case SecureArea.EC_CURVE_BRAINPOOLP384R1:
+                case SecureArea.EC_CURVE_BRAINPOOLP512R1:
                     signatureAlgorithms = new int[] {
-                            KeystoreEngine.ALGORITHM_ES256,
-                            KeystoreEngine.ALGORITHM_ES384,
-                            KeystoreEngine.ALGORITHM_ES512};
+                            SecureArea.ALGORITHM_ES256,
+                            SecureArea.ALGORITHM_ES384,
+                            SecureArea.ALGORITHM_ES512};
                     break;
 
-                case KeystoreEngine.EC_CURVE_ED25519:
-                case KeystoreEngine.EC_CURVE_ED448:
-                    signatureAlgorithms = new int[] {KeystoreEngine.ALGORITHM_EDDSA};
+                case SecureArea.EC_CURVE_ED25519:
+                case SecureArea.EC_CURVE_ED448:
+                    signatureAlgorithms = new int[] {SecureArea.ALGORITHM_EDDSA};
                     break;
 
                 default:
                     Assert.fail();
             }
 
-            for (@KeystoreEngine.Algorithm int signatureAlgorithm : signatureAlgorithms){
+            for (@SecureArea.Algorithm int signatureAlgorithm : signatureAlgorithms){
                 byte[] dataToSign = new byte[]{4, 5, 6};
                 byte[] derSignature = null;
                 try {
                     derSignature = ks.sign("testKey", signatureAlgorithm, dataToSign, null);
-                } catch (KeystoreEngine.KeyLockedException e) {
+                } catch (SecureArea.KeyLockedException e) {
                     throw new AssertionError(e);
                 }
 
                 String signatureAlgorithmName = "";
                 switch (signatureAlgorithm) {
-                    case KeystoreEngine.ALGORITHM_ES256:
+                    case SecureArea.ALGORITHM_ES256:
                         signatureAlgorithmName = "SHA256withECDSA";
                         break;
-                    case KeystoreEngine.ALGORITHM_ES384:
+                    case SecureArea.ALGORITHM_ES384:
                         signatureAlgorithmName = "SHA384withECDSA";
                         break;
-                    case KeystoreEngine.ALGORITHM_ES512:
+                    case SecureArea.ALGORITHM_ES512:
                         signatureAlgorithmName = "SHA512withECDSA";
                         break;
-                    case KeystoreEngine.ALGORITHM_EDDSA:
-                        if (ecCurve == KeystoreEngine.EC_CURVE_ED25519) {
+                    case SecureArea.ALGORITHM_EDDSA:
+                        if (ecCurve == SecureArea.EC_CURVE_ED25519) {
                             signatureAlgorithmName = "Ed25519";
-                        } else if (ecCurve == KeystoreEngine.EC_CURVE_ED448) {
+                        } else if (ecCurve == SecureArea.EC_CURVE_ED448) {
                             signatureAlgorithmName = "Ed448";
                         } else {
                             Assert.fail("ALGORITHM_EDDSA can only be used with "
@@ -578,57 +578,57 @@ public class BouncyCastleKeystoreTest {
     @Test
     public void testEcKeyEcdhAllCurves() {
         EphemeralStorageEngine storage = new EphemeralStorageEngine();
-        BouncyCastleKeystore ks = new BouncyCastleKeystore(storage);
+        BouncyCastleSecureArea ks = new BouncyCastleSecureArea(storage);
 
         // Because we're using curves that cannot be used for signatures we need to
         // create an key used to sign the key attestations
         ks.createKey("attestationKey",
-                new BouncyCastleKeystore.CreateKeySettings.Builder()
+                new BouncyCastleSecureArea.CreateKeySettings.Builder()
                         .build());
 
         int[] knownEcCurves = new int[] {
-                KeystoreEngine.EC_CURVE_P256,
-                KeystoreEngine.EC_CURVE_P384,
-                KeystoreEngine.EC_CURVE_P521,
-                KeystoreEngine.EC_CURVE_BRAINPOOLP256R1,
-                KeystoreEngine.EC_CURVE_BRAINPOOLP320R1,
-                KeystoreEngine.EC_CURVE_BRAINPOOLP384R1,
-                KeystoreEngine.EC_CURVE_BRAINPOOLP512R1,
+                SecureArea.EC_CURVE_P256,
+                SecureArea.EC_CURVE_P384,
+                SecureArea.EC_CURVE_P521,
+                SecureArea.EC_CURVE_BRAINPOOLP256R1,
+                SecureArea.EC_CURVE_BRAINPOOLP320R1,
+                SecureArea.EC_CURVE_BRAINPOOLP384R1,
+                SecureArea.EC_CURVE_BRAINPOOLP512R1,
                 // TODO: Edwards curve keys requires work in how private key is saved/loaded
-                //KeystoreEngine.EC_CURVE_X25519,
-                //KeystoreEngine.EC_CURVE_X448,
+                //SecureArea.EC_CURVE_X25519,
+                //SecureArea.EC_CURVE_X448,
         };
 
-        for (@KeystoreEngine.EcCurve int ecCurve : knownEcCurves) {
+        for (@SecureArea.EcCurve int ecCurve : knownEcCurves) {
             KeyPair otherKeyPair;
             try {
                 KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
                 switch (ecCurve) {
-                    case KeystoreEngine.EC_CURVE_P256:
+                    case SecureArea.EC_CURVE_P256:
                         kpg.initialize(new ECGenParameterSpec("secp256r1"));
                         break;
-                    case KeystoreEngine.EC_CURVE_P384:
+                    case SecureArea.EC_CURVE_P384:
                         kpg.initialize(new ECGenParameterSpec("secp384r1"));
                         break;
-                    case KeystoreEngine.EC_CURVE_P521:
+                    case SecureArea.EC_CURVE_P521:
                         kpg.initialize(new ECGenParameterSpec("secp521r1"));
                         break;
-                    case KeystoreEngine.EC_CURVE_BRAINPOOLP256R1:
+                    case SecureArea.EC_CURVE_BRAINPOOLP256R1:
                         kpg.initialize(new ECGenParameterSpec("brainpoolP256r1"));
                         break;
-                    case KeystoreEngine.EC_CURVE_BRAINPOOLP320R1:
+                    case SecureArea.EC_CURVE_BRAINPOOLP320R1:
                         kpg.initialize(new ECGenParameterSpec("brainpoolP320r1"));
                         break;
-                    case KeystoreEngine.EC_CURVE_BRAINPOOLP384R1:
+                    case SecureArea.EC_CURVE_BRAINPOOLP384R1:
                         kpg.initialize(new ECGenParameterSpec("brainpoolP384r1"));
                         break;
-                    case KeystoreEngine.EC_CURVE_BRAINPOOLP512R1:
+                    case SecureArea.EC_CURVE_BRAINPOOLP512R1:
                         kpg.initialize(new ECGenParameterSpec("brainpoolP512r1"));
                         break;
-                    case KeystoreEngine.EC_CURVE_X25519:
+                    case SecureArea.EC_CURVE_X25519:
                         kpg = KeyPairGenerator.getInstance("x25519", new BouncyCastleProvider());
                         break;
-                    case KeystoreEngine.EC_CURVE_X448:
+                    case SecureArea.EC_CURVE_X448:
                         kpg = KeyPairGenerator.getInstance("x448", new BouncyCastleProvider());
                         break;
                     default:
@@ -641,16 +641,16 @@ public class BouncyCastleKeystoreTest {
             }
 
             ks.createKey("testKey",
-                    new BouncyCastleKeystore.CreateKeySettings.Builder()
-                            .setKeyPurposes(KeystoreEngine.KEY_PURPOSE_AGREE_KEY)
+                    new BouncyCastleSecureArea.CreateKeySettings.Builder()
+                            .setKeyPurposes(SecureArea.KEY_PURPOSE_AGREE_KEY)
                             .setEcCurve(ecCurve)
                             .setAttestationKeyAlias("attestationKey")
                             .build());
 
-            BouncyCastleKeystore.KeyInfo keyInfo = ks.getKeyInfo("testKey");
+            BouncyCastleSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
             Assert.assertNotNull(keyInfo);
             Assert.assertTrue(keyInfo.getAttestation().size() >= 1);
-            Assert.assertEquals(KeystoreEngine.KEY_PURPOSE_AGREE_KEY, keyInfo.getKeyPurposes());
+            Assert.assertEquals(SecureArea.KEY_PURPOSE_AGREE_KEY, keyInfo.getKeyPurposes());
             Assert.assertEquals(ecCurve, keyInfo.getEcCurve());
             Assert.assertFalse(keyInfo.isHardwareBacked());
             Assert.assertFalse(keyInfo.isPassphraseProtected());
@@ -660,7 +660,7 @@ public class BouncyCastleKeystoreTest {
             byte[] ourSharedSecret;
             try {
                 ourSharedSecret = ks.keyAgreement("testKey", otherKeyPair.getPublic(), null);
-            } catch (KeystoreEngine.KeyLockedException e) {
+            } catch (SecureArea.KeyLockedException e) {
                 throw new AssertionError(e);
             }
 


### PR DESCRIPTION
It's likely we want to add features implemented in the secure area in the future that are specific to real-world identity credentials in addition to symmetric and asymmetric keys that are guaranteed to never leave the secure area. For example, this could include keys and objects needed for ZKP and storage of credential data.

Also add a feature to the Android Keystore implementation of SecureArea to allow specifying whether LSKF, biometric, or both can be used to unlock the key. Make a note in the docs that this only works with API 30 or later.

Also fix a bug in DeviceRetrievalHelperTest.

Test: All unit tests pass.
Test: Manually tested with holder and reader.
