### PR TITLE
Add support for per-MSO data elements.

### DIFF
--- a/identity-android/src/androidTest/java/com/android/identity/android/legacy/MigrateFromKeystoreICStoreTest.java
+++ b/identity-android/src/androidTest/java/com/android/identity/android/legacy/MigrateFromKeystoreICStoreTest.java
@@ -330,7 +330,8 @@ public class MigrateFromKeystoreICStoreTest {
         Map<String, List<byte[]>> issuerNameSpaces = MdocUtil.generateIssuerNameSpaces(
                 nsData,
                 deterministicRandomProvider,
-                16);
+                16,
+                null);
 
         for (String nameSpaceName : issuerNameSpaces.keySet()) {
             Map<Long, byte[]> digests = MdocUtil.calculateDigestsForNameSpace(
@@ -358,7 +359,7 @@ public class MigrateFromKeystoreICStoreTest {
                 issuerCertChain));
 
         byte[] issuerProvidedAuthenticationData = new StaticAuthDataGenerator(
-                MdocUtil.stripIssuerNameSpaces(issuerNameSpaces),
+                MdocUtil.stripIssuerNameSpaces(issuerNameSpaces, null),
                 encodedIssuerAuth).generate();
 
         // Now that we have issuer-provided authentication data we certify the authentication key.

--- a/identity/src/main/java/com/android/identity/credential/Credential.java
+++ b/identity/src/main/java/com/android/identity/credential/Credential.java
@@ -402,6 +402,18 @@ public class Credential {
     }
 
     /**
+     * Gets the authentication key counter.
+     *
+     * <p>This is a number which starts at 0 and is increased by one for every call
+     * to {@link #createPendingAuthenticationKey(SecureArea.CreateKeySettings, AuthenticationKey)}.
+     *
+     * @return the authentication key counter.
+     */
+    public long getAuthenticationKeyCounter() {
+        return mAuthenticationKeyCounter;
+    }
+
+    /**
      * A certified authentication key.
      *
      * <p>To create an instance of this type, an application must first use
@@ -419,6 +431,7 @@ public class Credential {
         private String mSecureAreaName;
         private String mReplacementAlias;
         private SimpleApplicationData mApplicationData;
+        private long mAuthenticationKeyCounter;
 
         static AuthenticationKey create(
                 @NonNull PendingAuthenticationKey pendingAuthenticationKey,
@@ -434,6 +447,7 @@ public class Credential {
             ret.mCredential = credential;
             ret.mSecureAreaName = pendingAuthenticationKey.mSecureAreaName;
             ret.mApplicationData = pendingAuthenticationKey.mApplicationData;
+            ret.mAuthenticationKeyCounter = pendingAuthenticationKey.mAuthenticationKeyCounter;
             return ret;
         }
 
@@ -471,6 +485,19 @@ public class Credential {
          */
         public @NonNull Timestamp getValidUntil() {
             return mValidUntil;
+        }
+
+        /**
+         * Gets the authentication key counter.
+         *
+         * <p>This is the value of the Credential's Authentication Key Counter
+         * at the time the pending authentication key for this authentication key
+         * was created.
+         *
+         * @return the authentication key counter.
+         */
+        public long getAuthenticationKeyCounter() {
+            return mAuthenticationKeyCounter;
         }
 
         /**
@@ -549,7 +576,8 @@ public class Credential {
                     .put("data", mData)
                     .put("validFrom", mValidFrom.toEpochMilli())
                     .put("validUntil", mValidUntil.toEpochMilli())
-                    .put("applicationData", mApplicationData.encodeAsCbor());
+                    .put("applicationData", mApplicationData.encodeAsCbor())
+                    .put("authenticationKeyCounter", mAuthenticationKeyCounter);
             if (mReplacementAlias != null) {
                 mapBuilder.put("replacementAlias", mReplacementAlias);
             }
@@ -576,6 +604,9 @@ public class Credential {
             ret.mApplicationData = SimpleApplicationData.decodeFromCbor(
                     ((ByteString) applicationDataDataItem).getBytes(),
                     () -> ret.mCredential.saveCredential());
+            if (Util.cborMapHasKey(dataItem, "authenticationKeyCounter")) {
+                ret.mAuthenticationKeyCounter = Util.cborMapExtractNumber(dataItem, "authenticationKeyCounter");
+            }
             return ret;
         }
 
@@ -640,6 +671,7 @@ public class Credential {
         Credential mCredential;
         private String mReplacementForAlias;
         private SimpleApplicationData mApplicationData;
+        private long mAuthenticationKeyCounter;
 
         static @NonNull PendingAuthenticationKey create(
                 @NonNull String alias,
@@ -660,6 +692,7 @@ public class Credential {
             }
             ret.mCredential = credential;
             ret.mApplicationData = new SimpleApplicationData(() -> ret.mCredential.saveCredential());
+            ret.mAuthenticationKeyCounter = credential.mAuthenticationKeyCounter;
             return ret;
         }
 
@@ -711,6 +744,18 @@ public class Credential {
         }
 
         /**
+         * Gets the authentication key counter.
+         *
+         * <p>This is the value of the Credential's Authentication Key Counter
+         * at the time this pending authentication key was created.
+         *
+         * @return the authentication key counter.
+         */
+        public long getAuthenticationKeyCounter() {
+            return mAuthenticationKeyCounter;
+        }
+
+        /**
          * Deletes the pending authentication key.
          */
         public void delete() {
@@ -754,7 +799,8 @@ public class Credential {
             if (mReplacementForAlias != null) {
                 mapBuilder.put("replacementForAlias", mReplacementForAlias);
             }
-            mapBuilder.put("applicationData", mApplicationData.encodeAsCbor());
+            mapBuilder.put("applicationData", mApplicationData.encodeAsCbor())
+                    .put("authenticationKeyCounter", mAuthenticationKeyCounter);
             return builder.build().get(0);
         }
 
@@ -774,6 +820,9 @@ public class Credential {
             ret.mApplicationData = SimpleApplicationData.decodeFromCbor(
                     ((ByteString) applicationDataDataItem).getBytes(),
                     () -> ret.mCredential.saveCredential());
+            if (Util.cborMapHasKey(dataItem, "authenticationKeyCounter")) {
+                ret.mAuthenticationKeyCounter = Util.cborMapExtractNumber(dataItem, "authenticationKeyCounter");
+            }
             return ret;
         }
 

--- a/identity/src/main/java/com/android/identity/mdoc/mso/StaticAuthDataParser.java
+++ b/identity/src/main/java/com/android/identity/mdoc/mso/StaticAuthDataParser.java
@@ -104,17 +104,6 @@ public class StaticAuthDataParser {
                     if (innerKey.getTag().getValue() != 24) {
                         throw new IllegalArgumentException("Inner key does not have tag 24");
                     }
-                    // Strictly not necessary but check that elementValue is NULL. This is to
-                    // avoid applications (or issuers) sending the value in issuerSignedMapping
-                    // which is part of staticAuthData.
-                    DataItem issuerSignedItem = Util.cborExtractTaggedAndEncodedCbor(innerKey);
-                    DataItem value = Util.cborMapExtract(issuerSignedItem, "elementValue");
-                    if (!(value instanceof SimpleValue)
-                            || ((SimpleValue) value).getSimpleValueType() != SimpleValueType.NULL) {
-                        String name = Util.cborMapExtractString(issuerSignedItem, "elementIdentifier");
-                        throw new IllegalArgumentException("elementValue for nameSpace " + namespace
-                                + " elementName " + name + " is not NULL");
-                    }
                     innerArray.add(Util.cborEncode(innerKey));
                 }
 

--- a/identity/src/test/java/com/android/identity/credential/CredentialStoreTest.java
+++ b/identity/src/test/java/com/android/identity/credential/CredentialStoreTest.java
@@ -171,6 +171,7 @@ public class CredentialStoreTest {
         // By default, we don't have any auth keys nor any pending auth keys.
         Assert.assertEquals(0, credential.getAuthenticationKeys().size());
         Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
+        Assert.assertEquals(0, credential.getAuthenticationKeyCounter());
 
         // Since none are certified or even pending yet, we can't present anything.
         Assert.assertNull(credential.findAuthenticationKey(timeDuringValidity));
@@ -183,6 +184,7 @@ public class CredentialStoreTest {
         }
         Assert.assertEquals(0, credential.getAuthenticationKeys().size());
         Assert.assertEquals(10, credential.getPendingAuthenticationKeys().size());
+        Assert.assertEquals(10, credential.getAuthenticationKeyCounter());
 
         // ... and certify all of them
         int n = 0;
@@ -193,6 +195,7 @@ public class CredentialStoreTest {
                     issuerProvidedAuthenticationData,
                     timeValidityBegin,
                     timeValidityEnd);
+            Assert.assertEquals(n, pendingAuthenticationKey.getAuthenticationKeyCounter());
         }
         Assert.assertEquals(10, credential.getAuthenticationKeys().size());
         Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
@@ -254,12 +257,16 @@ public class CredentialStoreTest {
         }
         Assert.assertEquals(10, credential.getAuthenticationKeys().size());
         Assert.assertEquals(5, credential.getPendingAuthenticationKeys().size());
+        Assert.assertEquals(15, credential.getAuthenticationKeyCounter());
+        n = 11;
         for (Credential.PendingAuthenticationKey pendingAuthenticationKey :
                 credential.getPendingAuthenticationKeys()) {
             pendingAuthenticationKey.certify(
                     new byte[0],
                     timeValidityBegin,
                     timeValidityEnd);
+            Assert.assertEquals(n, pendingAuthenticationKey.getAuthenticationKeyCounter());
+            n++;
         }
         Assert.assertEquals(15, credential.getAuthenticationKeys().size());
         Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());

--- a/identity/src/test/java/com/android/identity/mdoc/mso/StaticAuthDataTest.java
+++ b/identity/src/test/java/com/android/identity/mdoc/mso/StaticAuthDataTest.java
@@ -60,67 +60,23 @@ public class StaticAuthDataTest {
                 Util.cborBuildTaggedByteString(Util.cborEncode(issuerSignedItemMetadata2));
         byte[] encodedIsiMetadata2Bytes = Util.cborEncode(isiMetadata2Bytes);
 
-        Map<String, List<byte[]>> issuerSignedMapping = new HashMap<>();
-        issuerSignedMapping.put("org.namespace",
-                Arrays.asList(encodedIsiMetadataBytes, encodedIsiMetadata2Bytes));
-        return issuerSignedMapping;
-    }
-
-    private Map<String, List<byte[]>> createInvalidElementValueDigestIdMapping() {
-        DataItem issuerSignedItemMetadata = new CborBuilder()
+        DataItem issuerSignedItemMetadata3 = new CborBuilder()
                 .addMap()
-                .put("random", new byte[] {0x50, 0x51, 0x52})
-                .put("digestID", 42)
-                .put("elementIdentifier", "dataElementName")
-                .put(new UnicodeString("elementValue"), SimpleValue.NULL)
-                .end()
-                .build().get(0);
-        DataItem isiMetadataBytes =
-                Util.cborBuildTaggedByteString(Util.cborEncode(issuerSignedItemMetadata));
-        byte[] encodedIsiMetadataBytes = Util.cborEncode(isiMetadataBytes);
-
-        DataItem issuerSignedItemMetadata2 = new CborBuilder()
-                .addMap()
-                .put("digestID", 43)
+                .put("digestID", 44)
                 .put("random", new byte[] {0x53, 0x54, 0x55})
-                .put("elementIdentifier", "dataElementName2")
-                .put(new UnicodeString("elementValue"), SimpleValue.TRUE)
+                .put("elementIdentifier", "portrait")
+                .put("elementValue", Util.cborEncodeBytestring(new byte[] {0x20, 0x21, 0x22, 0x23}))
                 .end()
                 .build().get(0);
-        DataItem isiMetadata2Bytes =
-                Util.cborBuildTaggedByteString(Util.cborEncode(issuerSignedItemMetadata2));
-        byte[] encodedIsiMetadata2Bytes = Util.cborEncode(isiMetadata2Bytes);
+        DataItem isiMetadata3Bytes =
+                Util.cborBuildTaggedByteString(Util.cborEncode(issuerSignedItemMetadata3));
+        byte[] encodedIsiMetadata3Bytes = Util.cborEncode(isiMetadata3Bytes);
 
         Map<String, List<byte[]>> issuerSignedMapping = new HashMap<>();
         issuerSignedMapping.put("org.namespace",
-                Arrays.asList(encodedIsiMetadataBytes, encodedIsiMetadata2Bytes));
-        return issuerSignedMapping;
-    }
-
-    private Map<String, List<byte[]>> createInvalidFormatDigestIdMapping() {
-        DataItem issuerSignedItemMetadata = new CborBuilder()
-                .addMap()
-                .put("random", new byte[] {0x50, 0x51, 0x52})
-                .put("digestID", 42)
-                .put("elementIdentifier", "dataElementName")
-                .put(new UnicodeString("elementValue"), SimpleValue.NULL)
-                .end()
-                .build().get(0);
-        byte[] encodedIsiMetadata = Util.cborEncode(issuerSignedItemMetadata);
-
-        DataItem issuerSignedItemMetadata2 = new CborBuilder()
-                .addMap()
-                .put("digestID", 43)
-                .put("random", new byte[] {0x53, 0x54, 0x55})
-                .put("elementIdentifier", "dataElementName2")
-                .put(new UnicodeString("elementValue"), SimpleValue.NULL)
-                .end()
-                .build().get(0);
-        byte[] encodedIsiMetadata2 = Util.cborEncode(issuerSignedItemMetadata2);
-
-        Map<String, List<byte[]>> issuerSignedMapping = new HashMap<>();
-        issuerSignedMapping.put("org.namespace",
-                Arrays.asList(encodedIsiMetadata, encodedIsiMetadata2));
+                Arrays.asList(encodedIsiMetadataBytes,
+                        encodedIsiMetadata2Bytes,
+                        encodedIsiMetadata3Bytes));
         return issuerSignedMapping;
     }
 
