### PR TITLE
Allow instantiating SecureArea.CreateKeySettings object.

### DIFF
--- a/appholder/src/main/java/com/android/identity/wallet/util/PreferencesHelper.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/util/PreferencesHelper.kt
@@ -31,7 +31,12 @@ object PreferencesHelper {
         // As per the docs, the credential data contains reference to Keystore aliases so ensure
         // this is stored in a location where it's not automatically backed up and restored by
         // Android Backup as per https://developer.android.com/guide/topics/data/autobackup
-        return context.noBackupFilesDir
+
+        val storageDir = File(context.noBackupFilesDir, "appholder")
+        if (!storageDir.exists()) {
+            storageDir.mkdir()
+        }
+        return storageDir;
     }
 
     fun isBleDataRetrievalEnabled(): Boolean {

--- a/identity-android/src/androidTest/java/com/android/identity/android/credential/AndroidKeystoreSecureAreaCredentialStoreTest.java
+++ b/identity-android/src/androidTest/java/com/android/identity/android/credential/AndroidKeystoreSecureAreaCredentialStoreTest.java
@@ -69,6 +69,7 @@ public class AndroidKeystoreSecureAreaCredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
+                mSecureArea,
                 new AndroidKeystoreSecureArea.CreateKeySettings.Builder(credentialKeyAttestationChallenge).build());
         Assert.assertEquals("testCredential", credential.getName());
         List<X509Certificate> certChain = credential.getAttestation();
