### PR TITLE
Ensure appverifier shows common name

### DIFF
--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
@@ -200,7 +200,7 @@ class ShowDocumentFragment : Fragment() {
             val commonName = StringBuffer()
             for (issuerItem in issuerItems) {
                 when {
-                    issuerItem.contains("O=") -> {
+                    issuerItem.contains("CN=") -> {
                         val (key, value) = issuerItem.split("=", limit = 2)
                         commonName.append(value)
                         cnFound = true


### PR DESCRIPTION
Replaced search for "O=" with "CN=" since the intended behavior is to show the common name of the issuer as opposed to the organization name.

Tested manually.

Fixes #369 