@@ -164,6 +120,12 @@ public class StaticAuthDataTest {
                         "        \"random\": h'535455',\n" +
                         "        \"elementIdentifier\": \"dataElementName2\",\n" +
                         "        \"elementValue\": null\n" +
+                        "      } >>),\n" +
+                        "      24(<< {\n" +
+                        "        \"digestID\": 44,\n" +
+                        "        \"random\": h'535455',\n" +
+                        "        \"elementIdentifier\": \"portrait\",\n" +
+                        "        \"elementValue\": h'4420212223'\n" +
                         "      } >>)\n" +
                         "    ]\n" +
                         "  },\n" +
@@ -186,7 +148,7 @@ public class StaticAuthDataTest {
         Assert.assertEquals(1, digestIdMapping.size());
         List<byte[]> list = digestIdMapping.get("org.namespace");
         Assert.assertNotNull(list);
-        Assert.assertEquals(2, list.size());
+        Assert.assertEquals(3, list.size());
         Assert.assertEquals(
                 "24(<< {\n" +
                         "  \"random\": h'505152',\n" +
@@ -216,18 +178,5 @@ public class StaticAuthDataTest {
                 IllegalArgumentException.class,
                 () -> new StaticAuthDataGenerator(new HashMap<>(), createValidIssuerAuth())
                         .generate());
-
-        Assert.assertThrows("expect exception for invalid digestIDMapping, where " +
-                        "elementValue is non-NULL",
-                IllegalArgumentException.class,
-                () -> new StaticAuthDataGenerator(createInvalidElementValueDigestIdMapping(),
-                        createValidIssuerAuth()).generate());
-
-        Assert.assertThrows("expect exception for invalid digestIDMapping, where " +
-                        "issuerSignedItemMetadata is not encoded as tagged bytestring",
-                IllegalArgumentException.class,
-                () -> new StaticAuthDataGenerator(createInvalidFormatDigestIdMapping(),
-                        createValidIssuerAuth()).generate());
     }
-
 }


### PR DESCRIPTION
Our current model involves sending all PII to the device and then a bunch of MSOs + associated data (StaticAuthData) where the latter doesn't include any PII at all. Add the ability for StaticAuthData to also include PII meaning the issuer has the option to send none, some, or all PII along with each MSO.

Also use this in appholder by embedding the string "MSO <counter>" on top of the portrait image where <counter> is the count of the MSO and increasing for every use. In this example, only the portrait data element is per-MSO.

Fixes #405.

Test: Manually tested.
Test: New unit tests and all unit tests pass.
