### PR TITLE
Close BluetoothGatt after disconnect.

### DIFF
--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/GattClient.java
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/GattClient.java
@@ -547,6 +547,7 @@ class GattClient extends BluetoothGattCallback {
             Logger.d(TAG, "Chunk is length 0, shutting down GattClient");
             try {
                 mGatt.disconnect();
+                mGatt.close();
             } catch (SecurityException e) {
                 Logger.e(TAG, "Caught SecurityException while shutting down: " + e);
             }


### PR DESCRIPTION
This would cause issues on some readers with some devices. Left previous connection open and was prone to further unexpected communications.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR