### PR TITLE
Make mdoc Session Encryption work with all nine KA curves.

### DIFF
--- a/appholder/src/main/java/com/android/identity/wallet/MainActivity.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/MainActivity.kt
@@ -13,9 +13,12 @@ import androidx.navigation.findNavController
 import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.NavigationUI.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
+import androidx.preference.PreferenceManager
 import com.android.identity.mdoc.origininfo.OriginInfo
 import com.android.identity.mdoc.origininfo.OriginInfoReferrerUrl
+import com.android.identity.util.Logger
 import com.android.identity.wallet.databinding.ActivityMainBinding
+import com.android.identity.wallet.util.PreferencesHelper
 import com.android.identity.wallet.util.log
 import com.android.identity.wallet.util.logError
 import com.android.identity.wallet.util.logInfo
@@ -46,8 +49,7 @@ class MainActivity : AppCompatActivity() {
         setupDrawerLayout()
         setupNfc()
         onNewIntent(intent)
-
-        Security.addProvider(BouncyCastleProvider())
+        Logger.setDebugEnabled(PreferencesHelper.isDebugLoggingEnabled())
     }
 
     private fun setupNfc() {

--- a/appholder/src/main/java/com/android/identity/wallet/settings/SettingsFragment.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/settings/SettingsFragment.kt
@@ -29,7 +29,7 @@ class SettingsFragment : Fragment() {
                         modifier = Modifier.fillMaxSize(),
                         screenState = state,
                         onAutoCloseChanged = settingsViewModel::onConnectionAutoCloseChanged,
-                        onEphemeralKeyCurveChanged = settingsViewModel::onEphemeralKeyCurveChanged,
+                        onSessionEncryptionCurveChanged = settingsViewModel::onEphemeralKeyCurveChanged,
                         onUseStaticHandoverChanged = settingsViewModel::onUseStaticHandoverChanged,
                         onUseL2CAPChanged = settingsViewModel::onL2CAPChanged,
                         onBLEDataRetrievalModeChanged = settingsViewModel::onBleDataRetrievalChanged,

--- a/appholder/src/main/java/com/android/identity/wallet/settings/SettingsScreen.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/settings/SettingsScreen.kt
@@ -36,7 +36,7 @@ fun SettingsScreen(
     modifier: Modifier = Modifier,
     screenState: SettingsScreenState,
     onAutoCloseChanged: (Boolean) -> Unit,
-    onEphemeralKeyCurveChanged: (newValue: SettingsScreenState.EphemeralKeyCurveOption) -> Unit,
+    onSessionEncryptionCurveChanged: (newValue: SettingsScreenState.SessionEncryptionCurveOption) -> Unit,
     onUseStaticHandoverChanged: (Boolean) -> Unit,
     onUseL2CAPChanged: (Boolean) -> Unit,
     onBLEServiceCacheChanged: (Boolean) -> Unit,
@@ -63,9 +63,9 @@ fun SettingsScreen(
                 onCheckedChange = onAutoCloseChanged
             )
             SettingsDropDown(
-                title = "Ephemeral Key Curve",
-                description = curveLabelFor(screenState.ephemeralKeyCurveOption.toEcCurve()),
-                onCurveChanged = onEphemeralKeyCurveChanged
+                title = "Session Encryption Curve",
+                description = curveLabelFor(screenState.sessionEncryptionCurveOption.toEcCurve()),
+                onCurveChanged = onSessionEncryptionCurveChanged
             )
             SettingSectionTitle(title = "NFC Engagement")
             SettingToggle(
@@ -185,7 +185,7 @@ private fun SettingsDropDown(
     modifier: Modifier = Modifier,
     title: String,
     description: String,
-    onCurveChanged: (selection: SettingsScreenState.EphemeralKeyCurveOption) -> Unit
+    onCurveChanged: (selection: SettingsScreenState.SessionEncryptionCurveOption) -> Unit
 ) {
     var dropDownExpanded by remember { mutableStateOf(false) }
     val expandDropDown = { dropDownExpanded = true }
@@ -212,7 +212,7 @@ private fun SettingsDropDown(
                 tint = MaterialTheme.colorScheme.onSurface
             )
         }
-        val entries = SettingsScreenState.EphemeralKeyCurveOption.values().toList()
+        val entries = SettingsScreenState.SessionEncryptionCurveOption.values().toList()
         DropdownMenu(
             expanded = dropDownExpanded,
             onDismissRequest = { dropDownExpanded = false }
@@ -246,7 +246,7 @@ private fun SettingsScreenPreview() {
             modifier = Modifier.fillMaxSize(),
             screenState = SettingsScreenState(),
             onAutoCloseChanged = {},
-            onEphemeralKeyCurveChanged = {},
+            onSessionEncryptionCurveChanged = {},
             onUseStaticHandoverChanged = {},
             onUseL2CAPChanged = {},
             onBLEServiceCacheChanged = {},

--- a/appholder/src/main/java/com/android/identity/wallet/settings/SettingsScreenState.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/settings/SettingsScreenState.kt
@@ -11,7 +11,7 @@ import kotlinx.parcelize.Parcelize
 @Immutable
 data class SettingsScreenState(
     val autoCloseEnabled: Boolean = true,
-    val ephemeralKeyCurveOption: EphemeralKeyCurveOption = EphemeralKeyCurveOption.P256,
+    val sessionEncryptionCurveOption: SessionEncryptionCurveOption = SessionEncryptionCurveOption.P256,
     val useStaticHandover: Boolean = true,
     val isL2CAPEnabled: Boolean = false,
     val isBleClearCacheEnabled: Boolean = false,
@@ -55,14 +55,16 @@ data class SettingsScreenState(
     }
 
     @Parcelize
-    enum class EphemeralKeyCurveOption : Parcelable {
+    enum class SessionEncryptionCurveOption : Parcelable {
         P256,
         P384,
         P521,
         BrainPoolP256R1,
         BrainPoolP320R1,
         BrainPoolP384R1,
-        BrainPoolP512R1;
+        BrainPoolP512R1,
+        X25519,
+        X448;
 
         fun toEcCurve(): Int {
 
@@ -74,11 +76,13 @@ data class SettingsScreenState(
                 BrainPoolP320R1 -> SecureArea.EC_CURVE_BRAINPOOLP320R1
                 BrainPoolP384R1 -> SecureArea.EC_CURVE_BRAINPOOLP384R1
                 BrainPoolP512R1 -> SecureArea.EC_CURVE_BRAINPOOLP512R1
+                X25519 -> SecureArea.EC_CURVE_X25519
+                X448 -> SecureArea.EC_CURVE_X448
             }
         }
 
         companion object {
-            fun fromEcCurve(@EcCurve curve: Int): EphemeralKeyCurveOption {
+            fun fromEcCurve(@EcCurve curve: Int): SessionEncryptionCurveOption {
                 return when (curve) {
                     SecureArea.EC_CURVE_P256 -> P256
                     SecureArea.EC_CURVE_P384 -> P384
@@ -87,6 +91,8 @@ data class SettingsScreenState(
                     SecureArea.EC_CURVE_BRAINPOOLP320R1 -> BrainPoolP320R1
                     SecureArea.EC_CURVE_BRAINPOOLP384R1 -> BrainPoolP384R1
                     SecureArea.EC_CURVE_BRAINPOOLP512R1 -> BrainPoolP512R1
+                    SecureArea.EC_CURVE_X25519 -> X25519
+                    SecureArea.EC_CURVE_X448 -> X448
                     else -> throw IllegalStateException("Unknown EcCurve")
                 }
             }

--- a/appholder/src/main/java/com/android/identity/wallet/settings/SettingsViewModel.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/settings/SettingsViewModel.kt
@@ -14,7 +14,7 @@ class SettingsViewModel : ViewModel() {
     fun loadSettings() {
         val settingsState = SettingsScreenState(
             autoCloseEnabled = PreferencesHelper.isConnectionAutoCloseEnabled(),
-            ephemeralKeyCurveOption = SettingsScreenState.EphemeralKeyCurveOption.fromEcCurve(
+            sessionEncryptionCurveOption = SettingsScreenState.SessionEncryptionCurveOption.fromEcCurve(
                 PreferencesHelper.getEphemeralKeyCurveOption()
             ),
             useStaticHandover = PreferencesHelper.shouldUseStaticHandover(),
@@ -35,10 +35,10 @@ class SettingsViewModel : ViewModel() {
     }
 
     fun onEphemeralKeyCurveChanged(
-        ephemeralKeyCurveOption: SettingsScreenState.EphemeralKeyCurveOption
+        sessionEncryptionCurveOption: SettingsScreenState.SessionEncryptionCurveOption
     ) {
-        PreferencesHelper.setEphemeralKeyCurveOption(ephemeralKeyCurveOption.toEcCurve())
-        mutableSettingsState.update { it.copy(ephemeralKeyCurveOption = ephemeralKeyCurveOption) }
+        PreferencesHelper.setEphemeralKeyCurveOption(sessionEncryptionCurveOption.toEcCurve())
+        mutableSettingsState.update { it.copy(sessionEncryptionCurveOption = sessionEncryptionCurveOption) }
     }
 
     fun onUseStaticHandoverChanged(newValue: Boolean) {

--- a/appholder/src/main/java/com/android/identity/wallet/transfer/Communication.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/transfer/Communication.kt
@@ -14,7 +14,7 @@ class Communication private constructor(
 ) {
 
     private var request: DeviceRequest? = null
-    private var deviceRetrievalHelper: DeviceRetrievalHelper? = null
+    var deviceRetrievalHelper: DeviceRetrievalHelper? = null
 
     fun setupPresentation(deviceRetrievalHelper: DeviceRetrievalHelper) {
         this.deviceRetrievalHelper = deviceRetrievalHelper

--- a/appholder/src/main/java/com/android/identity/wallet/transfer/TransferManager.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/transfer/TransferManager.kt
@@ -212,7 +212,7 @@ class TransferManager private constructor(private val context: Context) {
                     authKey.secureArea,
                     authKey.alias,
                     keyUnlockData,
-                    authKey.attestation.first().publicKey
+                    communication.deviceRetrievalHelper!!.eReaderKey
                 )
             }
             val data = generator.generate()

--- a/appholder/src/main/java/com/android/identity/wallet/util/PreferencesHelper.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/util/PreferencesHelper.kt
@@ -6,6 +6,7 @@ import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import com.android.identity.securearea.SecureArea
 import com.android.identity.securearea.SecureArea.EcCurve
+import com.android.identity.util.Logger
 import java.io.File
 
 object PreferencesHelper {
@@ -103,6 +104,7 @@ object PreferencesHelper {
 
     fun setDebugLoggingEnabled(enabled: Boolean) {
         sharedPreferences.edit { putBoolean(DEBUG_LOG, enabled) }
+        Logger.setDebugEnabled(enabled)
     }
 
     @EcCurve

--- a/appverifier/src/main/java/com/android/mdl/appreader/MainActivity.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/MainActivity.kt
@@ -46,8 +46,6 @@ class MainActivity : AppCompatActivity() {
             addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
         }
         mPendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
-
-        Security.addProvider(BouncyCastleProvider())
     }
 
     private fun setupDrawerLayout() {

--- a/appverifier/src/main/java/com/android/mdl/appreader/VerifierApp.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/VerifierApp.kt
@@ -19,6 +19,7 @@ class VerifierApp : Application() {
         Logger.setLogPrinter(AndroidLogPrinter())
         DynamicColors.applyToActivitiesIfAvailable(this)
         userPreferencesInstance = userPreferences
+        Logger.setDebugEnabled(userPreferences.isDebugLoggingEnabled())
     }
 
     companion object {

--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
@@ -17,6 +17,8 @@ import androidx.annotation.AttrRes
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.android.identity.mdoc.response.DeviceResponseParser
+import com.android.identity.securearea.SecureArea
+import com.android.identity.securearea.SecureArea.EcCurve
 import com.android.mdl.appreader.R
 import com.android.mdl.appreader.databinding.FragmentShowDocumentBinding
 import com.android.mdl.appreader.issuerauth.SimpleIssuerTrustStore
@@ -155,6 +157,23 @@ class ShowDocumentFragment : Fragment() {
         binding.btNewRequest.visibility = View.GONE
     }
 
+    private fun curveNameFor(ecCurve: Int): String {
+        return when (ecCurve) {
+            SecureArea.EC_CURVE_P256 -> "P-256"
+            SecureArea.EC_CURVE_P384 -> "P-384"
+            SecureArea.EC_CURVE_P521 -> "P-521"
+            SecureArea.EC_CURVE_BRAINPOOLP256R1 -> "BrainpoolP256R1"
+            SecureArea.EC_CURVE_BRAINPOOLP320R1 -> "BrainpoolP320R1"
+            SecureArea.EC_CURVE_BRAINPOOLP384R1 -> "BrainpoolP384R1"
+            SecureArea.EC_CURVE_BRAINPOOLP512R1 -> "BrainpoolP512R1"
+            SecureArea.EC_CURVE_ED25519 -> "Ed25519"
+            SecureArea.EC_CURVE_X25519 -> "X25519"
+            SecureArea.EC_CURVE_ED448 -> "Ed448"
+            SecureArea.EC_CURVE_X448 -> "X448"
+            else -> throw IllegalArgumentException("Unknown curve $ecCurve")
+        }
+    }
+
     private fun formatTextResult(documents: Collection<DeviceResponseParser.Document>): String {
         // Create the trustManager to validate the DS Certificate against the list of known
         // certificates in the app
@@ -177,6 +196,7 @@ class ShowDocumentFragment : Fragment() {
 
         sb.append("Number of documents returned: <b>${documents.size}</b><br>")
         sb.append("Address: <b>" + transferManager.mdocConnectionMethod + "</b><br>")
+        sb.append("Session encryption curve: <b>" + curveNameFor(transferManager.getMdocSessionEncryptionCurve()) + "</b><br>")
         sb.append("<br>")
         for (doc in documents) {
             // Get primary color from theme to use in the HTML formatted document.

--- a/appverifier/src/main/java/com/android/mdl/appreader/settings/UserPreferences.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/settings/UserPreferences.kt
@@ -2,6 +2,7 @@ package com.android.mdl.appreader.settings
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.android.identity.util.Logger
 
 class UserPreferences(
     private val preferences: SharedPreferences
@@ -77,6 +78,7 @@ class UserPreferences(
 
     fun setDebugLoggingEnabled(enabled: Boolean) {
         preferences.edit { putBoolean(LOG_ENABLED, enabled) }
+        Logger.setDebugEnabled(enabled)
     }
 
     fun getReaderAuthentication(): Int {

--- a/appverifier/src/main/java/com/android/mdl/appreader/transfer/TransferManager.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/transfer/TransferManager.kt
@@ -16,6 +16,7 @@ import com.android.identity.mdoc.request.DeviceRequestGenerator
 import com.android.identity.mdoc.response.DeviceResponseParser
 import com.android.identity.android.mdoc.deviceretrieval.VerificationHelper
 import androidx.preference.PreferenceManager
+import com.android.identity.internal.Util
 import com.android.mdl.appreader.R
 import com.android.mdl.appreader.document.RequestDocumentList
 import com.android.mdl.appreader.readercertgen.ReaderCertificateGenerator
@@ -351,10 +352,14 @@ class TransferManager private constructor(private val context: Context) {
                 val parser =
                     DeviceResponseParser()
                 parser.setSessionTranscript(v.sessionTranscript)
-                parser.setEphemeralReaderKey(v.ephemeralReaderKey)
+                parser.setEphemeralReaderKey(v.eReaderKeyPair.private)
                 parser.setDeviceResponse(rb)
                 return parser.parse()
             } ?: throw IllegalStateException("Verification is null")
         } ?: throw IllegalStateException("Response not received")
+    }
+
+    fun getMdocSessionEncryptionCurve(): Int {
+        return Util.getCurve(verification!!.eReaderKeyPair.public)
     }
 }

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelper.java
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelper.java
@@ -268,19 +268,6 @@ public class DeviceRetrievalHelper {
             }
         }
         DataItem eReaderKeyDataItem = Util.cborDecode(encodedEReaderKey);
-        @SecureArea.EcCurve int curve;
-        try {
-            curve = Util.coseKeyGetCurve(eReaderKeyDataItem);
-        } catch (IllegalArgumentException e) {
-            Logger.w(TAG, "No curve identifier in COSE_Key", e);
-            return OptionalLong.of(Constants.SESSION_DATA_STATUS_ERROR_SESSION_ENCRYPTION);
-        }
-        if (curve != SecureArea.EC_CURVE_P256) {
-            Logger.w(TAG,
-                    String.format(Locale.US, "Expected curve P-256 (%d) but got %d",
-                            SecureArea.EC_CURVE_P256, curve));
-            return OptionalLong.of(Constants.SESSION_DATA_STATUS_ERROR_SESSION_ENCRYPTION);
-        }
         try {
             mEReaderKey = Util.coseKeyDecode(eReaderKeyDataItem);
         } catch (IllegalArgumentException

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.java
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.java
@@ -727,6 +727,10 @@ public class VerificationHelper {
         EngagementParser.Engagement engagement = engagementParser.parse();
         PublicKey eDeviceKey = engagement.getESenderKey();
 
+        // Create reader ephemeral key with key to match device ephemeral key's curve.
+        int curveToUse = Util.getCurve(eDeviceKey);
+        mEphemeralKeyPair = Util.createEphemeralKeyPair(curveToUse);
+
         byte[] encodedEReaderKeyPub = Util.cborEncode(Util.cborBuildCoseKey(mEphemeralKeyPair.getPublic()));
         mEncodedSessionTranscript = Util.cborEncode(new CborBuilder()
                 .addArray()
@@ -1103,8 +1107,8 @@ public class VerificationHelper {
      * @return the ephemeral key used by the reader for session encryption.
      */
     public @NonNull
-    PrivateKey getEphemeralReaderKey() {
-        return mEphemeralKeyPair.getPrivate();
+    KeyPair getEReaderKeyPair() {
+        return mEphemeralKeyPair;
     }
 
     /**
@@ -1264,7 +1268,6 @@ public class VerificationHelper {
             mHelper.mContext = context;
             mHelper.mListener = listener;
             mHelper.mListenerExecutor = executor;
-            mHelper.mEphemeralKeyPair = Util.createEphemeralKeyPair(SecureArea.EC_CURVE_P256);
         }
 
         /**

--- a/identity/src/main/java/com/android/identity/mdoc/sessionencryption/SessionEncryption.java
+++ b/identity/src/main/java/com/android/identity/mdoc/sessionencryption/SessionEncryption.java
@@ -23,6 +23,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.android.identity.internal.Util;
+import com.android.identity.securearea.SecureArea;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import java.io.ByteArrayInputStream;
 import java.lang.annotation.Retention;
@@ -110,7 +113,18 @@ public final class SessionEncryption {
 
         SecretKeySpec deviceSK, readerSK;
         try {
-            KeyAgreement ka = KeyAgreement.getInstance("ECDH");
+            KeyAgreement ka;
+            switch (Util.getCurve(remotePublicKey)) {
+                case SecureArea.EC_CURVE_X25519:
+                    ka = KeyAgreement.getInstance("X25519", new BouncyCastleProvider());
+                    break;
+                case SecureArea.EC_CURVE_X448:
+                    ka = KeyAgreement.getInstance("X448", new BouncyCastleProvider());
+                    break;
+                default:
+                    ka = KeyAgreement.getInstance("ECDH", new BouncyCastleProvider());
+                    break;
+            }
             ka.init(mESelfKeyPrivate);
             ka.doPhase(remotePublicKey, true);
             byte[] sharedSecret = ka.generateSecret();

--- a/identity/src/main/java/com/android/identity/util/Constants.java
+++ b/identity/src/main/java/com/android/identity/util/Constants.java
@@ -100,32 +100,6 @@ public class Constants {
      */
     public static final long SESSION_DATA_STATUS_SESSION_TERMINATION = 20;
 
-    /** The curve identifier for P-256 */
-    public static final int EC_CURVE_P256 = 1;
-
-    /** The curve identifier for P-384 */
-    public static final int EC_CURVE_P384 = 2;
-
-    /** The curve identifier for P-521 */
-    public static final int EC_CURVE_P521 = 3;
-
-    /** The curve identifier for brainpoolP256r1 */
-    public static final int EC_CURVE_BRAINPOOLP256R1 = -65537;
-
-    /** The curve identifier for brainpoolP320r1 */
-    public static final int EC_CURVE_BRAINPOOLP320R1 = -65538;
-
-    /** The curve identifier for brainpoolP384r1 */
-    public static final int EC_CURVE_BRAINPOOLP384R1 = -65539;
-
-    /** The curve identifier for brainpoolP512r1 */
-    public static final int EC_CURVE_BRAINPOOLP512R1 = -65540;
-
-    /** The curve identifier for Ed25519 */
-    public static final int EC_CURVE_ED25519 = 6;
-
-    /** The curve identifier for Ed448 */
-    public static final int EC_CURVE_ED448 = 7;
 
     /**
      * The status code used for session data exchange.

--- a/identity/src/test/java/com/android/identity/internal/UtilTest.java
+++ b/identity/src/test/java/com/android/identity/internal/UtilTest.java
@@ -25,11 +25,13 @@ import static org.junit.Assert.assertTrue;
 
 import com.android.identity.TestUtilities;
 
+import com.android.identity.securearea.SecureArea;
 import com.android.identity.util.Timestamp;
 import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECParameterSpec;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -39,6 +41,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.PublicKey;
 import java.security.Security;
 import java.security.Signature;
 import java.security.cert.X509Certificate;
@@ -997,5 +1000,69 @@ public class UtilTest {
         assertEquals(0, Util.mdocVersionCompare("1.0", "1.0"));
         assertTrue(Util.mdocVersionCompare("1.0", "1.1") < 0);
         assertTrue(Util.mdocVersionCompare("1.1", "1.0") > 0);
+    }
+
+    // Checks that our COSE_Key encode and decode functions work as expected
+    // for an EC key of a given curve.
+    static private void testCoseKey(@SecureArea.EcCurve int curve) {
+        KeyPair kp = Util.createEphemeralKeyPair(curve);
+        DataItem coseKey = Util.cborBuildCoseKey(kp.getPublic());
+        PublicKey decoded = Util.coseKeyDecode(coseKey);
+        Assert.assertEquals(kp.getPublic(), decoded);
+    }
+
+    @Test
+    public void testCoseKeyP256() {
+        testCoseKey(SecureArea.EC_CURVE_P256);
+    }
+
+    @Test
+    public void testCoseKeyP384() {
+        testCoseKey(SecureArea.EC_CURVE_P384);
+    }
+
+    @Test
+    public void testCoseKeyP521() {
+        testCoseKey(SecureArea.EC_CURVE_P521);
+    }
+
+    @Test
+    public void testCoseKeyBrainpool256() {
+        testCoseKey(SecureArea.EC_CURVE_BRAINPOOLP256R1);
+    }
+
+    @Test
+    public void testCoseKeyBrainpool320() {
+        testCoseKey(SecureArea.EC_CURVE_BRAINPOOLP320R1);
+    }
+
+    @Test
+    public void testCoseKeyBrainpool384() {
+        testCoseKey(SecureArea.EC_CURVE_BRAINPOOLP384R1);
+    }
+
+    @Test
+    public void testCoseKeyBrainpool521() {
+        testCoseKey(SecureArea.EC_CURVE_BRAINPOOLP512R1);
+    }
+
+    @Test
+    public void testCoseKeyX25519() {
+        testCoseKey(SecureArea.EC_CURVE_X25519);
+    }
+
+    @Test
+    public void testCoseKeyX448() {
+        testCoseKey(SecureArea.EC_CURVE_X448);
+    }
+
+    @Test
+    public void testCoseKeyEd25519() {
+        testCoseKey(SecureArea.EC_CURVE_ED25519);
+    }
+
+    @Test
+    public void testCoseKeyEd448() {
+        testCoseKey(SecureArea.EC_CURVE_ED448);
     }
 }

--- a/identity/src/test/java/com/android/identity/mdoc/sessionencryption/SessionEncryptionTest.java
+++ b/identity/src/test/java/com/android/identity/mdoc/sessionencryption/SessionEncryptionTest.java
@@ -221,49 +221,46 @@ public class SessionEncryptionTest {
 
     @Test
     public void testP256() {
-        testCurve(Constants.EC_CURVE_P256);
+        testCurve(SecureArea.EC_CURVE_P256);
     }
 
     @Test
     public void testP384() {
-        testCurve(Constants.EC_CURVE_P384);
+        testCurve(SecureArea.EC_CURVE_P384);
     }
 
     @Test
     public void testP521() {
-        testCurve(Constants.EC_CURVE_P521);
+        testCurve(SecureArea.EC_CURVE_P521);
     }
 
     @Test
     public void testBrainpool256() {
-        testCurve(Constants.EC_CURVE_BRAINPOOLP256R1);
+        testCurve(SecureArea.EC_CURVE_BRAINPOOLP256R1);
     }
 
     @Test
     public void testBrainpool320() {
-        testCurve(Constants.EC_CURVE_BRAINPOOLP320R1);
+        testCurve(SecureArea.EC_CURVE_BRAINPOOLP320R1);
     }
 
     @Test
     public void testBrainpool384() {
-        testCurve(Constants.EC_CURVE_BRAINPOOLP384R1);
+        testCurve(SecureArea.EC_CURVE_BRAINPOOLP384R1);
     }
 
     @Test
     public void testBrainpool521() {
-        testCurve(Constants.EC_CURVE_BRAINPOOLP512R1);
+        testCurve(SecureArea.EC_CURVE_BRAINPOOLP512R1);
     }
 
-    // TODO: remove @Ignore once ED25519 / ED448 is no longer buggy
-    @Ignore
     @Test
-    public void testEd25519() {
-        testCurve(Constants.EC_CURVE_ED25519);
+    public void testX25519() {
+        testCurve(SecureArea.EC_CURVE_X25519);
     }
 
-    @Ignore
     @Test
-    public void testEd448() {
-        testCurve(Constants.EC_CURVE_ED448);
+    public void testX448() {
+        testCurve(SecureArea.EC_CURVE_X448);
     }
 }


### PR DESCRIPTION
Change from "Ephemeral Key Curve" to "Session Encryption Curve" in preferences since that's more accurate.

Also show which mdoc Session Encryption curve was used in the reader.

Fix "Show debugging logs" buttons in both wallet and reader app (currently a no-op).

Add new unit tests for COSE_Key encode and decode.

Also fix mdoc MAC authentication to make it use the reader public key.

Test: New unit tests + all unit tests pass.
Test: Manually tested all nine curves with 18013-5 presentations.