### PR TITLE
Rework BouncyCastleSecureArea.

### DIFF
--- a/appholder/src/main/java/com/android/identity/wallet/HolderApp.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/HolderApp.kt
@@ -6,12 +6,18 @@ import com.android.identity.util.Logger
 import com.android.identity.wallet.util.PeriodicKeysRefreshWorkRequest
 import com.android.identity.wallet.util.PreferencesHelper
 import com.google.android.material.color.DynamicColors
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import java.security.Security
 
 class HolderApp: Application() {
 
     override fun onCreate() {
         super.onCreate()
         Logger.setLogPrinter(AndroidLogPrinter())
+        // This is needed to prefer BouncyCastle bundled with the app instead of the Conscrypt
+        // based implementation included in the OS itself.
+        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
+        Security.addProvider(BouncyCastleProvider())
         DynamicColors.applyToActivitiesIfAvailable(this)
         PreferencesHelper.initialize(this)
         PeriodicKeysRefreshWorkRequest(this).schedulePeriodicKeysRefreshing()

--- a/appholder/src/main/java/com/android/identity/wallet/authconfirmation/AuthConfirmationFragment.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/authconfirmation/AuthConfirmationFragment.kt
@@ -20,7 +20,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.android.identity.android.securearea.AndroidKeystoreSecureArea
-import com.android.identity.securearea.BouncyCastleSecureArea
+import com.android.identity.securearea.SoftwareSecureArea
 import com.android.identity.securearea.SecureArea.ALGORITHM_ES256
 import com.android.identity.wallet.R
 import com.android.identity.wallet.authprompt.UserAuthPromptBuilder
@@ -161,7 +161,7 @@ class AuthConfirmationFragment : BottomSheetDialogFragment() {
     }
 
     private fun onPassphraseProvided(passphrase: String) {
-        val unlockData = BouncyCastleSecureArea.KeyUnlockData(passphrase)
+        val unlockData = SoftwareSecureArea.KeyUnlockData(passphrase)
         val result = viewModel.sendResponseForSelection(unlockData)
         onSendResponseResult(result)
     }

--- a/appverifier/src/main/java/com/android/mdl/appreader/VerifierApp.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/VerifierApp.kt
@@ -6,6 +6,8 @@ import com.android.identity.util.Logger
 import androidx.preference.PreferenceManager
 import com.android.mdl.appreader.settings.UserPreferences
 import com.google.android.material.color.DynamicColors
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import java.security.Security
 
 class VerifierApp : Application() {
 
@@ -17,6 +19,10 @@ class VerifierApp : Application() {
     override fun onCreate() {
         super.onCreate()
         Logger.setLogPrinter(AndroidLogPrinter())
+        // This is needed to prefer BouncyCastle bundled with the app instead of the Conscrypt
+        // based implementation included in the OS itself.
+        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
+        Security.addProvider(BouncyCastleProvider())
         DynamicColors.applyToActivitiesIfAvailable(this)
         userPreferencesInstance = userPreferences
         Logger.setDebugEnabled(userPreferences.isDebugLoggingEnabled())

--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
@@ -16,6 +16,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.annotation.AttrRes
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import com.android.identity.internal.Util
 import com.android.identity.mdoc.response.DeviceResponseParser
 import com.android.identity.securearea.SecureArea
 import com.android.identity.securearea.SecureArea.EcCurve
@@ -262,6 +263,7 @@ class ShowDocumentFragment : Fragment() {
             // Just show the SHA-1 of DeviceKey since all we're interested in here is whether
             // we saw the same key earlier.
             sb.append("<h6>DeviceKey</h6>")
+            sb.append("${getFormattedCheck(true)}Curve: <b>${curveNameFor(Util.getCurve(doc.deviceKey))}</b><br>")
             val deviceKeySha1 = FormatUtil.encodeToString(
                 MessageDigest.getInstance("SHA-1").digest(doc.deviceKey.encoded)
             )

--- a/appverifier/src/main/java/com/android/mdl/appreader/readercertgen/CertificateGenerator.java
+++ b/appverifier/src/main/java/com/android/mdl/appreader/readercertgen/CertificateGenerator.java
@@ -38,8 +38,6 @@ public final class CertificateGenerator {
 
 	static X509Certificate generateCertificate(DataMaterial data, CertificateMaterial certMaterial, KeyMaterial keyMaterial)
 			throws CertIOException, CertificateException, OperatorCreationException {
-		Provider bcProvider = new BouncyCastleProvider();
-		Security.addProvider(bcProvider);
 
 		Optional<X509Certificate> issuerCert = keyMaterial.issuerCertificate();
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@
     biometrics = "1.2.0-alpha05"
     cbor = "0.9"
     exif = "1.3.6"
-    bouncy-castle = "1.67"
+    bouncy-castle = "1.70"
     sonar-gradle-plugin = "3.4.0.2513"
     jacoco = "0.47.0"
     navigation = "2.6.0"

--- a/identity/src/main/java/com/android/identity/securearea/AttestationExtension.kt
+++ b/identity/src/main/java/com/android/identity/securearea/AttestationExtension.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity.securearea
+
+import co.nstant.`in`.cbor.CborBuilder
+import co.nstant.`in`.cbor.CborDecoder
+import co.nstant.`in`.cbor.CborEncoder
+import co.nstant.`in`.cbor.CborException
+import co.nstant.`in`.cbor.model.ByteString
+import co.nstant.`in`.cbor.model.DataItem
+import co.nstant.`in`.cbor.model.Map
+import co.nstant.`in`.cbor.model.UnicodeString
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+/**
+ * X.509 Extension which may be used by [SecureArea] implementations.
+ *
+ * The main purpose of the extension is to define a place to include the
+ * challenge passed at key creation time, for freshness.
+ *
+ * If used, the extension must be put in X.509 certificate for the created
+ * key (that is, included in the first certificate in the attestation for the key)
+ * at the OID defined by [ATTESTATION_OID] and the payload should be an
+ * OCTET STRING containing the bytes of the CBOR conforming to the following CDDL:
+ *
+ * ```
+ * Attestation = {
+ *   "challenge" : bstr,   ; contains the challenge
+ * }
+ * ```
+ *
+ * This map may be extended in the future with additional fields.
+ */
+object AttestationExtension {
+    /**
+     * The OID for the attestation extension.
+     */
+    const val ATTESTATION_OID = "1.3.6.1.4.1.11129.2.1.39"
+
+    /**
+     * Generates the payload of the attestation extension.
+     *
+     * @param challenge the challenge to include
+     * @return the bytes of the CBOR for the extension.
+     */
+    @JvmStatic
+    fun encode(challenge: ByteArray): ByteArray {
+        val baos = ByteArrayOutputStream()
+        try {
+            CborEncoder(baos).nonCanonical().encode(
+                CborBuilder()
+                    .addMap()
+                    .put("challenge", challenge)
+                    .end()
+                    .build().get(0)
+            )
+        } catch (e: CborException) {
+            throw IllegalStateException("Unexpected failure encoding data", e)
+        }
+        return baos.toByteArray()
+    }
+
+    /**
+     * Extracts the challenge from the attestation extension.
+     *
+     * @param attestationExtension the bytes of the CBOR for the extension.
+     * @return the challenge value.
+     */
+    @JvmStatic
+    fun decode(attestationExtension: ByteArray): ByteArray {
+        val dataItems: List<DataItem> = try {
+            val bais = ByteArrayInputStream(attestationExtension)
+            CborDecoder(bais).decode()
+        } catch (e: CborException) {
+            throw IllegalArgumentException("Error decoding CBOR", e)
+        }
+        return ((dataItems[0] as Map).get(UnicodeString("challenge")) as ByteString).bytes
+    }
+
+}

--- a/identity/src/main/java/com/android/identity/securearea/SecureArea.java
+++ b/identity/src/main/java/com/android/identity/securearea/SecureArea.java
@@ -227,7 +227,7 @@ public interface SecureArea {
     /**
      * Class with information about a key.
      *
-     * <p>Concrete {@link SecureArea} implementations may subclass this to provide
+     * <p>Concrete {@link SecureArea} implementations may subclass this to provide additional
      * implementation-specific information about the key.
      */
     class KeyInfo {
@@ -247,7 +247,7 @@ public interface SecureArea {
         }
 
         /**
-         * Gets the attestation for a key.
+         * Gets the attestation for the key.
          *
          * @return A list of certificates representing a certificate chain.
          */

--- a/identity/src/test/java/com/android/identity/credential/CredentialStoreTest.java
+++ b/identity/src/test/java/com/android/identity/credential/CredentialStoreTest.java
@@ -17,7 +17,7 @@
 package com.android.identity.credential;
 
 import com.android.identity.internal.Util;
-import com.android.identity.securearea.BouncyCastleSecureArea;
+import com.android.identity.securearea.SoftwareSecureArea;
 import com.android.identity.securearea.SecureArea;
 import com.android.identity.securearea.SecureAreaRepository;
 import com.android.identity.storage.EphemeralStorageEngine;
@@ -46,8 +46,10 @@ public class CredentialStoreTest {
         mStorageEngine = new EphemeralStorageEngine();
 
         mSecureAreaRepository = new SecureAreaRepository();
-        mSecureArea = new BouncyCastleSecureArea(mStorageEngine);
+        mSecureArea = new SoftwareSecureArea(mStorageEngine);
         mSecureAreaRepository.addImplementation(mSecureArea);
+
+
     }
 
     @Test
@@ -61,7 +63,7 @@ public class CredentialStoreTest {
         for (int n = 0; n < 10; n++) {
             credentialStore.createCredential(
                     "testCred" + n,
-                    new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+                    new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
         }
         Assert.assertEquals(10, credentialStore.listCredentials().size());
         credentialStore.deleteCredential("testCred1");
@@ -84,7 +86,7 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
         Assert.assertEquals("testCredential", credential.getName());
         List<X509Certificate> certChain = credential.getAttestation();
         Assert.assertTrue(certChain.size() >= 1);
@@ -103,7 +105,7 @@ public class CredentialStoreTest {
         // Check creating a credential with an existing name overwrites the existing one
         credential = credentialStore.createCredential(
                 "testCredential",
-                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
         Assert.assertEquals("testCredential", credential.getName());
         // At least the leaf certificate should be different
         List<X509Certificate> certChain3 = credential.getAttestation();
@@ -125,7 +127,7 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
 
         // After creation, NameSpacedData is present but empty.
         Assert.assertEquals(0, credential.getNameSpacedData().getNameSpaceNames().size());
@@ -158,7 +160,7 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
 
         Timestamp timeBeforeValidity = Timestamp.ofEpochMilli(40);
         Timestamp timeValidityBegin = Timestamp.ofEpochMilli(50);
@@ -176,7 +178,7 @@ public class CredentialStoreTest {
         // Create ten authentication keys...
         for (int n = 0; n < 10; n++) {
             credential.createPendingAuthenticationKey(
-                    new BouncyCastleSecureArea.CreateKeySettings.Builder().build(),
+                    new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
                     null);
         }
         Assert.assertEquals(0, credential.getAuthenticationKeys().size());
@@ -247,7 +249,7 @@ public class CredentialStoreTest {
         // Create and certify five replacements
         for (n = 0; n < 5; n++) {
             credential.createPendingAuthenticationKey(
-                    new BouncyCastleSecureArea.CreateKeySettings.Builder().build(),
+                    new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
                     null);
         }
         Assert.assertEquals(10, credential.getAuthenticationKeys().size());
@@ -302,7 +304,7 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
 
         Assert.assertEquals(0, credential.getAuthenticationKeys().size());
         Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
@@ -310,7 +312,7 @@ public class CredentialStoreTest {
         // Create ten pending auth keys and certify four of them
         for (n = 0; n < 4; n++) {
             credential.createPendingAuthenticationKey(
-                    new BouncyCastleSecureArea.CreateKeySettings.Builder().build(),
+                    new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
                     null);
         }
         Assert.assertEquals(0, credential.getAuthenticationKeys().size());
@@ -334,7 +336,7 @@ public class CredentialStoreTest {
         Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
         for (n = 0; n < 6; n++) {
             credential.createPendingAuthenticationKey(
-                    new BouncyCastleSecureArea.CreateKeySettings.Builder().build(),
+                    new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
                     null);
         }
         Assert.assertEquals(4, credential.getAuthenticationKeys().size());
@@ -379,7 +381,7 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
 
         // We want to check the behavior for when the holder has a birthday and the issuer
         // carefully sends half the MSOs to be used before the birthday (with age_in_years set to
@@ -400,7 +402,7 @@ public class CredentialStoreTest {
         int n;
         for (n = 0; n < 10; n++) {
             credential.createPendingAuthenticationKey(
-                    new BouncyCastleSecureArea.CreateKeySettings.Builder().build(),
+                    new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
                     null);
         }
         Assert.assertEquals(10, credential.getPendingAuthenticationKeys().size());
@@ -456,7 +458,7 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
 
         // After creation, NameSpacedData is present but empty.
         Assert.assertEquals(0, credential.getNameSpacedData().getNameSpaceNames().size());
@@ -506,15 +508,15 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
 
         SecureArea.CreateKeySettings authKeySettings =
-                new BouncyCastleSecureArea.CreateKeySettings.Builder()
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0])
                         .build();
         for (int n = 0; n < 10; n++) {
             Credential.PendingAuthenticationKey pendingAuthKey =
                     credential.createPendingAuthenticationKey(
-                            new BouncyCastleSecureArea.CreateKeySettings.Builder().build(),
+                            new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
                             null);
             String value = String.format(Locale.US, "bar%02d", n);
             ApplicationData pendingAppData = pendingAuthKey.getApplicationData();
@@ -591,18 +593,18 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
 
         Assert.assertEquals(0, credential.getAuthenticationKeys().size());
         Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
 
         SecureArea.CreateKeySettings authKeySettings =
-                new BouncyCastleSecureArea.CreateKeySettings.Builder()
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0])
                         .build();
         for (int n = 0; n < 10; n++) {
             Credential.PendingAuthenticationKey pendingAuthKey =
                     credential.createPendingAuthenticationKey(
-                            new BouncyCastleSecureArea.CreateKeySettings.Builder().build(),
+                            new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
                             null);
             pendingAuthKey.certify(new byte[] {0, (byte) n},
                     Timestamp.ofEpochMilli(100),
@@ -616,7 +618,7 @@ public class CredentialStoreTest {
         Assert.assertArrayEquals(new byte[] {0, 5}, keyToReplace.getIssuerProvidedData());
         Credential.PendingAuthenticationKey pendingAuthKey =
                 credential.createPendingAuthenticationKey(
-                        new BouncyCastleSecureArea.CreateKeySettings.Builder().build(),
+                        new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
                         keyToReplace);
         // ... it's not replaced until certify() is called
         Assert.assertEquals(1, credential.getPendingAuthenticationKeys().size());
@@ -653,7 +655,7 @@ public class CredentialStoreTest {
         Credential.AuthenticationKey toBeReplaced = credential.getAuthenticationKeys().get(0);
         Credential.PendingAuthenticationKey replacement =
                 credential.createPendingAuthenticationKey(
-                        new BouncyCastleSecureArea.CreateKeySettings.Builder().build(),
+                        new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
                         toBeReplaced);
         Assert.assertEquals(toBeReplaced, replacement.getReplacementFor());
         Assert.assertEquals(replacement, toBeReplaced.getReplacement());
@@ -663,7 +665,7 @@ public class CredentialStoreTest {
         // Similarly, test the case where the key to be replaced is prematurely deleted.
         // The replacement key should no longer indicate it's a replacement key.
         replacement = credential.createPendingAuthenticationKey(
-                new BouncyCastleSecureArea.CreateKeySettings.Builder().build(),
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
                 toBeReplaced);
         Assert.assertEquals(toBeReplaced, replacement.getReplacementFor());
         Assert.assertEquals(replacement, toBeReplaced.getReplacement());

--- a/identity/src/test/java/com/android/identity/credential/CredentialUtilTest.java
+++ b/identity/src/test/java/com/android/identity/credential/CredentialUtilTest.java
@@ -16,7 +16,7 @@
 
 package com.android.identity.credential;
 
-import com.android.identity.securearea.BouncyCastleSecureArea;
+import com.android.identity.securearea.SoftwareSecureArea;
 import com.android.identity.securearea.SecureArea;
 import com.android.identity.securearea.SecureAreaRepository;
 import com.android.identity.storage.EphemeralStorageEngine;
@@ -39,7 +39,7 @@ public class CredentialUtilTest {
         mStorageEngine = new EphemeralStorageEngine();
 
         mSecureAreaRepository = new SecureAreaRepository();
-        mSecureArea = new BouncyCastleSecureArea(mStorageEngine);
+        mSecureArea = new SoftwareSecureArea(mStorageEngine);
         mSecureAreaRepository.addImplementation(mSecureArea);
     }
 
@@ -51,13 +51,13 @@ public class CredentialUtilTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
 
         Assert.assertEquals(0, credential.getAuthenticationKeys().size());
         Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
 
         SecureArea.CreateKeySettings authKeySettings =
-                new BouncyCastleSecureArea.CreateKeySettings.Builder()
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0])
                         .build();
 
         int numAuthKeys = 10;

--- a/identity/src/test/java/com/android/identity/mdoc/response/DeviceResponseGeneratorTest.java
+++ b/identity/src/test/java/com/android/identity/mdoc/response/DeviceResponseGeneratorTest.java
@@ -21,7 +21,7 @@ import com.android.identity.credential.CredentialRequest;
 import com.android.identity.credential.CredentialStore;
 import com.android.identity.credential.NameSpacedData;
 import com.android.identity.internal.Util;
-import com.android.identity.securearea.BouncyCastleSecureArea;
+import com.android.identity.securearea.SoftwareSecureArea;
 import com.android.identity.securearea.SecureArea;
 import com.android.identity.securearea.SecureAreaRepository;
 import com.android.identity.mdoc.mso.MobileSecurityObjectGenerator;
@@ -109,7 +109,7 @@ public class DeviceResponseGeneratorTest {
         mStorageEngine = new EphemeralStorageEngine();
 
         mSecureAreaRepository = new SecureAreaRepository();
-        mSecureArea = new BouncyCastleSecureArea(mStorageEngine);
+        mSecureArea = new SoftwareSecureArea(mStorageEngine);
         mSecureAreaRepository.addImplementation(mSecureArea);
 
         provisionCredential();
@@ -123,7 +123,7 @@ public class DeviceResponseGeneratorTest {
         // Create the credential...
         mCredential = credentialStore.createCredential(
                 "testCredential",
-                new BouncyCastleSecureArea.CreateKeySettings.Builder().build());
+                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
         NameSpacedData nameSpacedData = new NameSpacedData.Builder()
                 .putEntryString("ns1", "foo1", "bar1")
                 .putEntryString("ns1", "foo2", "bar2")
@@ -141,7 +141,7 @@ public class DeviceResponseGeneratorTest {
         mTimeValidityEnd = Timestamp.ofEpochMilli(nowMillis + 10 * 86400 * 1000);
         Credential.PendingAuthenticationKey pendingAuthKey =
                 mCredential.createPendingAuthenticationKey(
-                        new BouncyCastleSecureArea.CreateKeySettings.Builder()
+                        new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0])
                                 .setKeyPurposes(SecureArea.KEY_PURPOSE_SIGN
                                         | SecureArea.KEY_PURPOSE_AGREE_KEY)
                                 .build(),


### PR DESCRIPTION
First of all, rename this to SoftwareSecureArea since there is no need to leak the fact that we're currently using BouncyCastle which could change in the future.

Instead of always using self-signed keys, make it possible to specify the attestation key to use at key creation time. Without this we cannot easily support curves which cannot be used for signing (for example X25519). Modify holder app to create an attestation root on demand.

Introduce attestation extension so SoftwareSecureArea keys also can convey the attestation challenge. The OID for this has been reserved (it's 1.3.6.1.4.1.11129.2.1.39) and we can extend this if needed. Add code for dealing with this and use it in SoftwareSecureArea.

Show the curve of DeviceKey in the reader app.

Make sure we use the BouncyCastle library bundled with the app instead of the Conscrypt-based implementation that may come with the OS. Do this for both wallet and reader app.

This has been manually test with mdocs using both ECDSA and MAC authentication with all curves except Ed25519, X25519, Ed448, and X448. These curves still have some serialization problems, we'll revisit this in a future PR.

The app still uses the name "Bouncy Castle", we'll address that in a future PR.

Test: Manually tested.
Test: All unit tests pass.
