### PR TITLE
Clarify error messages in Android Keystore Secure Area.

### DIFF
--- a/identity-android/src/main/java/com/android/identity/android/securearea/AndroidKeystoreSecureArea.java
+++ b/identity-android/src/main/java/com/android/identity/android/securearea/AndroidKeystoreSecureArea.java
@@ -444,7 +444,7 @@ public class AndroidKeystoreSecureArea implements SecureArea {
             }
             throw new IllegalStateException(e.getMessage(), e);
         } catch (InvalidKeyException e) {
-            throw new IllegalArgumentException("Key does not have purpose KEY_PURPOSE_SIGN", e);
+            throw new IllegalArgumentException(e);
         }
     }
 
@@ -484,7 +484,7 @@ public class AndroidKeystoreSecureArea implements SecureArea {
             }
             throw new IllegalStateException(e.getMessage(), e);
         } catch (InvalidKeyException e) {
-            throw new IllegalArgumentException("Key does not have purpose KEY_PURPOSE_AGREE_KEY", e);
+            throw new IllegalArgumentException(e);
         }
     }
 


### PR DESCRIPTION
The current text assumes the failure has to do with key purpose, but this is not the case and we're actively running into this error message in the context of brokenness in Android Keystore wrt. Ed25519 and X25519 support. With this fix, it's clear what the error is.

Test: Manually test.