@@ -82,11 +83,13 @@ public class AndroidKeystoreSecureAreaCredentialStoreTest {
         // Create pending authentication key and check its attestation
         byte[] authKeyChallenge = new byte[] {20, 21, 22};
         Credential.PendingAuthenticationKey pendingAuthenticationKey =
-                credential.createPendingAuthenticationKey(new AndroidKeystoreSecureArea.CreateKeySettings.Builder(authKeyChallenge)
-                        .setUserAuthenticationRequired(true, 30*1000,
-                                AndroidKeystoreSecureArea.USER_AUTHENTICATION_TYPE_LSKF
-                                        | AndroidKeystoreSecureArea.USER_AUTHENTICATION_TYPE_BIOMETRIC)
-                        .build(),
+                credential.createPendingAuthenticationKey(
+                        mSecureArea,
+                        new AndroidKeystoreSecureArea.CreateKeySettings.Builder(authKeyChallenge)
+                                .setUserAuthenticationRequired(true, 30*1000,
+                                        AndroidKeystoreSecureArea.USER_AUTHENTICATION_TYPE_LSKF
+                                                | AndroidKeystoreSecureArea.USER_AUTHENTICATION_TYPE_BIOMETRIC)
+                                .build(),
                         null);
         parser = new AndroidAttestationExtensionParser(pendingAuthenticationKey.getAttestation().get(0));
         Assert.assertArrayEquals(authKeyChallenge,
@@ -109,6 +112,7 @@ public class AndroidKeystoreSecureAreaCredentialStoreTest {
         // Check creating a credential with an existing name overwrites the existing one
         credential = credentialStore.createCredential(
                 "testCredential",
+                mSecureArea,
                 new AndroidKeystoreSecureArea.CreateKeySettings.Builder(credentialKeyAttestationChallenge).build());
         Assert.assertEquals("testCredential", credential.getName());
         // At least the leaf certificate should be different

--- a/identity-android/src/main/java/com/android/identity/android/legacy/KeystoreIdentityCredential.java
+++ b/identity-android/src/main/java/com/android/identity/android/legacy/KeystoreIdentityCredential.java
@@ -840,21 +840,26 @@ class KeystoreIdentityCredential extends IdentityCredential {
      * new {@link Credential}, while the access control profile information, per reader session/acp
      * timeout/auth keys will not be transferred.
      *
+     * @param androidKeystoreSecureArea an {@link AndroidKeystoreSecureArea} instance.
      * @param credentialStore the credential store where the new {@link Credential} should be stored.
      * @return the new {@link Credential}.
      */
-    public @NonNull Credential migrateToCredentialStore(@NonNull CredentialStore credentialStore) {
+    public @NonNull Credential migrateToCredentialStore(
+            @NonNull AndroidKeystoreSecureArea androidKeystoreSecureArea,
+            @NonNull CredentialStore credentialStore) {
         loadData();
 
         if (mData == null) {
             throw new IllegalStateException("The credential has been deleted prior to migration.");
         }
         String aliasForOldCredKey = mData.getCredentialKeyAlias();
-        AndroidKeystoreSecureArea.CreateKeySettings.Builder keySettingsBuilder = Utility.extractKeySettings(aliasForOldCredKey);
-        keySettingsBuilder.setEcCurve(SecureArea.EC_CURVE_P256);
+        AndroidKeystoreSecureArea.CreateKeySettings.Builder ksSettingsBuilder = Utility.extractKeySettings(aliasForOldCredKey);
+        ksSettingsBuilder.setEcCurve(SecureArea.EC_CURVE_P256);
 
         Credential newCred = credentialStore.createCredentialWithExistingKey(mCredentialName,
-                keySettingsBuilder.build(), aliasForOldCredKey);
+                androidKeystoreSecureArea,
+                ksSettingsBuilder.build(),
+                aliasForOldCredKey);
 
         NameSpacedData.Builder nsBuilder = new NameSpacedData.Builder();
         for (PersonalizationData.NamespaceData namespaceData : mData.getNamespaceDatas()) {

--- a/identity/src/main/java/com/android/identity/credential/CredentialStore.java
+++ b/identity/src/main/java/com/android/identity/credential/CredentialStore.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Class for holding real-world identity credentials.
+ * Class for storing real-world identity credentials.
  *
  * <p>This class is designed for storing real-world identity credentials such as
  * Mobile Driving Licenses (mDL) as specified in ISO/IEC 18013-5:2021. It is however
@@ -35,9 +35,9 @@ import java.util.List;
  * credential, regardless of shape, presentation-, or issuance-protocol used.
  *
  * <p>This code relies on a Secure Area for keys and this dependency is abstracted
- * by the {@link SecureArea} interface and allows the use of different implementations
- * on a per-credential basis. Persistent storage of credentials is abstracted via
- * the {@link StorageEngine} interface which provides a simple key/value store.
+ * by the {@link SecureArea} interface and allows the use of different {@link SecureArea}
+ * implementations for <em>Credential Key</em> and <em>Authentication Keys</em>) used
+ * in the credentials stored in the Credential Store.
  *
  * <p>For more details about credentials stored in a {@link CredentialStore} see the
  * {@link Credential} class.
@@ -66,14 +66,17 @@ public class CredentialStore {
      * newly created credential.
      *
      * @param name name of the credential.
-     * @param credentialKeySettings the settings to use for CredentialKey.
+     * @param secureArea the secure area to use for <em>CredentialKey</em>.
+     * @param credentialKeySettings the settings to use for creating <em>CredentialKey</em>.
      * @return A newly created credential.
      */
     public @NonNull Credential createCredential(@NonNull String name,
+                                                @NonNull SecureArea secureArea,
                                                 @NonNull SecureArea.CreateKeySettings credentialKeySettings) {
         return Credential.create(mStorageEngine,
                 mSecureAreaRepository,
                 name,
+                secureArea,
                 credentialKeySettings);
     }
 
@@ -84,17 +87,20 @@ public class CredentialStore {
      * newly created credential.
      *
      * @param name name of the credential.
-     * @param credentialKeySettings the settings to use for CredentialKey.
+     * @param secureArea the secure area to use for CredentialKey.
+     * @param credentialKeySettings the settings to use for creating CredentialKey.
      * @param existingKeyAlias the alias of the existing key.
      * @return A newly created credential.
      */
     public @NonNull Credential createCredentialWithExistingKey(
             @NonNull String name,
+            @NonNull SecureArea secureArea,
             @NonNull SecureArea.CreateKeySettings credentialKeySettings,
             @NonNull String existingKeyAlias) {
         return Credential.createWithExistingKey(mStorageEngine,
                 mSecureAreaRepository,
                 name,
+                secureArea,
                 credentialKeySettings,
                 existingKeyAlias);
     }

--- a/identity/src/main/java/com/android/identity/credential/CredentialUtil.java
+++ b/identity/src/main/java/com/android/identity/credential/CredentialUtil.java
@@ -35,7 +35,7 @@ public class CredentialUtil {
      *     <li>If a key is used more than {@code maxUsesPerKey} times, a replacement is generated.</li>
      *     <li>If a key expires within {@code minValidTimeMillis} milliseconds, a replacement is generated.</li>
      * </ul>
-     * <p>This is all implemented on top of {@link Credential#createPendingAuthenticationKey(SecureArea.CreateKeySettings, Credential.AuthenticationKey)}
+     * <p>This is all implemented on top of {@link Credential#createPendingAuthenticationKey(SecureArea, SecureArea.CreateKeySettings, Credential.AuthenticationKey)}
      * and {@link Credential.PendingAuthenticationKey#certify(byte[], Timestamp, Timestamp)}.
      * The application should examine the return value and if positive, collect the
      * pending authentication keys via {@link Credential#getPendingAuthenticationKeys()},
@@ -49,6 +49,7 @@ public class CredentialUtil {
      * sets of authentication keys for different purposes and with different strategies.
      *
      * @param credential the credential to manage authentication keys for.
+     * @param secureArea the secure area to use for new pending authentication keys.
      * @param createKeySettings the settings used to create new pending authentication keys.
      * @param managedKeyDomain the identifier to use for created authentication keys.
      * @param now the time right now, used for figuring out when existing should be replaced.
@@ -59,6 +60,7 @@ public class CredentialUtil {
      */
     public static int managedAuthenticationKeyHelper(
             @NonNull Credential credential,
+            @NonNull SecureArea secureArea,
             @NonNull SecureArea.CreateKeySettings createKeySettings,
             @NonNull String managedKeyDomain,
             @NonNull Timestamp now,
@@ -90,7 +92,7 @@ public class CredentialUtil {
             if (keyExceededUseCount || keyBeyondExpirationDate) {
                 if (authKey.getReplacement() == null) {
                     Credential.PendingAuthenticationKey pendingKey =
-                            credential.createPendingAuthenticationKey(createKeySettings, authKey);
+                            credential.createPendingAuthenticationKey(secureArea, createKeySettings, authKey);
                     pendingKey.getApplicationData().setBoolean(managedKeyDomain, true);
                     numReplacementsGenerated++;
                     continue;
@@ -106,7 +108,7 @@ public class CredentialUtil {
         if (numNonReplacementsToGenerate > 0) {
             for (int n = 0; n < numNonReplacementsToGenerate; n++) {
                 Credential.PendingAuthenticationKey pendingKey =
-                        credential.createPendingAuthenticationKey(createKeySettings, null);
+                        credential.createPendingAuthenticationKey(secureArea, createKeySettings, null);
                 pendingKey.getApplicationData().setBoolean(managedKeyDomain, true);
             }
         }

--- a/identity/src/main/java/com/android/identity/securearea/SecureArea.java
+++ b/identity/src/main/java/com/android/identity/securearea/SecureArea.java
@@ -135,6 +135,23 @@ public interface SecureArea {
     @interface KeyPurpose {}
 
     /**
+     * Gets a stable identifier for the Secure Area.
+     *
+     * <p>This is typically just the class name but for secure areas allowing
+     * multiple instances, this could differ.
+     *
+     * @return a stable identifier for the Secure Area.
+     */
+    @NonNull String getIdentifier();
+
+    /**
+     * Gets a string suitable to display to the end user, for identifying the Secure Area instance.
+     *
+     * @return the display name for the Secure Area.
+     */
+    @NonNull String getDisplayName();
+
+    /**
      * Creates an new key.
      *
      * <p>This creates an EC key-pair where the private part of the key never
@@ -330,26 +347,32 @@ public interface SecureArea {
     }
 
     /**
-     *  Abstract type used to indicate key creation settings (authentication
-     *  required, nonce/challenge for remote attestation, etc.) and which
-     *  {@link SecureArea} to use.
+     * Base class for key creation settings.
+     *
+     * <p>This can be used for any conforming {@link SecureArea} implementations.
+     * although such implementations will typically supply their own implementations
+     * with additional settings to e.g. configure user authentication, passphrase
+     * protections, and other things.
      */
-    abstract class CreateKeySettings {
+    class CreateKeySettings {
+        protected final byte[] mAttestationChallenge;
 
-        private final Class<?> mSecureAreaClass;
-
-        protected CreateKeySettings(@NonNull Class<?> secureAreaClass) {
-            mSecureAreaClass = secureAreaClass;
+        /**
+         * Creates a new settings object.
+         *
+         * @param attestationChallenge challenge to include in attestation for the created key.
+         */
+        public CreateKeySettings(@NonNull byte[] attestationChallenge) {
+            mAttestationChallenge = attestationChallenge;
         }
 
         /**
-         * Returns the class of the {@link SecureArea} these settings are for.
+         * Gets the attestation challenge.
          *
-         * @return A {@link SecureArea}-derived type.
+         * @return the attestation challenge.
          */
-        public @NonNull
-        Class<?> getSecureAreaClass() {
-            return mSecureAreaClass;
+        public @NonNull byte[] getAttestationChallenge() {
+            return mAttestationChallenge;
         }
     }
 }

--- a/identity/src/main/java/com/android/identity/securearea/SecureAreaRepository.java
+++ b/identity/src/main/java/com/android/identity/securearea/SecureAreaRepository.java
@@ -49,14 +49,16 @@ public class SecureAreaRepository {
     }
 
     /**
-     * Gets a {@link SecureArea} for a specific classname.
+     * Gets a {@link SecureArea} by identifier
      *
-     * @param className the classname for an implementation.
+     * <p>The identifier being used is the one returned by {@link SecureArea#getIdentifier()}.
+     *
+     * @param identifier the identifier for the Secure Area.
      * @return the implementation or {@code null} if no implementation has been registered.
      */
-    public @Nullable SecureArea getImplementation(@NonNull String className) {
+    public @Nullable SecureArea getImplementation(@NonNull String identifier) {
         for (SecureArea implementation : mImplementations) {
-            if (implementation.getClass().getName().equals(className)) {
+            if (implementation.getIdentifier().equals(identifier)) {
                 return implementation;
             }
         }

--- a/identity/src/main/java/com/android/identity/securearea/SoftwareSecureArea.java
+++ b/identity/src/main/java/com/android/identity/securearea/SoftwareSecureArea.java
@@ -101,6 +101,8 @@ public class SoftwareSecureArea implements SecureArea {
     // Prefix for storage items.
     private static final String PREFIX = "IC_SoftwareSecureArea_key_";
 
+
+
     /**
      * Creates a new software-backed secure area.
      *
@@ -110,10 +112,30 @@ public class SoftwareSecureArea implements SecureArea {
         mStorageEngine = storageEngine;
     }
 
+    @NonNull
+    @Override
+    public String getIdentifier() {
+        return "SoftwareSecureArea";
+    }
+
+    @NonNull
+    @Override
+    public String getDisplayName() {
+        return "Software Secure Area";
+    }
+
     @Override
     public void createKey(@NonNull String alias,
                           @NonNull SecureArea.CreateKeySettings createKeySettings) {
-        CreateKeySettings settings = (CreateKeySettings) createKeySettings;
+        CreateKeySettings settings;
+        if (createKeySettings instanceof CreateKeySettings) {
+            settings = (CreateKeySettings) createKeySettings;
+        } else {
+            // Use default settings if user passed in a generic SecureArea.CreateKeySettings.
+            settings = new SoftwareSecureArea.CreateKeySettings.Builder(
+                    createKeySettings.getAttestationChallenge())
+                    .build();
+        }
 
         KeyPairGenerator kpg;
         try {
@@ -557,7 +579,6 @@ public class SoftwareSecureArea implements SecureArea {
         private final String mSubject;
         private final Timestamp mValidFrom;
         private final Timestamp mValidUntil;
-        private final byte[] mAttestationChallenge;
         private PrivateKey mAttestationKey;
         private String mAttestationKeySignatureAlgorithm;
         private List<X509Certificate> mAttestationKeyCertification;
@@ -573,12 +594,11 @@ public class SoftwareSecureArea implements SecureArea {
                                   @Nullable PrivateKey attestationKey,
                                   @Nullable String attestationKeySignatureAlgorithm,
                                   @Nullable List<X509Certificate> attestationKeyCertification) {
-            super(SoftwareSecureArea.class);
+            super(attestationChallenge);
             mPassphraseRequired = passphraseRequired;
             mPassphrase = passphrase;
             mEcCurve = ecCurve;
             mKeyPurposes = keyPurposes;
-            mAttestationChallenge = attestationChallenge;
             mSubject = subject;
             mValidFrom = validFrom;
             mValidUntil = validUntil;
@@ -621,15 +641,6 @@ public class SoftwareSecureArea implements SecureArea {
          */
         public @KeyPurpose int getKeyPurposes() {
             return mKeyPurposes;
-        }
-
-        /**
-         * Gets the attestation challenge.
-         *
-         * @return the attestation challenge.
-         */
-        public @NonNull byte[] getAttestationChallenge() {
-            return mAttestationChallenge;
         }
 
         /**

--- a/identity/src/test/java/com/android/identity/credential/CredentialStoreTest.java
+++ b/identity/src/test/java/com/android/identity/credential/CredentialStoreTest.java
@@ -63,7 +63,8 @@ public class CredentialStoreTest {
         for (int n = 0; n < 10; n++) {
             credentialStore.createCredential(
                     "testCred" + n,
-                    new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+                    mSecureArea,
+                    new SecureArea.CreateKeySettings(new byte[0]));
         }
         Assert.assertEquals(10, credentialStore.listCredentials().size());
         credentialStore.deleteCredential("testCred1");
@@ -86,7 +87,8 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+                mSecureArea,
+                new SecureArea.CreateKeySettings(new byte[0]));
         Assert.assertEquals("testCredential", credential.getName());
         List<X509Certificate> certChain = credential.getAttestation();
         Assert.assertTrue(certChain.size() >= 1);
@@ -105,7 +107,8 @@ public class CredentialStoreTest {
         // Check creating a credential with an existing name overwrites the existing one
         credential = credentialStore.createCredential(
                 "testCredential",
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+                mSecureArea,
+                new SecureArea.CreateKeySettings(new byte[0]));
         Assert.assertEquals("testCredential", credential.getName());
         // At least the leaf certificate should be different
         List<X509Certificate> certChain3 = credential.getAttestation();
@@ -127,7 +130,8 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+                mSecureArea,
+                new SecureArea.CreateKeySettings(new byte[0]));
 
         // After creation, NameSpacedData is present but empty.
         Assert.assertEquals(0, credential.getNameSpacedData().getNameSpaceNames().size());
@@ -160,7 +164,8 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+                mSecureArea,
+                new SecureArea.CreateKeySettings(new byte[0]));
 
         Timestamp timeBeforeValidity = Timestamp.ofEpochMilli(40);
         Timestamp timeValidityBegin = Timestamp.ofEpochMilli(50);
@@ -179,7 +184,8 @@ public class CredentialStoreTest {
         // Create ten authentication keys...
         for (int n = 0; n < 10; n++) {
             credential.createPendingAuthenticationKey(
-                    new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
+                    mSecureArea,
+                    new SecureArea.CreateKeySettings(new byte[0]),
                     null);
         }
         Assert.assertEquals(0, credential.getAuthenticationKeys().size());
@@ -252,7 +258,8 @@ public class CredentialStoreTest {
         // Create and certify five replacements
         for (n = 0; n < 5; n++) {
             credential.createPendingAuthenticationKey(
-                    new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
+                    mSecureArea,
+                    new SecureArea.CreateKeySettings(new byte[0]),
                     null);
         }
         Assert.assertEquals(10, credential.getAuthenticationKeys().size());
@@ -311,7 +318,8 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+                mSecureArea,
+                new SecureArea.CreateKeySettings(new byte[0]));
 
         Assert.assertEquals(0, credential.getAuthenticationKeys().size());
         Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
@@ -319,7 +327,8 @@ public class CredentialStoreTest {
         // Create ten pending auth keys and certify four of them
         for (n = 0; n < 4; n++) {
             credential.createPendingAuthenticationKey(
-                    new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
+                    mSecureArea,
+                    new SecureArea.CreateKeySettings(new byte[0]),
                     null);
         }
         Assert.assertEquals(0, credential.getAuthenticationKeys().size());
@@ -343,7 +352,8 @@ public class CredentialStoreTest {
         Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
         for (n = 0; n < 6; n++) {
             credential.createPendingAuthenticationKey(
-                    new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
+                    mSecureArea,
+                    new SecureArea.CreateKeySettings(new byte[0]),
                     null);
         }
         Assert.assertEquals(4, credential.getAuthenticationKeys().size());
@@ -388,7 +398,8 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+                mSecureArea,
+                new SecureArea.CreateKeySettings(new byte[0]));
 
         // We want to check the behavior for when the holder has a birthday and the issuer
         // carefully sends half the MSOs to be used before the birthday (with age_in_years set to
@@ -409,7 +420,8 @@ public class CredentialStoreTest {
         int n;
         for (n = 0; n < 10; n++) {
             credential.createPendingAuthenticationKey(
-                    new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
+                    mSecureArea,
+                    new SecureArea.CreateKeySettings(new byte[0]),
                     null);
         }
         Assert.assertEquals(10, credential.getPendingAuthenticationKeys().size());
@@ -465,7 +477,8 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+                mSecureArea,
+                new SecureArea.CreateKeySettings(new byte[0]));
 
         // After creation, NameSpacedData is present but empty.
         Assert.assertEquals(0, credential.getNameSpacedData().getNameSpaceNames().size());
@@ -515,15 +528,14 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+                mSecureArea,
+                new SecureArea.CreateKeySettings(new byte[0]));
 
-        SecureArea.CreateKeySettings authKeySettings =
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0])
-                        .build();
         for (int n = 0; n < 10; n++) {
             Credential.PendingAuthenticationKey pendingAuthKey =
                     credential.createPendingAuthenticationKey(
-                            new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
+                            mSecureArea,
+                            new SecureArea.CreateKeySettings(new byte[0]),
                             null);
             String value = String.format(Locale.US, "bar%02d", n);
             ApplicationData pendingAppData = pendingAuthKey.getApplicationData();
@@ -600,18 +612,17 @@ public class CredentialStoreTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+                mSecureArea,
+                new SecureArea.CreateKeySettings(new byte[0]));
 
         Assert.assertEquals(0, credential.getAuthenticationKeys().size());
         Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
 
-        SecureArea.CreateKeySettings authKeySettings =
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0])
-                        .build();
         for (int n = 0; n < 10; n++) {
             Credential.PendingAuthenticationKey pendingAuthKey =
                     credential.createPendingAuthenticationKey(
-                            new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
+                            mSecureArea,
+                            new SecureArea.CreateKeySettings(new byte[0]),
                             null);
             pendingAuthKey.certify(new byte[] {0, (byte) n},
                     Timestamp.ofEpochMilli(100),
@@ -625,7 +636,8 @@ public class CredentialStoreTest {
         Assert.assertArrayEquals(new byte[] {0, 5}, keyToReplace.getIssuerProvidedData());
         Credential.PendingAuthenticationKey pendingAuthKey =
                 credential.createPendingAuthenticationKey(
-                        new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
+                        mSecureArea,
+                        new SecureArea.CreateKeySettings(new byte[0]),
                         keyToReplace);
         // ... it's not replaced until certify() is called
         Assert.assertEquals(1, credential.getPendingAuthenticationKeys().size());
@@ -662,7 +674,8 @@ public class CredentialStoreTest {
         Credential.AuthenticationKey toBeReplaced = credential.getAuthenticationKeys().get(0);
         Credential.PendingAuthenticationKey replacement =
                 credential.createPendingAuthenticationKey(
-                        new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
+                        mSecureArea,
+                        new SecureArea.CreateKeySettings(new byte[0]),
                         toBeReplaced);
         Assert.assertEquals(toBeReplaced, replacement.getReplacementFor());
         Assert.assertEquals(replacement, toBeReplaced.getReplacement());
@@ -672,7 +685,8 @@ public class CredentialStoreTest {
         // Similarly, test the case where the key to be replaced is prematurely deleted.
         // The replacement key should no longer indicate it's a replacement key.
         replacement = credential.createPendingAuthenticationKey(
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build(),
+                mSecureArea,
+                new SecureArea.CreateKeySettings(new byte[0]),
                 toBeReplaced);
         Assert.assertEquals(toBeReplaced, replacement.getReplacementFor());
         Assert.assertEquals(replacement, toBeReplaced.getReplacement());

--- a/identity/src/test/java/com/android/identity/credential/CredentialUtilTest.java
+++ b/identity/src/test/java/com/android/identity/credential/CredentialUtilTest.java
@@ -51,14 +51,14 @@ public class CredentialUtilTest {
 
         Credential credential = credentialStore.createCredential(
                 "testCredential",
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+                mSecureArea,
+                new SecureArea.CreateKeySettings(new byte[0]));
 
         Assert.assertEquals(0, credential.getAuthenticationKeys().size());
         Assert.assertEquals(0, credential.getPendingAuthenticationKeys().size());
 
         SecureArea.CreateKeySettings authKeySettings =
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0])
-                        .build();
+                new SecureArea.CreateKeySettings(new byte[0]);
 
         int numAuthKeys = 10;
         int maxUsesPerKey = 5;
@@ -71,6 +71,7 @@ public class CredentialUtilTest {
         // valid until time 200.
         numKeysCreated = CredentialUtil.managedAuthenticationKeyHelper(
                 credential,
+                mSecureArea,
                 authKeySettings,
                 managedKeyDomain,
                 Timestamp.ofEpochMilli(100),
@@ -93,6 +94,7 @@ public class CredentialUtilTest {
         // Certifying again at this point should not make a difference.
         numKeysCreated = CredentialUtil.managedAuthenticationKeyHelper(
                 credential,
+                mSecureArea,
                 authKeySettings,
                 managedKeyDomain,
                 Timestamp.ofEpochMilli(100),
@@ -110,6 +112,7 @@ public class CredentialUtilTest {
         }
         numKeysCreated = CredentialUtil.managedAuthenticationKeyHelper(
                 credential,
+                mSecureArea,
                 authKeySettings,
                 managedKeyDomain,
                 Timestamp.ofEpochMilli(100),
@@ -130,6 +133,7 @@ public class CredentialUtilTest {
         }
         numKeysCreated = CredentialUtil.managedAuthenticationKeyHelper(
                 credential,
+                mSecureArea,
                 authKeySettings,
                 managedKeyDomain,
                 Timestamp.ofEpochMilli(100),
@@ -172,6 +176,7 @@ public class CredentialUtilTest {
         // This should trigger just them for replacement
         numKeysCreated = CredentialUtil.managedAuthenticationKeyHelper(
                 credential,
+                mSecureArea,
                 authKeySettings,
                 managedKeyDomain,
                 Timestamp.ofEpochMilli(195),

--- a/identity/src/test/java/com/android/identity/mdoc/response/DeviceResponseGeneratorTest.java
+++ b/identity/src/test/java/com/android/identity/mdoc/response/DeviceResponseGeneratorTest.java
@@ -124,6 +124,7 @@ public class DeviceResponseGeneratorTest {
         // Create the credential...
         mCredential = credentialStore.createCredential(
                 "testCredential",
+                mSecureArea,
                 new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
         NameSpacedData nameSpacedData = new NameSpacedData.Builder()
                 .putEntryString("ns1", "foo1", "bar1")
@@ -151,6 +152,7 @@ public class DeviceResponseGeneratorTest {
         mTimeValidityEnd = Timestamp.ofEpochMilli(nowMillis + 10 * 86400 * 1000);
         Credential.PendingAuthenticationKey pendingAuthKey =
                 mCredential.createPendingAuthenticationKey(
+                        mSecureArea,
                         new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0])
                                 .setKeyPurposes(SecureArea.KEY_PURPOSE_SIGN
                                         | SecureArea.KEY_PURPOSE_AGREE_KEY)

--- a/identity/src/test/java/com/android/identity/securearea/SoftwareSecureAreaTest.java
+++ b/identity/src/test/java/com/android/identity/securearea/SoftwareSecureAreaTest.java
@@ -57,7 +57,7 @@ import javax.crypto.KeyAgreement;
 
 public class SoftwareSecureAreaTest {
 
-    private static final String TAG = "BouncyCastleSATest";  // limit to <= 23 chars
+    private static final String TAG = "SoftwareSecureAreaTest";
 
     PrivateKey mAttestationKey;
     String mAttestationKeySignatureAlgorithm;
@@ -104,7 +104,7 @@ public class SoftwareSecureAreaTest {
         SoftwareSecureArea ks = new SoftwareSecureArea(storage);
 
         // First create the key...
-        ks.createKey("testKey", new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+        ks.createKey("testKey", new SecureArea.CreateKeySettings(new byte[0]));
         SoftwareSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
         List<X509Certificate> certChain = keyInfo.getAttestation();
         Assert.assertTrue(certChain.size() >= 1);
@@ -131,7 +131,7 @@ public class SoftwareSecureAreaTest {
         EphemeralStorageEngine storage = new EphemeralStorageEngine();
         SoftwareSecureArea ks = new SoftwareSecureArea(storage);
 
-        ks.createKey("testKey", new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+        ks.createKey("testKey", new SecureArea.CreateKeySettings(new byte[0]));
 
         SoftwareSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
         Assert.assertNotNull(keyInfo);
@@ -166,7 +166,7 @@ public class SoftwareSecureAreaTest {
         EphemeralStorageEngine storage = new EphemeralStorageEngine();
         SoftwareSecureArea ks = new SoftwareSecureArea(storage);
 
-        ks.createKey("testKey", new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+        ks.createKey("testKey", new SecureArea.CreateKeySettings(new byte[0]));
 
         SoftwareSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
         Assert.assertNotNull(keyInfo);
@@ -234,6 +234,26 @@ public class SoftwareSecureAreaTest {
                  | SignatureException e) {
             throw new AssertionError(e);
         }
+    }
+
+    @Test
+    public void testEcKeyWithGenericCreateKeySettings() {
+        EphemeralStorageEngine storage = new EphemeralStorageEngine();
+        SoftwareSecureArea ks = new SoftwareSecureArea(storage);
+
+        byte[] challenge = new byte[] {1, 2, 3};
+        ks.createKey("testKey", new SecureArea.CreateKeySettings(challenge));
+
+        SoftwareSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
+        Assert.assertNotNull(keyInfo);
+        Assert.assertTrue(keyInfo.getAttestation().size() >= 1);
+        Assert.assertEquals(SecureArea.KEY_PURPOSE_SIGN, keyInfo.getKeyPurposes());
+        Assert.assertEquals(SecureArea.EC_CURVE_P256, keyInfo.getEcCurve());
+        Assert.assertFalse(keyInfo.isHardwareBacked());
+        Assert.assertFalse(keyInfo.isPassphraseProtected());
+
+        // Check challenge.
+        Assert.assertArrayEquals(challenge, getChallenge(keyInfo.getAttestation().get(0)));
     }
 
     @Test
@@ -480,13 +500,13 @@ public class SoftwareSecureAreaTest {
         SoftwareSecureArea ks = new SoftwareSecureArea(storage);
 
         ks.createKey("testKey",
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+                new SecureArea.CreateKeySettings(new byte[0]));
         SoftwareSecureArea.KeyInfo keyInfoOld = ks.getKeyInfo("testKey");
         List<X509Certificate> certChainOld = keyInfoOld.getAttestation();
         Assert.assertTrue(certChainOld.size() >= 1);
 
         ks.createKey("testKey",
-                new SoftwareSecureArea.CreateKeySettings.Builder(new byte[0]).build());
+                new SecureArea.CreateKeySettings(new byte[0]));
         SoftwareSecureArea.KeyInfo keyInfo = ks.getKeyInfo("testKey");
         List<X509Certificate> certChain = keyInfo.getAttestation();
         Assert.assertTrue(certChain.size() >= 1);


### PR DESCRIPTION
In order to support new kinds of SecureArea without app changes, change the SecureArea.CreateKeySettings class so it can be instantiated by apps.

Also stop carrying the SecureArea class name in CreateKeySettings subclasses, instead have users of CreateKeySettings take a separate SecureArea class. Make it explicit that different SecureArea instances can be used by CredentialKey and even for different Authentication Keys.

Introduce the concept of an "identifier" for a SecureArea instead of Credential, Credential.Authentiationkey, and
Credential.PendingAuthenticationKey classes all using the Java class name when persisting on-disk. This paves the way to have multiple SecureArea instances of the same type but with different configuration. We'll need this for CloudSecureArea so an app can have two instances pointing to different providers, for different credentials. Also add "display name" since that is needed for Issue #380.

Unfortunately this breaks the on-disk format but this is going to happen _anyway_ as we're renaming the project and moving all the code to new packages as part of the contribution of the code to the OpenWallet Foundation. In the near future we'll start committing to stable on-disk formats.

Test: All unit tests pass.
Test: Manually tested

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR