### PR TITLE
Modify gradle files for publication of identity and identity-android

### DIFF
--- a/identity-android/build.gradle
+++ b/identity-android/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.library")
-    id("maven-publish")
     alias libs.plugins.kotlin.android
     alias libs.plugins.dokka
 }
@@ -29,13 +28,6 @@ android {
     lint {
         lintConfig file('lint.xml')
     }
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
 }
 
 dependencies {
@@ -62,23 +54,14 @@ tasks.withType(Test) {
     }
 }
 
+apply from: '../publish-helper.gradle'
 afterEvaluate {
-
     publishing {
         publications {
             release(MavenPublication) {
-                from components.release
-                groupId 'com.android.identity'
-                artifactId 'identity-credential'
-
-                pom {
-                    licenses {
-                        license {
-                            name = 'Apache 2.0'
-                            url = 'https://opensource.org/licenses/Apache-2.0'
-                        }
-                    }
-                }
+                // Specify custom artifactId if needed,
+                // otherwise it will use module's name by default.
+                artifactId = "identity-credential-android"
             }
         }
     }

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -5,14 +5,8 @@ plugins {
 }
 
 java {
-    apply plugin: 'org.jetbrains.dokka'
-
-    withSourcesJar()
-    withJavadocJar()
-
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
-
 }
 
 dependencies {
@@ -23,4 +17,17 @@ dependencies {
 
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.bouncycastle:bcprov-jdk15on:1.69"
+}
+
+apply from: '../publish-helper.gradle'
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                // Specify custom artifactId if needed,
+                // otherwise it will use module's name by default.
+                artifactId = "identity-credential"
+            }
+        }
+    }
 }

--- a/publish-helper.gradle
+++ b/publish-helper.gradle
@@ -1,0 +1,78 @@
+apply plugin: 'maven-publish'
+
+task androidJavadoc(type: Javadoc) {
+    if (plugins.hasPlugin('android-library')) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+        android.libraryVariants.all { variant ->
+            if (variant.name == 'release') {
+                owner.classpath += variant.javaCompileProvider.get().classpath
+            }
+        }
+    }
+    else {
+        source = sourceSets.main.allJava
+        classpath += configurations.runtimeClasspath
+        classpath += configurations.compileClasspath
+    }
+    exclude '**/R.html', '**/R.*.html', '**/index.html', '**/*.kt'
+    options.encoding 'utf-8'
+    options {
+        addStringOption 'docencoding', 'utf-8'
+        addStringOption 'charset', 'utf-8'
+        links 'https://docs.oracle.com/javase/7/docs/api/'
+        links 'https://d.android.com/reference'
+        links 'https://developer.android.com/reference/androidx/'
+    }
+}
+
+task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
+    archiveClassifier.set('javadoc')
+    from androidJavadoc.destinationDir
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}
+
+task javaSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    if (plugins.hasPlugin('android-library')) {
+        from android.sourceSets.main.java.srcDirs
+    }
+    else {
+        from sourceSets.main.allSource
+    }
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                if (plugins.hasPlugin('android-library')) {
+                    from components.release
+                }
+                else if (plugins.hasPlugin('java')) {
+                    from components.java
+                    jar.preserveFileTimestamps = false
+                    jar.reproducibleFileOrder = true
+                }
+
+                artifact androidJavadocJar
+                artifact javaSourcesJar
+
+                groupId 'com.android.identity'
+                version 'YYYYMMDD'
+                pom {
+                    name = artifactId
+                    licenses {
+                        license {
+                            name = 'Apache 2.0'
+                            url = 'https://opensource.org/licenses/Apache-2.0'
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added publish-helper.gradle for use by identity/build.gradle and identity-android/build.gradle so that publishing will generate the appropriate files for only those two modules.

Tested manually.

Fixes #299 